### PR TITLE
fix: bugsweep dataroom 3 — compounded fixes (24 PRs)

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenController.cs
@@ -92,6 +92,7 @@ namespace DCL.AuthenticationScreenFlow
         internal void RaiseProfileFinalized() =>
             ProfileFinalized?.Invoke();
 
+        // Null until OnViewInstantiated: the view is created lazily on first Show and may never be instantiated.
         private MVCStateMachine<AuthStateBase>? fsm;
         private AuthenticationScreenAudio? audio;
 

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
@@ -70,7 +70,7 @@ namespace DCL.AuthenticationScreenFlow
                                     ProfileNotFoundException ex => new SpanErrorInfo($"Profile not found during {nameof(ProfileFetchingAuthState)}", ex),
                                     NotAllowedUserException ex => new SpanErrorInfo(ex.Message, ex),
                                     TimeoutException ex => new SpanErrorInfo($"Profile fetch timed out during {nameof(ProfileFetchingAuthState)}", ex),
-                                    Exception ex => new SpanErrorInfo($"Unexpected error during {nameof(ProfileFetchingAuthState)}", ex),
+                                    { } ex => new SpanErrorInfo($"Unexpected error during {nameof(ProfileFetchingAuthState)}", ex),
                                 };
 
                 if (profileFetchException is not OperationCanceledException and not ProfileNotFoundException and not NotAllowedUserException)
@@ -110,9 +110,7 @@ namespace DCL.AuthenticationScreenFlow
                     });
 
                     // Timeout surfaces catalyst stalls as CONNECTION_ERROR instead of a frozen spinner.
-                    Profile? profile = await selfProfile.ProfileAsync(ct).Timeout(PROFILE_FETCH_TIMEOUT);
-
-                    if (profile != null)
+                    if (await FetchProfileWithTimeoutAsync(selfProfile, PROFILE_FETCH_TIMEOUT, ct) is { } profile)
                     {
                         // When the profile was already in cache, for example your previous account after logout, we need to ensure that all systems related to the profile will update
                         profile.IsDirty = true;
@@ -154,6 +152,30 @@ namespace DCL.AuthenticationScreenFlow
                     machine.Enter<LoginSelectionAuthState, ErrorType>(ErrorType.ConnectionError);
                 }
             }
+        }
+
+        /// <summary>
+        ///     The fetch runs under a linked token, so a timed-out fetch cancels its underlying request instead of
+        ///     abandoning it. Timeout surfaces as <see cref="TimeoutException" /> (CONNECTION_ERROR);
+        ///     cancellation of <paramref name="ct" /> surfaces as <see cref="OperationCanceledException" />.
+        /// </summary>
+        internal static async UniTask<Profile?> FetchProfileWithTimeoutAsync(ISelfProfile selfProfile, TimeSpan timeout, CancellationToken ct)
+        {
+            using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            using IDisposable timeoutTimer = timeoutCts.CancelAfterSlim(timeout);
+
+            if (await selfProfile.ProfileAsync(timeoutCts.Token) is { } profile)
+                return profile;
+
+            // The repository suppresses cancellation into a null profile, including cancellation of the flow token.
+            // Surface external cancellation as OCE so it is classified as a user cancel, not as "no deployed profile"
+            // (which on the cached flow would clear a still-valid stored identity)
+            ct.ThrowIfCancellationRequested();
+
+            if (timeoutCts.IsCancellationRequested)
+                throw new TimeoutException($"Profile fetch timed out after {timeout.TotalSeconds:F0}s");
+
+            return null; // genuine "no deployed profile"
         }
 
         private Profile CreateRandomProfile(string identityAddress)

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/States/ProfileFetchingAuthState.cs
@@ -155,9 +155,8 @@ namespace DCL.AuthenticationScreenFlow
         }
 
         /// <summary>
-        ///     The fetch runs under a linked token, so a timed-out fetch cancels its underlying request instead of
-        ///     abandoning it. Timeout surfaces as <see cref="TimeoutException" /> (CONNECTION_ERROR);
-        ///     cancellation of <paramref name="ct" /> surfaces as <see cref="OperationCanceledException" />.
+        ///     Runs the fetch under a linked token so a timeout cancels the underlying request. Timeout throws
+        ///     <see cref="TimeoutException" />; cancellation of <paramref name="ct" /> throws <see cref="OperationCanceledException" />.
         /// </summary>
         internal static async UniTask<Profile?> FetchProfileWithTimeoutAsync(ISelfProfile selfProfile, TimeSpan timeout, CancellationToken ct)
         {
@@ -167,9 +166,8 @@ namespace DCL.AuthenticationScreenFlow
             if (await selfProfile.ProfileAsync(timeoutCts.Token) is { } profile)
                 return profile;
 
-            // The repository suppresses cancellation into a null profile, including cancellation of the flow token.
-            // Surface external cancellation as OCE so it is classified as a user cancel, not as "no deployed profile"
-            // (which on the cached flow would clear a still-valid stored identity)
+            // The repository suppresses cancellation into a null profile; rethrow external cancellation as OCE
+            // so it is not misread as "no deployed profile"
             ct.ThrowIfCancellationRequested();
 
             if (timeoutCts.IsCancellationRequested)

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+
+namespace DCL.AuthenticationScreenFlow.Tests
+{
+    [TestFixture]
+    public class AuthenticationScreenControllerShould
+    {
+        [Test]
+        public void NotThrowOnDisposeWhenViewWasNeverShown()
+        {
+            // Registered-but-never-shown lifecycle: the view factory is never invoked, so
+            // OnViewInstantiated never runs and the lazily-created members stay null
+            // (sessions with --skip-auth-screen + a valid cached identity).
+            // The constructor only stores its dependencies; none are dereferenced before the view exists.
+            var controller = new AuthenticationScreenController(
+                () => null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                string.Empty,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!);
+
+            Assert.DoesNotThrow(controller.Dispose);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs
@@ -8,10 +8,8 @@ namespace DCL.AuthenticationScreenFlow.Tests
         [Test]
         public void NotThrowOnDisposeWhenViewWasNeverShown()
         {
-            // Registered-but-never-shown lifecycle: the view factory is never invoked, so
-            // OnViewInstantiated never runs and the lazily-created members stay null
-            // (sessions with --skip-auth-screen + a valid cached identity).
-            // The constructor only stores its dependencies; none are dereferenced before the view exists.
+            // Never-shown lifecycle (--skip-auth-screen with a cached identity): OnViewInstantiated never runs,
+            // so lazily-created members stay null; the constructor only stores dependencies, so null! args are safe.
             var controller = new AuthenticationScreenController(
                 () => null!,
                 null!,

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs.meta
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/AuthenticationScreenControllerShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66373631147046cd8f17228cbe05ddba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
@@ -1,0 +1,230 @@
+using Cysharp.Threading.Tasks;
+using DCL.Profiles;
+using DCL.Profiles.Self;
+using DCL.Utilities;
+using DCL.Web3.Identities;
+using MVC;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+using static DCL.AuthenticationScreenFlow.AuthenticationScreenController;
+
+namespace DCL.AuthenticationScreenFlow.Tests
+{
+    [TestFixture]
+    public class ProfileFetchingAuthStateShould
+    {
+        // Mirrors ProfileFetchingAuthState.PROFILE_FETCH_TIMEOUT (private)
+        private const float FETCH_TIMEOUT_SECONDS = 15f;
+
+        // Long enough for the fetch timeout to fire and be observed
+        private const float OBSERVATION_SECONDS = 16.5f;
+
+        [UnityTest]
+        public IEnumerator CancelStalledFetchOnTimeout() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                // The state machine has no states registered: transitions attempted by the flow throw and are logged
+                // through the fire-and-forget UniTaskVoid; those logs are irrelevant to the invariant under test
+                LogAssert.ignoreFailingMessages = true;
+
+                using var cts = new CancellationTokenSource();
+                var root = new GameObject(nameof(ProfileFetchingAuthStateShould));
+
+                try
+                {
+                    AuthenticationScreenView screenView = root.AddComponent<AuthenticationScreenView>();
+
+                    var viewGo = new GameObject(nameof(ProfileFetchingAuthView));
+                    viewGo.transform.SetParent(root.transform);
+                    StubProfileFetchingAuthView fetchingView = viewGo.AddComponent<StubProfileFetchingAuthView>();
+
+                    var buttonGo = new GameObject("CancelButton");
+                    buttonGo.transform.SetParent(viewGo.transform);
+                    Button cancelButton = buttonGo.AddComponent<Button>();
+
+                    SetBackingField(fetchingView, typeof(ProfileFetchingAuthView), nameof(ProfileFetchingAuthView.CancelButton), cancelButton);
+                    SetBackingField(screenView, typeof(AuthenticationScreenView), nameof(AuthenticationScreenView.ProfileFetchingAuthView), fetchingView);
+
+                    var machine = new MVCStateMachine<AuthStateBase>();
+                    var selfProfile = new StalledSelfProfile();
+
+                    // The controller is only captured for the Cancel button listener, which is never invoked here
+                    var controller = (AuthenticationScreenController)FormatterServices.GetUninitializedObject(typeof(AuthenticationScreenController));
+
+                    var state = new ProfileFetchingAuthState(
+                        machine,
+                        screenView,
+                        controller,
+                        new ReactiveProperty<AuthStatus>(AuthStatus.None),
+                        selfProfile,
+                        Substitute.For<IWeb3IdentityCache>());
+
+                    state.Enter(new ProfileFetchingPayload(Substitute.For<IWeb3Identity>(), true, cts.Token));
+
+                    float deadline = UnityEngine.Time.realtimeSinceStartup + OBSERVATION_SECONDS;
+
+                    while (UnityEngine.Time.realtimeSinceStartup < deadline)
+                        await UniTask.Yield();
+
+                    Assert.That(selfProfile.CapturedTokens.Count, Is.EqualTo(1), "the profile fetch must run exactly once (no retries)");
+
+                    Assert.That(selfProfile.CapturedTokens[0].IsCancellationRequested, Is.True,
+                        $"the fetch's token must be cancelled once the {FETCH_TIMEOUT_SECONDS}s timeout elapses; " +
+                        "an uncancelled token means the request was abandoned and keeps poisoning the repository's ongoing batch");
+                }
+                finally
+                {
+                    // Unblock the pending attempt (even on assertion failure) so the detached flow finishes
+                    // inside this test's ignore-failing-messages window instead of erroring into a later test
+                    cts.Cancel();
+
+                    for (var i = 0; i < 32; i++)
+                        await UniTask.Yield();
+
+                    UnityEngine.Object.DestroyImmediate(root);
+                }
+            });
+
+        [UnityTest]
+        public IEnumerator SurfaceExternalCancellationInsteadOfMissingProfile() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                var selfProfile = new StalledSelfProfile();
+                using var cts = new CancellationTokenSource();
+
+                UniTask<Profile?> fetch = ProfileFetchingAuthState.FetchProfileWithTimeoutAsync(
+                    selfProfile, TimeSpan.FromSeconds(FETCH_TIMEOUT_SECONDS), cts.Token);
+
+                float deadline = UnityEngine.Time.realtimeSinceStartup + 5f;
+
+                while (selfProfile.CapturedTokens.Count == 0 && UnityEngine.Time.realtimeSinceStartup < deadline)
+                    await UniTask.Yield();
+
+                Assert.That(selfProfile.CapturedTokens.Count, Is.EqualTo(1), "the fetch must be in flight before the external cancel");
+
+                cts.Cancel();
+
+                try
+                {
+                    Profile? result = await fetch;
+
+                    Assert.Fail("cancelling the flow token must surface as OperationCanceledException, not be read as " +
+                                $"\"no deployed profile\" (got {(result == null ? "null" : "a profile")}); a null here wipes " +
+                                "a still-valid cached identity on the cached flow");
+                }
+                catch (OperationCanceledException) { }
+            });
+
+        [UnityTest]
+        public IEnumerator ThrowTimeoutWhenFetchStalls() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                var selfProfile = new StalledSelfProfile();
+
+                try
+                {
+                    await ProfileFetchingAuthState.FetchProfileWithTimeoutAsync(
+                        selfProfile, TimeSpan.FromSeconds(0.25), CancellationToken.None);
+
+                    Assert.Fail("a stalled fetch must surface as TimeoutException");
+                }
+                catch (TimeoutException) { }
+
+                Assert.That(selfProfile.CapturedTokens.Count, Is.EqualTo(1), "the fetch must run exactly once");
+
+                Assert.That(selfProfile.CapturedTokens[0].IsCancellationRequested, Is.True,
+                    "a timed-out fetch must cancel its own request instead of abandoning it");
+            });
+
+        [UnityTest]
+        public IEnumerator ReturnNullWhenProfileIsNotDeployed() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                var selfProfile = new MissingProfileSelfProfile();
+
+                Profile? result = await ProfileFetchingAuthState.FetchProfileWithTimeoutAsync(
+                    selfProfile, TimeSpan.FromSeconds(FETCH_TIMEOUT_SECONDS), CancellationToken.None);
+
+                Assert.That(result, Is.Null);
+                Assert.That(selfProfile.Calls, Is.EqualTo(1), "a genuine \"no deployed profile\" must resolve on the single fetch");
+            });
+
+        private static void SetBackingField(object target, Type declaringType, string propertyName, object value)
+        {
+            FieldInfo? field = declaringType.GetField($"<{propertyName}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null, $"auto-property backing field for {declaringType.Name}.{propertyName} not found");
+            field!.SetValue(target, value);
+        }
+
+        /// <summary>
+        ///     Simulates a stalled catalyst request. Mirrors the production contract of
+        ///     <see cref="SelfProfile.ProfileAsync" />: cancellation is suppressed into a null profile
+        ///     (RealmProfileRepository's suppressing GetAsync extension), never surfaced as an exception.
+        /// </summary>
+        private class StalledSelfProfile : ISelfProfile
+        {
+            public readonly List<CancellationToken> CapturedTokens = new ();
+
+            public event Action<Profile>? ProfilePropagated;
+
+            public async UniTask<Profile?> ProfileAsync(CancellationToken ct)
+            {
+                CapturedTokens.Add(ct);
+
+                try { return await UniTask.Never<Profile?>(ct); }
+                catch (OperationCanceledException) { return null; }
+            }
+
+            public UniTask<Profile?> UpdateProfileAsync(CancellationToken ct, bool updateAvatarInWorld = true) =>
+                UniTask.FromResult<Profile?>(null);
+
+            public UniTask<Profile?> UpdateProfileAsync(Profile profile, CancellationToken ct, bool updateAvatarInWorld = true) =>
+                UniTask.FromResult<Profile?>(null);
+
+            public void Dispose() { }
+        }
+
+        /// <summary>
+        ///     Simulates a responsive catalyst that has no deployed profile for the address:
+        ///     resolves to null immediately, without any cancellation involved.
+        /// </summary>
+        private class MissingProfileSelfProfile : ISelfProfile
+        {
+            public int Calls { get; private set; }
+
+            public event Action<Profile>? ProfilePropagated;
+
+            public UniTask<Profile?> ProfileAsync(CancellationToken ct)
+            {
+                Calls++;
+                return UniTask.FromResult<Profile?>(null);
+            }
+
+            public UniTask<Profile?> UpdateProfileAsync(CancellationToken ct, bool updateAvatarInWorld = true) =>
+                UniTask.FromResult<Profile?>(null);
+
+            public UniTask<Profile?> UpdateProfileAsync(Profile profile, CancellationToken ct, bool updateAvatarInWorld = true) =>
+                UniTask.FromResult<Profile?>(null);
+
+            public void Dispose() { }
+        }
+    }
+
+    public class StubProfileFetchingAuthView : ProfileFetchingAuthView
+    {
+        public override UniTask ShowAsync(CancellationToken ct) =>
+            UniTask.CompletedTask;
+
+        public override UniTask HideAsync(CancellationToken ct, bool isInstant = false) =>
+            UniTask.CompletedTask;
+    }
+}

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
@@ -32,8 +32,7 @@ namespace DCL.AuthenticationScreenFlow.Tests
         public IEnumerator CancelStalledFetchOnTimeout() =>
             UniTask.ToCoroutine(async () =>
             {
-                // The state machine has no states registered: transitions attempted by the flow throw and are logged
-                // through the fire-and-forget UniTaskVoid; those logs are irrelevant to the invariant under test
+                // No states registered: transitions throw and log via the fire-and-forget flow; those logs are irrelevant here
                 LogAssert.ignoreFailingMessages = true;
 
                 using var cts = new CancellationTokenSource();
@@ -83,8 +82,7 @@ namespace DCL.AuthenticationScreenFlow.Tests
                 }
                 finally
                 {
-                    // Unblock the pending attempt (even on assertion failure) so the detached flow finishes
-                    // inside this test's ignore-failing-messages window instead of erroring into a later test
+                    // Unblock the pending attempt so the detached flow finishes inside this test's ignore-failing-messages window
                     cts.Cancel();
 
                     for (var i = 0; i < 32; i++)
@@ -166,9 +164,8 @@ namespace DCL.AuthenticationScreenFlow.Tests
         }
 
         /// <summary>
-        ///     Simulates a stalled catalyst request. Mirrors the production contract of
-        ///     <see cref="SelfProfile.ProfileAsync" />: cancellation is suppressed into a null profile
-        ///     (RealmProfileRepository's suppressing GetAsync extension), never surfaced as an exception.
+        ///     Stalled catalyst request. Mirrors <see cref="SelfProfile.ProfileAsync" />: cancellation is
+        ///     suppressed into a null profile, never surfaced as an exception.
         /// </summary>
         private class StalledSelfProfile : ISelfProfile
         {
@@ -194,8 +191,7 @@ namespace DCL.AuthenticationScreenFlow.Tests
         }
 
         /// <summary>
-        ///     Simulates a responsive catalyst that has no deployed profile for the address:
-        ///     resolves to null immediately, without any cancellation involved.
+        ///     Responsive catalyst with no deployed profile: resolves to null immediately, no cancellation involved.
         /// </summary>
         private class MissingProfileSelfProfile : ISelfProfile
         {

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs.meta
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52b0bfdf4a194c62b8121caa81ed45b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/ECSThumbnailProviderShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/ECSThumbnailProviderShould.cs
@@ -1,0 +1,124 @@
+using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.AvatarRendering.Loading.Components;
+using DCL.AvatarRendering.Loading.DTO;
+using DCL.AvatarRendering.Loading.Exceptions;
+using DCL.AvatarRendering.Wearables;
+using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using ECS.StreamableLoading.Common.Components;
+using ECS.StreamableLoading.Textures;
+using NSubstitute;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using Promise = ECS.StreamableLoading.Common.AssetPromise<ECS.StreamableLoading.Textures.TextureData, ECS.StreamableLoading.Textures.GetTextureIntention>;
+
+namespace DCL.AvatarRendering.AvatarShape.Tests
+{
+    [TestFixture]
+    public class ECSThumbnailProviderShould
+    {
+        private static readonly QueryDescription THUMBNAIL_PROMISES = new QueryDescription().WithAll<IThumbnailAttachment, Promise>();
+
+        private World world = null!;
+        private ECSThumbnailProvider provider = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+
+            IDecentralandUrlsSource urlsSource = Substitute.For<IDecentralandUrlsSource>();
+            urlsSource.Url(Arg.Any<DecentralandUrl>()).Returns("https://peer.decentraland.test/content");
+
+            provider = new ECSThumbnailProvider(urlsSource, world);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            world.Dispose();
+        }
+
+        [Test]
+        public async Task RetryAfterFailedSlotInsteadOfRethrowing()
+        {
+            FakeWearable wearable = NewWearable();
+            wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.Failed();
+
+            UniTask<Sprite> getTask = provider.GetAsync(wearable, CancellationToken.None);
+            int promisesSpawned = world.CountEntities(in THUMBNAIL_PROMISES);
+
+            // Resolve the attachment the way ResolveAvatarAttachmentThumbnailSystem does on success.
+            SpriteData spriteData = NewSpriteData();
+            wearable.ThumbnailAssetResult = new StreamableLoadingResult<SpriteData>.WithFallback(spriteData);
+
+            Sprite? sprite;
+
+            try { sprite = await getTask; }
+            catch (ThumbnailLoadFailedException) { sprite = null; }
+
+            Assert.That(promisesSpawned, Is.EqualTo(1), "GetAsync must clear a Failed slot and spawn a fresh promise instead of rethrowing the cached failure");
+            Assert.That(sprite, Is.SameAs(spriteData.Sprite));
+        }
+
+        [Test]
+        public async Task ReturnCachedSuccessWithoutSpawningPromise()
+        {
+            FakeWearable wearable = NewWearable();
+            SpriteData spriteData = NewSpriteData();
+            wearable.ThumbnailAssetResult = new StreamableLoadingResult<SpriteData>.WithFallback(spriteData);
+
+            Sprite sprite = await provider.GetAsync(wearable, CancellationToken.None);
+
+            Assert.That(sprite, Is.SameAs(spriteData.Sprite));
+            Assert.That(world.CountEntities(in THUMBNAIL_PROMISES), Is.Zero);
+        }
+
+        [Test]
+        public async Task MarkFailedOnTimeoutAndRetryOnNextCall()
+        {
+            FakeWearable wearable = NewWearable();
+
+            try
+            {
+                await provider.GetAsync(wearable, CancellationToken.None, timeoutMs: 1);
+                Assert.Fail("Expected the first never-resolving load to throw after the timeout");
+            }
+            catch (ThumbnailLoadFailedException) { }
+
+            Assert.That(wearable.ThumbnailAssetResult, Is.Not.Null);
+            Assert.That(wearable.ThumbnailAssetResult!.Value.IsInitialized, Is.True);
+            Assert.That(wearable.ThumbnailAssetResult!.Value.Succeeded, Is.False);
+
+            int promisesAfterTimeout = world.CountEntities(in THUMBNAIL_PROMISES);
+
+            UniTask<Sprite> retryTask = provider.GetAsync(wearable, CancellationToken.None, timeoutMs: 1);
+            int promisesAfterRetry = world.CountEntities(in THUMBNAIL_PROMISES);
+
+            try { await retryTask; }
+            catch (ThumbnailLoadFailedException) { }
+
+            Assert.That(promisesAfterRetry, Is.EqualTo(promisesAfterTimeout + 1), "A call after a timed-out attempt must spawn a fresh promise instead of rethrowing the cached failure");
+        }
+
+        private static FakeWearable NewWearable() =>
+            new (new WearableDTO
+            {
+                metadata = new WearableDTO.WearableMetadataDto
+                {
+                    id = "urn:decentraland:off-chain:base-avatars:red_hoodie",
+                    thumbnail = "bafybeie7lzqakerm4n4x7557g3va4sv7aeoniexlomdgjskuoubo6s3mku",
+                    data =
+                    {
+                        representations = new AvatarAttachmentDTO.Representation[] { new () },
+                    },
+                },
+            });
+
+        private static SpriteData NewSpriteData() =>
+            new (new TextureData(Texture2D.whiteTexture), Sprite.Create(Texture2D.whiteTexture!, new Rect(0, 0, 1, 1), new Vector2()));
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/ECSThumbnailProviderShould.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/ECSThumbnailProviderShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5ac2b2c12d04e4daf8944308dc7d449
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteIntent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteIntent.cs
@@ -31,7 +31,7 @@ namespace DCL.AvatarRendering.Emotes
         public bool UpdatePlayTimeout(float dt)
         {
             // Timeout access returns a temporary value. We need to reassign the field or we lose the changes
-            playTimeout = new LoadTimeout(playTimeout?.Timeout ?? StreamableLoadingDefaults.TIMEOUT, playTimeout?.ElapsedTime ?? 0 + dt);
+            playTimeout = new LoadTimeout(playTimeout?.Timeout ?? StreamableLoadingDefaults.TIMEOUT, (playTimeout?.ElapsedTime ?? 0) + dt);
             bool result = playTimeout.Value.IsTimeout;
             return result;
         }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
@@ -1,10 +1,8 @@
 using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Assets;
-using DCL.AvatarRendering.Wearables.Components;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.StreamableLoading.AudioClips;
 using ECS.StreamableLoading.Common.Components;
-using System;
 using System.Collections.Generic;
 using DCL.AvatarRendering.Wearables.Registry;
 using Utility.Multithreading;
@@ -79,7 +77,7 @@ namespace DCL.AvatarRendering.Emotes
         {
             lock (lockObject)
             {
-                for (LinkedListNode<(URN key, long lastUsedFrame)> node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
+                for (LinkedListNode<(URN key, long lastUsedFrame)>? node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
                 {
                     URN urn = node.Value.key;
 
@@ -139,8 +137,9 @@ namespace DCL.AvatarRendering.Emotes
 
         private static void DisposeThumbnail(IEmote wearable)
         {
-            if (wearable.ThumbnailAssetResult is { IsInitialized: true })
-                wearable.ThumbnailAssetResult.Value.Asset.RemoveReference();
+            // A reference was acquired only if the result succeeded; failed/cancelled results carry a default SpriteData
+            if (wearable.ThumbnailAssetResult is { Succeeded: true } thumbnail)
+                thumbnail.Asset.RemoveReference();
         }
 
         private static void DisposeAudioClips(IEmote emote)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/TrimmedEmoteStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/TrimmedEmoteStorage.cs
@@ -85,8 +85,9 @@ namespace DCL.AvatarRendering.Emotes
 
         private static void DisposeThumbnail(ITrimmedEmote wearable)
         {
-            if (wearable.ThumbnailAssetResult is { IsInitialized: true })
-                wearable.ThumbnailAssetResult.Value.Asset.RemoveReference();
+            // A reference was acquired only if the result succeeded; failed/cancelled results carry a default SpriteData
+            if (wearable.ThumbnailAssetResult is { Succeeded: true } thumbnail)
+                thumbnail.Asset.RemoveReference();
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteIntentShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteIntentShould.cs
@@ -1,0 +1,38 @@
+using ECS.StreamableLoading;
+using NUnit.Framework;
+
+namespace DCL.AvatarRendering.Emotes.Tests
+{
+    public class CharacterEmoteIntentShould
+    {
+        [Test]
+        public void UpdatePlayTimeout_AccumulateElapsedTimeAcrossCalls_ReturnTrueOnceTotalReachesTimeout()
+        {
+            var intent = new CharacterEmoteIntent();
+
+            var timedOutBeforeLastSecond = false;
+
+            for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT - 1; second++)
+                timedOutBeforeLastSecond |= intent.UpdatePlayTimeout(1f);
+
+            Assert.IsFalse(timedOutBeforeLastSecond,
+                "Must not report a timeout before StreamableLoadingDefaults.TIMEOUT seconds of elapsed time have accumulated.");
+
+            var timedOutAtTimeoutSecond = intent.UpdatePlayTimeout(1f);
+
+            Assert.IsTrue(timedOutAtTimeoutSecond,
+                "Every call must add its dt to the running elapsed time, so the timeout fires once the accumulated total " +
+                "reaches StreamableLoadingDefaults.TIMEOUT seconds.");
+        }
+
+        [Test]
+        public void UpdatePlayTimeout_ReturnFalse_OnFirstCallBeforeTimeoutElapsed()
+        {
+            var intent = new CharacterEmoteIntent();
+
+            var result = intent.UpdatePlayTimeout(1f);
+
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteIntentShould.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteIntentShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e2161c20201e4772a7f4fa02d22f71de

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
@@ -1,18 +1,26 @@
 using Arch.Core;
 using CommunicationData.URLHelpers;
+using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.AvatarRendering.AvatarShape.UnityInterface;
 using DCL.AvatarRendering.Emotes.Play;
-using DCL.ECSComponents;
+using DCL.AvatarRendering.Loading.Assets;
+using DCL.AvatarRendering.Loading.Components;
 using DCL.Character.Components;
 using DCL.DebugUtilities;
 using DCL.Diagnostics;
+using DCL.ECSComponents;
 using DCL.Multiplayer.Emotes;
 using ECS.SceneLifeCycle;
+using ECS.StreamableLoading;
+using ECS.StreamableLoading.Common.Components;
 using ECS.TestSuite;
 using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Scene;
+using System.Text.RegularExpressions;
 using UnityEngine;
+using UnityEngine.TestTools;
+using Utility.Animations;
 using Object = UnityEngine.Object;
 
 namespace DCL.AvatarRendering.Emotes.Tests
@@ -21,9 +29,11 @@ namespace DCL.AvatarRendering.Emotes.Tests
     {
         private const string SMART_WEARABLE_ENTITY_ID = "bafkreiwearable";
         private const string EMOTE_HASH = "bafkreiemotehash";
+        private const string SCENE_EMOTE_URN = "urn:decentraland:off-chain:scene-emote:test-scene-bafkreiemotehash-false";
 
         private ScenesCache scenesCache = null!;
         private IEmotesMessageBus messageBus = null!;
+        private IEmoteStorage emoteStorage = null!;
         private IAvatarView avatarView = null!;
         private GameObject poolRoot = null!;
         private GameObject audioSourcePrefab = null!;
@@ -40,8 +50,9 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
             scenesCache = new ScenesCache();
             messageBus = Substitute.For<IEmotesMessageBus>();
+            emoteStorage = Substitute.For<IEmoteStorage>();
 
-            system = new CharacterEmoteSystem(world, Substitute.For<IEmoteStorage>(), messageBus, emotePlayer,
+            system = new CharacterEmoteSystem(world, emoteStorage, messageBus, emotePlayer,
                 Substitute.For<IDebugContainerBuilder>(), localSceneDevelopment: false, scenesCache);
 
             avatarView = Substitute.For<IAvatarView>();
@@ -91,6 +102,84 @@ namespace DCL.AvatarRendering.Emotes.Tests
             Assert.IsNull(world.Get<CharacterEmoteComponent>(playerEntity).CurrentEmoteReference);
             avatarView.Received().StopLegacyAnimation();
             messageBus.Received().SendStop();
+        }
+
+        /// <summary>
+        /// Regression for https://github.com/decentraland/unity-explorer/issues/6531: an emote whose
+        /// per-body-shape asset never resolves keeps ConsumeEmoteIntent parked on the "loading not complete"
+        /// branch every frame, so the play timeout is the only thing that can release the intent (and with it
+        /// the props of the previously played emote).
+        /// </summary>
+        [Test]
+        public void RemoveStrandedCharacterEmoteIntentAfterPlayTimeoutElapses()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("Cant play emote .* timeout reached"));
+
+            IAvatarView strandedAvatarView = Substitute.For<IAvatarView>();
+
+            // Grounded and not moving, so the intent reaches the emote-storage branch instead of parking
+            // on the movement gate.
+            strandedAvatarView.GetAnimatorBool(AnimationHashes.GROUNDED).Returns(true);
+
+            IEmote emote = Substitute.For<IEmote>();
+            emote.IsLoading.Returns(false);
+
+            // Empty results: the asset is not resident, so playback stops short of the avatar view every frame.
+            emote.AssetResults.Returns(new StreamableLoadingResult<AttachmentRegularAsset>?[BodyShape.COUNT]);
+
+            emoteStorage.TryGetElement(Arg.Any<URN>(), out Arg.Any<IEmote>())
+                        .Returns(call =>
+                         {
+                             call[1] = emote;
+                             return true;
+                         });
+
+            Entity strandedEntity = world.Create(
+                new CharacterEmoteComponent(),
+                new CharacterEmoteIntent
+                {
+                    EmoteId = new URN(SCENE_EMOTE_URN),
+                    Mask = AvatarEmoteMask.AemFullBody,
+                },
+                strandedAvatarView,
+                new AvatarShapeComponent { BodyShape = BodyShape.MALE });
+
+            for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
+                system!.Update(1f);
+
+            Assert.IsFalse(world.Has<CharacterEmoteIntent>(strandedEntity),
+                "A CharacterEmoteIntent whose asset never resolves must expire after StreamableLoadingDefaults.TIMEOUT seconds of elapsed play time.");
+        }
+
+        /// <summary>
+        /// The play timeout must not count the time an intent spends waiting for the avatar to stop moving:
+        /// that wait is user driven and unbounded, so counting it would discard the queued emote of a player
+        /// who simply keeps running or jumping for StreamableLoadingDefaults.TIMEOUT seconds.
+        /// </summary>
+        [Test]
+        public void KeepCharacterEmoteIntentWhileTheAvatarKeepsMoving()
+        {
+            IAvatarView movingAvatarView = Substitute.For<IAvatarView>();
+            movingAvatarView.GetAnimatorBool(AnimationHashes.GROUNDED).Returns(true);
+            movingAvatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND).Returns(1f);
+
+            Entity movingEntity = world.Create(
+                new CharacterEmoteComponent(),
+                new CharacterEmoteIntent
+                {
+                    EmoteId = new URN(SCENE_EMOTE_URN),
+                    Mask = AvatarEmoteMask.AemFullBody,
+                },
+                movingAvatarView,
+                new AvatarShapeComponent { BodyShape = BodyShape.MALE });
+
+            for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
+                system!.Update(1f);
+
+            Assert.IsTrue(world.Has<CharacterEmoteIntent>(movingEntity),
+                "An intent held back by the movement gate must survive: the avatar is moving, which is not a stuck state.");
+
+            emoteStorage.DidNotReceive().TryGetElement(Arg.Any<URN>(), out Arg.Any<IEmote>());
         }
 
         [Test]

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
@@ -105,10 +105,8 @@ namespace DCL.AvatarRendering.Emotes.Tests
         }
 
         /// <summary>
-        /// Regression for https://github.com/decentraland/unity-explorer/issues/6531: an emote whose
-        /// per-body-shape asset never resolves keeps ConsumeEmoteIntent parked on the "loading not complete"
-        /// branch every frame, so the play timeout is the only thing that can release the intent (and with it
-        /// the props of the previously played emote).
+        /// Regression for https://github.com/decentraland/unity-explorer/issues/6531: an emote whose asset
+        /// never resolves must be released by the play timeout instead of parking the intent forever.
         /// </summary>
         [Test]
         public void RemoveStrandedCharacterEmoteIntentAfterPlayTimeoutElapses()
@@ -117,8 +115,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
             IAvatarView strandedAvatarView = Substitute.For<IAvatarView>();
 
-            // Grounded and not moving, so the intent reaches the emote-storage branch instead of parking
-            // on the movement gate.
+            // Grounded and not moving: the intent reaches the emote-storage branch instead of the movement gate.
             strandedAvatarView.GetAnimatorBool(AnimationHashes.GROUNDED).Returns(true);
 
             IEmote emote = Substitute.For<IEmote>();
@@ -152,9 +149,8 @@ namespace DCL.AvatarRendering.Emotes.Tests
         }
 
         /// <summary>
-        /// The play timeout must not count the time an intent spends waiting for the avatar to stop moving:
-        /// that wait is user driven and unbounded, so counting it would discard the queued emote of a player
-        /// who simply keeps running or jumping for StreamableLoadingDefaults.TIMEOUT seconds.
+        /// The play timeout must not count time spent waiting for the avatar to stop moving:
+        /// that wait is user driven and unbounded.
         /// </summary>
         [Test]
         public void KeepCharacterEmoteIntentWhileTheAvatarKeepsMoving()

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/ECSThumbnailProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/ECSThumbnailProvider.cs
@@ -31,12 +31,10 @@ namespace DCL.AvatarRendering.Wearables
                 if (existing.Succeeded)
                     return existing.Asset;
 
-                // A previous attempt was cancelled (e.g. page change). Clear so a fresh promise
-                // can spawn below. Sticky failures keep the slot and fall through to throw.
-                if (existing.Cancelled)
-                    avatarAttachment.ThumbnailAssetResult = null;
-                else
-                    throw new ThumbnailLoadFailedException();
+                // A previous attempt ended without a sprite (timeout or cancellation). Terminal
+                // non-success states are per-attempt, never sticky across explicit requests:
+                // clear the slot so a fresh promise can spawn below.
+                avatarAttachment.ThumbnailAssetResult = null;
             }
 
             CancellationTokenSource promiseCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -59,10 +57,9 @@ namespace DCL.AvatarRendering.Wearables
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                // Timed out: cancel the underlying promise so the resolver cleans it up, and record
-                // a sticky Failed on the attachment so subsequent calls don't immediately re-attempt
-                // a load that we already gave up on. (The resolver will see IsCancellationRequested
-                // but skip overwriting because the slot is now Failed, not Cancelled.)
+                // Timed out: cancel the underlying promise so the resolver cleans it up. Failed
+                // releases concurrent waiters on this attachment and keeps the resolver from
+                // stamping Cancelled over the slot; the next explicit GetAsync clears it and retries.
                 promiseCts.Cancel();
                 avatarAttachment.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.Failed();
 

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/ECSThumbnailProvider.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/ECSThumbnailProvider.cs
@@ -31,9 +31,7 @@ namespace DCL.AvatarRendering.Wearables
                 if (existing.Succeeded)
                     return existing.Asset;
 
-                // A previous attempt ended without a sprite (timeout or cancellation). Terminal
-                // non-success states are per-attempt, never sticky across explicit requests:
-                // clear the slot so a fresh promise can spawn below.
+                // Terminal non-success (timeout or cancellation) is per-attempt, never sticky: clear the slot so a fresh promise can spawn
                 avatarAttachment.ThumbnailAssetResult = null;
             }
 
@@ -57,9 +55,8 @@ namespace DCL.AvatarRendering.Wearables
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                // Timed out: cancel the underlying promise so the resolver cleans it up. Failed
-                // releases concurrent waiters on this attachment and keeps the resolver from
-                // stamping Cancelled over the slot; the next explicit GetAsync clears it and retries.
+                // Timed out: cancel the underlying promise so the resolver cleans it up. Failed releases
+                // concurrent waiters and keeps the resolver from stamping Cancelled over the slot.
                 promiseCts.Cancel();
                 avatarAttachment.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.Failed();
 

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
@@ -4,7 +4,6 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Thumbnails.Utils;
-using DCL.AvatarRendering.Wearables;
 using DCL.Diagnostics;
 using ECS.Abstract;
 using ECS.StreamableLoading.Common.Components;
@@ -34,9 +33,8 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         {
             if (promise.IsCancellationRequested(World))
             {
-                // Mark as Cancelled so the next GetAsync call clears the slot and retries.
-                // Don't overwrite a sticky Failed (e.g. from a consumer timeout); only reset to
-                // Cancelled when the slot is clear.
+                // Release waiters with Cancelled only while the slot still signals in-flight; an
+                // initialized slot (e.g. Failed from a consumer timeout) already carries this attempt's terminal state.
                 if (wearable.ThumbnailAssetResult is not { IsInitialized: true })
                     wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);
@@ -55,8 +53,8 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         {
             if (promise.IsCancellationRequested(World))
             {
-                // Mark as Cancelled so the next GetAsync call clears the slot and retries.
-                // Don't overwrite a sticky Failed (e.g. from a consumer timeout).
+                // Release waiters with Cancelled only while the slot still signals in-flight; an
+                // initialized slot already carries this attempt's terminal state.
                 if (wearable.ThumbnailAssetResult is not { IsInitialized: true })
                     wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);

--- a/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Thumbnails/Systems/ResolveAvatarAttachmentThumbnailSystem.cs
@@ -33,8 +33,7 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         {
             if (promise.IsCancellationRequested(World))
             {
-                // Release waiters with Cancelled only while the slot still signals in-flight; an
-                // initialized slot (e.g. Failed from a consumer timeout) already carries this attempt's terminal state.
+                // Stamp Cancelled only while the slot is in-flight; an initialized slot (e.g. Failed from a consumer timeout) already carries the terminal state
                 if (wearable.ThumbnailAssetResult is not { IsInitialized: true })
                     wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);
@@ -53,8 +52,7 @@ namespace DCL.AvatarRendering.Thumbnails.Systems
         {
             if (promise.IsCancellationRequested(World))
             {
-                // Release waiters with Cancelled only while the slot still signals in-flight; an
-                // initialized slot already carries this attempt's terminal state.
+                // Stamp Cancelled only while the slot is in-flight; an initialized slot already carries the terminal state
                 if (wearable.ThumbnailAssetResult is not { IsInitialized: true })
                     wearable.ThumbnailAssetResult = StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult();
                 World.Destroy(entity);

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/TrimmedWearableStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/TrimmedWearableStorage.cs
@@ -86,8 +86,9 @@ namespace DCL.AvatarRendering.Wearables.Helpers
 
         private static void DisposeThumbnail(ITrimmedWearable wearable)
         {
-            if (wearable.ThumbnailAssetResult is { IsInitialized: true })
-                wearable.ThumbnailAssetResult.Value.Asset.RemoveReference();
+            // A reference was acquired only if the result succeeded; failed/cancelled results carry a default SpriteData
+            if (wearable.ThumbnailAssetResult is { Succeeded: true } thumbnail)
+                thumbnail.Asset.RemoveReference();
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Helpers/WearableStorage.cs
@@ -14,9 +14,8 @@ namespace DCL.AvatarRendering.Wearables.Helpers
     {
         private readonly LinkedList<(URN key, long lastUsedFrame)> listedCacheKeys = new ();
         private readonly Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>> cacheKeysDictionary = new (new Dictionary<URN, LinkedListNode<(URN key, long lastUsedFrame)>>(), URNIgnoreCaseEqualityComparer.Default);
-        private readonly Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>> ownedNftsRegistry = new (new Dictionary<URN, Dictionary<URN, NftBlockchainOperationEntry>>(), URNIgnoreCaseEqualityComparer.Default);
 
-        private readonly object lockObject = new ();
+        private new readonly object lockObject = new ();
 
         internal Dictionary<URN, IWearable> wearablesCache { get; } = new (new Dictionary<URN, IWearable>(), URNIgnoreCaseEqualityComparer.Default);
 
@@ -62,7 +61,7 @@ namespace DCL.AvatarRendering.Wearables.Helpers
         {
             lock (lockObject)
             {
-                for (LinkedListNode<(URN key, long lastUsedFrame)> node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
+                for (LinkedListNode<(URN key, long lastUsedFrame)>? node = listedCacheKeys.First; frameTimeBudget.TrySpendBudget() && node != null; node = node.Next)
                 {
                     URN urn = node.Value.key;
 
@@ -132,8 +131,10 @@ namespace DCL.AvatarRendering.Wearables.Helpers
         private static void DisposeThumbnail(IWearable wearable)
         {
             IAvatarAttachment attachment = wearable;
-            if (attachment.ThumbnailAssetResult is { IsInitialized: true })
-                attachment.ThumbnailAssetResult.Value.Asset.RemoveReference();
+
+            // A reference was acquired only if the result succeeded; failed/cancelled results carry a default SpriteData
+            if (attachment.ThumbnailAssetResult is { Succeeded: true } thumbnail)
+                thumbnail.Asset.RemoveReference();
         }
 
         private void UpdateListedCachePriority(URN @for)

--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs
@@ -1,0 +1,109 @@
+using DCL.Chat.History;
+using DCL.PerformanceAndDiagnostics.Analytics;
+using DCL.Profiles;
+using ECS.TestSuite;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace DCL.Chat.MessageBus.Tests
+{
+    /// <summary>
+    ///     Regression coverage for the "mentions" field of the <see cref="AnalyticsEvents.Ui.MESSAGE_SENT" /> event:
+    ///     it must carry wallet-address strings (JArray.Add takes object, so <see cref="UserId" />'s implicit
+    ///     string conversion never applies), and each tracked payload must own its mentions array so
+    ///     later sends cannot mutate events already queued for flush.
+    /// </summary>
+    [TestFixture]
+    public class ChatMessagesBusAnalyticsDecoratorShould
+    {
+        private const string FIRST_WALLET = "0x1111111111111111111111111111111111111111";
+        private const string SECOND_WALLET = "0x2222222222222222222222222222222222222222";
+
+        private IChatMessagesBus core = null!;
+        private IAnalyticsController analytics = null!;
+        private IProfileCache profileCache = null!;
+        private ChatMessagesBusAnalyticsDecorator decorator = null!;
+        private List<JObject> trackedPayloads = null!;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // Profile.CompactInfo touches FeaturesRegistry.Instance on construction; the editor
+            // domain may still hold an initialized registry from a play-mode session
+            EcsTestsUtils.TearDownFeaturesRegistry();
+            EcsTestsUtils.SetUpFeaturesRegistry();
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown() =>
+            EcsTestsUtils.TearDownFeaturesRegistry();
+
+        [SetUp]
+        public void SetUp()
+        {
+            core = Substitute.For<IChatMessagesBus>();
+            analytics = Substitute.For<IAnalyticsController>();
+            profileCache = Substitute.For<IProfileCache>();
+            trackedPayloads = new List<JObject>();
+
+            analytics.When(a => a.Track(AnalyticsEvents.Ui.MESSAGE_SENT, Arg.Any<JObject?>(), Arg.Any<bool>()))
+                     .Do(call => trackedPayloads.Add((JObject)call[1]!));
+
+            // selfProfile is only dereferenced when timestamp > 0; every Send here passes 0
+            decorator = new ChatMessagesBusAnalyticsDecorator(core, analytics, profileCache, null!);
+        }
+
+        [TearDown]
+        public void TearDown() =>
+            decorator.Dispose();
+
+        private static ProfileTier? CachedProfile(string wallet, string name) =>
+            new Profile.CompactInfo(UserId.New(wallet).Unwrap(), name);
+
+        [Test]
+        public void TrackMentionOfCachedProfileAsWalletAddressString()
+        {
+            profileCache.GetByUserName("TestName").Returns(CachedProfile(FIRST_WALLET, "TestName"));
+
+            Assert.DoesNotThrow(() => decorator.Send(ChatChannel.NEARBY_CHANNEL, "hello @TestName", ChatMessageOrigin.Chat, 0));
+
+            core.Received(1).Send(ChatChannel.NEARBY_CHANNEL, "hello @TestName", ChatMessageOrigin.Chat, 0);
+            Assert.That(trackedPayloads, Has.Count.EqualTo(1));
+
+            JObject payload = trackedPayloads[0];
+            Assert.That(payload["is_mention"]!.Value<bool>(), Is.True);
+
+            var mentions = (JArray)payload["mentions"]!;
+            Assert.That(mentions, Has.Count.EqualTo(1));
+            Assert.That(mentions[0].Type, Is.EqualTo(JTokenType.String));
+            Assert.That(mentions[0].Value<string>(), Is.EqualTo(FIRST_WALLET));
+        }
+
+        [Test]
+        public void KeepMentionsOfQueuedEventsIntactAcrossSends()
+        {
+            profileCache.GetByUserName("FirstUser").Returns(CachedProfile(FIRST_WALLET, "FirstUser"));
+            profileCache.GetByUserName("SecondUser").Returns(CachedProfile(SECOND_WALLET, "SecondUser"));
+
+            Assert.DoesNotThrow(() =>
+            {
+                decorator.Send(ChatChannel.NEARBY_CHANNEL, "hi @FirstUser", ChatMessageOrigin.Chat, 0);
+                decorator.Send(ChatChannel.NEARBY_CHANNEL, "hi @SecondUser", ChatMessageOrigin.Chat, 0);
+            });
+
+            Assert.That(trackedPayloads, Has.Count.EqualTo(2));
+
+            // The analytics queue holds payload references until flush: the first event's mentions
+            // must survive the second send unchanged
+            var firstMentions = (JArray)trackedPayloads[0]["mentions"]!;
+            Assert.That(firstMentions, Has.Count.EqualTo(1));
+            Assert.That(firstMentions[0].Value<string>(), Is.EqualTo(FIRST_WALLET));
+
+            var secondMentions = (JArray)trackedPayloads[1]["mentions"]!;
+            Assert.That(secondMentions, Has.Count.EqualTo(1));
+            Assert.That(secondMentions[0].Value<string>(), Is.EqualTo(SECOND_WALLET));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs
@@ -10,10 +10,8 @@ using System.Collections.Generic;
 namespace DCL.Chat.MessageBus.Tests
 {
     /// <summary>
-    ///     Regression coverage for the "mentions" field of the <see cref="AnalyticsEvents.Ui.MESSAGE_SENT" /> event:
-    ///     it must carry wallet-address strings (JArray.Add takes object, so <see cref="UserId" />'s implicit
-    ///     string conversion never applies), and each tracked payload must own its mentions array so
-    ///     later sends cannot mutate events already queued for flush.
+    ///     Regression coverage for the "mentions" field of <see cref="AnalyticsEvents.Ui.MESSAGE_SENT" />:
+    ///     it must carry wallet-address strings and each tracked payload must own its mentions array.
     /// </summary>
     [TestFixture]
     public class ChatMessagesBusAnalyticsDecoratorShould
@@ -95,8 +93,7 @@ namespace DCL.Chat.MessageBus.Tests
 
             Assert.That(trackedPayloads, Has.Count.EqualTo(2));
 
-            // The analytics queue holds payload references until flush: the first event's mentions
-            // must survive the second send unchanged
+            // The analytics queue holds payload references until flush
             var firstMentions = (JArray)trackedPayloads[0]["mentions"]!;
             Assert.That(firstMentions, Has.Count.EqualTo(1));
             Assert.That(firstMentions[0].Value<string>(), Is.EqualTo(FIRST_WALLET));

--- a/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs.meta
+++ b/Explorer/Assets/DCL/Chat/MessageBus/Tests/ChatMessagesBusAnalyticsDecoratorShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70e4e9e01f6c42b995033fa817c2d60d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetUserCallStatusCommand.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatCommands/GetUserCallStatusCommand.cs
@@ -22,6 +22,10 @@ namespace DCL.Chat.ChatCommands
                                                .SuppressCancellationThrow()
                                                .SuppressToResultAsync(ReportCategory.CHAT_MESSAGES);
 
+            // result.Value is default on cancellation or failure and must not be decoded as a user state
+            if (ct.IsCancellationRequested || !result.Success)
+                return CallButtonPresenter.OtherUserCallStatus.UserOffline;
+
             switch (result.Value.Result.ChatUserState)
             {
                 case PrivateConversationUserStateService.ChatUserState.Connected:

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -4,11 +4,8 @@ using DCL.Diagnostics;
 using DCL.Friends;
 using DCL.Friends.UserBlocking;
 using DCL.Multiplayer.Connections.RoomHubs;
-using DCL.Multiplayer.Profiles.Poses;
 using DCL.Optimization.Pools;
-using DCL.Profiles;
 using DCL.Settings.Settings;
-using DCL.Utilities;
 using DCL.Utility;
 using DCL.LiveKit.Public;
 using LiveKit.Rooms;
@@ -16,10 +13,11 @@ using LiveKit.Rooms.Participants;
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using LiveKit.Proto;
 using System.Linq;
 using UnityEngine;
 using Utility;
+
+// ReSharper disable InconsistentNaming
 
 namespace DCL.Chat.ChatServices
 {
@@ -175,7 +173,11 @@ namespace DCL.Chat.ChatServices
         {
             string lowerUserId = userId.ToLower();
 
-            FriendshipStatus friendshipStatus = await friendsService!.GetFriendshipStatusAsync(userId, ct);
+            // friendsService is null when the Friends feature is disabled (e.g. local scene development):
+            // every user resolves as a non-friend and the flow below handles them through the non-friend branches
+            FriendshipStatus friendshipStatus = friendsService != null
+                ? await friendsService.GetFriendshipStatusAsync(userId, ct)
+                : FriendshipStatus.None;
             bool isUserConnected = UserIsConsideredAsOnline(userId);
 
             //If it's a friend we just return its connection status
@@ -285,7 +287,7 @@ namespace DCL.Chat.ChatServices
         }
 
         private void OnYouUnblockedProfile(BlockedProfile profile) =>
-            CheckOnlineStatusAndNotify(profile.Profile.UserId);
+            CheckOnlineStatusAndNotify(profile.Profile.UserId.Value);
 
         private void OnYouBlockedByUser(string userId)
         {
@@ -295,7 +297,7 @@ namespace DCL.Chat.ChatServices
         }
 
         private void OnYouBlockedProfile(BlockedProfile profile) =>
-            CheckOnlineStatusAndNotify(profile.Profile.UserId);
+            CheckOnlineStatusAndNotify(profile.Profile.UserId.Value);
 
         /// <summary>
         /// Determines if a given user should be considered "online"

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -17,8 +17,6 @@ using System.Linq;
 using UnityEngine;
 using Utility;
 
-// ReSharper disable InconsistentNaming
-
 namespace DCL.Chat.ChatServices
 {
     /// <summary>
@@ -173,8 +171,7 @@ namespace DCL.Chat.ChatServices
         {
             string lowerUserId = userId.ToLower();
 
-            // friendsService is null when the Friends feature is disabled (e.g. local scene development):
-            // every user resolves as a non-friend and the flow below handles them through the non-friend branches
+            // friendsService is null when the Friends feature is disabled (e.g. local scene development)
             FriendshipStatus friendshipStatus = friendsService != null
                 ? await friendsService.GetFriendshipStatusAsync(userId, ct)
                 : FriendshipStatus.None;

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests.meta
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a871751de6bc41fe865bf48679055a14
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/PrivateConversationUserStateServiceShould.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/PrivateConversationUserStateServiceShould.cs
@@ -1,0 +1,86 @@
+using Cysharp.Threading.Tasks;
+using DCL.Chat.ChatCommands;
+using DCL.Friends;
+using DCL.Friends.UserBlocking;
+using DCL.Multiplayer.Connections.RoomHubs;
+using DCL.Multiplayer.Connections.Rooms;
+using DCL.Settings.Settings;
+using DCL.SocialService;
+using DCL.VoiceChat;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace DCL.Chat.ChatServices.Tests
+{
+    [TestFixture]
+    public class PrivateConversationUserStateServiceShould
+    {
+        private IUserBlockingCache userBlockingCache = null!;
+        private ChatSettingsAsset settingsAsset = null!;
+        private PrivateConversationUserStateService service = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            userBlockingCache = Substitute.For<IUserBlockingCache>();
+            settingsAsset = ScriptableObject.CreateInstance<ChatSettingsAsset>();
+
+            IRoomHub roomHub = Substitute.For<IRoomHub>();
+            roomHub.ChatRoom().Returns(NullRoom.INSTANCE);
+
+            // friendsService: null mirrors sessions where the Friends feature is force-disabled (local scene development)
+            service = new PrivateConversationUserStateService(
+                new CurrentChannelService(),
+                new ChatEventBus(),
+                userBlockingCache,
+                friendsService: null,
+                settingsAsset,
+                new RPCChatPrivacyService(Substitute.For<IRPCSocialServices>(), settingsAsset),
+                Substitute.For<IFriendsEventBus>(),
+                roomHub);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UnityEngine.Object.DestroyImmediate(settingsAsset);
+        }
+
+        [Test]
+        public void ResolveUserStateWithoutFriendsService()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            // The path has no pending awaits when friendsService is null, so the task completes synchronously
+            UniTask<PrivateConversationUserStateService.UserState> task = service.GetChatUserStateAsync("0xabc", CancellationToken.None);
+
+            Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
+
+            PrivateConversationUserStateService.UserState state = task.GetAwaiter().GetResult();
+
+            Assert.That(state.IsConsideredOnline, Is.False);
+            Assert.That(state.ChatUserState, Is.EqualTo(PrivateConversationUserStateService.ChatUserState.Disconnected));
+        }
+
+        [Test]
+        public void ReportCallStatusOfflineWhenResolutionFails()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            userBlockingCache.UserIsBlocked(Arg.Any<string>()).Returns(_ => throw new InvalidOperationException("blocking cache unavailable"));
+
+            var command = new GetUserCallStatusCommand(service);
+
+            UniTask<CallButtonPresenter.OtherUserCallStatus> task = command.ExecuteAsync("0xabc", CancellationToken.None);
+
+            Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
+            Assert.That(task.GetAwaiter().GetResult(), Is.EqualTo(CallButtonPresenter.OtherUserCallStatus.UserOffline));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/PrivateConversationUserStateServiceShould.cs.meta
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/PrivateConversationUserStateServiceShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e5c5d1edcdec493aacd9955cc452df2d

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/UserStateService.Tests.asmref
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/UserStateService.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/UserStateService.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/Tests/UserStateService.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1f67717920be42d88d6babbb7788072d
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
+++ b/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
@@ -2,7 +2,7 @@ using Arch.Core;
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.AvatarRendering.Emotes;
-using DCL.AvatarRendering.Loading.Components;
+using DCL.AvatarRendering.Thumbnails.Utils;
 using DCL.AvatarRendering.Wearables;
 using DCL.Backpack;
 using DCL.Diagnostics;
@@ -13,6 +13,7 @@ using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.UI;
 using MVC;
+using System;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -181,9 +182,24 @@ namespace DCL.EmotesWheel
             view.Thumbnail.gameObject.SetActive(false);
             view.LoadingSpinner.SetActive(true);
 
-            Sprite sprite = await thumbnailProvider.GetAsync(emote, ct);
+            try
+            {
+                Sprite sprite = await thumbnailProvider.GetAsync(emote, ct);
 
-            view.Thumbnail.sprite = sprite;
+                view.Thumbnail.sprite = sprite;
+            }
+            catch (OperationCanceledException) { return; }
+            catch (Exception e)
+            {
+                ReportHub.LogException(e, new ReportData(ReportCategory.THUMBNAILS));
+
+                if (ct.IsCancellationRequested) return;
+
+                // The failure path must still surface a sprite and release the spinner, otherwise
+                // the slot stays stuck on a load that already gave up.
+                view.Thumbnail.sprite = LoadThumbnailsUtils.DEFAULT_THUMBNAIL.Sprite;
+            }
+
             view.Thumbnail.gameObject.SetActive(true);
             view.LoadingSpinner.SetActive(false);
         }

--- a/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
+++ b/Explorer/Assets/DCL/EmotesWheel/EmotesWheelController.cs
@@ -195,8 +195,7 @@ namespace DCL.EmotesWheel
 
                 if (ct.IsCancellationRequested) return;
 
-                // The failure path must still surface a sprite and release the spinner, otherwise
-                // the slot stays stuck on a load that already gave up.
+                // The failure path must still surface a sprite, otherwise the slot stays stuck on a load that already gave up
                 view.Thumbnail.sprite = LoadThumbnailsUtils.DEFAULT_THUMBNAIL.Sprite;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/CommunicationsControllerAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Communications/CommunicationsControllerAPIImplementation.cs
@@ -1,9 +1,9 @@
 ﻿using CrdtEcsBridge.PoolsProviders;
+using DCL.Diagnostics;
 using SceneRunner.Scene;
 using SceneRuntime;
 using System;
 using System.Text;
-using RichTypes;
 
 namespace CrdtEcsBridge.JsModulesImplementation.Communications
 {
@@ -24,17 +24,28 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
 
         protected override void OnMessageReceived(ISceneCommunicationPipe.DecodedMessage message)
         {
-            var array = byteArrayPool.GetAPIRawDataPool(
-                IJsOperations.LIVEKIT_MAX_SIZE);
-
-            int walletIdLength = Encoding.UTF8.GetBytes(message.FromWalletId,
-                array.Array.AsSpan(1));
+            int maxWalletIdBytes = Encoding.UTF8.GetMaxByteCount(message.FromWalletId.Length);
+            var array = byteArrayPool.GetAPIRawDataPool(maxWalletIdBytes + 1 + IJsOperations.LIVEKIT_MAX_SIZE);
+            int walletIdLength = Encoding.UTF8.GetBytes(message.FromWalletId, array.Array.AsSpan(1));
 
             if (walletIdLength > 255)
+            {
+                array.Dispose();
                 throw new OverflowException("Wallet ID is too long");
+            }
 
             array.Array[0] = (byte)walletIdLength;
             int dataOffset = walletIdLength + 1;
+
+            // The consumed Uint8Array is fixed at LIVEKIT_MAX_SIZE; an oversized peer payload is a routine network condition, so drop instead of throwing.
+            if (dataOffset + message.Data.Length > IJsOperations.LIVEKIT_MAX_SIZE)
+            {
+                array.Dispose();
+                ReportHub.LogWarning(ReportCategory.LIVEKIT,
+                    $"Dropped oversized scene message ({message.Data.Length} bytes) from {message.FromWalletId}");
+                return;
+            }
+
             int totalLength = dataOffset;
 
             // At this point data is already without MsgType (Explorer routing is truncated a step above).
@@ -66,10 +77,6 @@ namespace CrdtEcsBridge.JsModulesImplementation.Communications
                 sourceData.CopyTo(filteredUnbounded); // basically no filtering
                 totalLength += sourceData.Length;
             }
-
-
-            if (totalLength > IJsOperations.LIVEKIT_MAX_SIZE)
-                throw new Exception("Received a message larger than LIVEKIT_MAX_SIZE");
 
             array.SetLength(totalLength);
             base.Enqueue(array);

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/EngineAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/EngineAPIImplementation.cs
@@ -105,37 +105,46 @@ namespace CrdtEcsBridge.JsModulesImplementation
             // as we no longer wait for a buffer to apply the thread should be frozen
             IWorldSyncCommandBuffer worldSyncBuffer = crdtWorldSynchronizer.GetSyncCommandBuffer();
 
-            // Reconcile CRDT state
-            for (var i = 0; i < messages.Count; i++)
+            try
             {
-                CRDTMessage message = messages[i];
-
-                // Skip Creator Hub components leaked from main.composite (inspector::*,
-                // specific asset-packs:: tooling metadata, composite::root) and phantom
-                // Creator Hub tags (custom components with empty data, e.g. cube-id).
-                if (message.Type is CRDTMessageType.PUT_COMPONENT
-                        or CRDTMessageType.DELETE_COMPONENT
-                        or CRDTMessageType.APPEND_COMPONENT
-                    && CreatorHubComponentFilter.ShouldFilter(in message))
+                // Reconcile CRDT state
+                for (var i = 0; i < messages.Count; i++)
                 {
-                    message.Data.Dispose();
-                    continue;
+                    CRDTMessage message = messages[i];
+
+                    // Skip Creator Hub components leaked from main.composite (inspector::*,
+                    // specific asset-packs:: tooling metadata, composite::root) and phantom
+                    // Creator Hub tags (custom components with empty data, e.g. cube-id).
+                    if (message.Type is CRDTMessageType.PUT_COMPONENT
+                            or CRDTMessageType.DELETE_COMPONENT
+                            or CRDTMessageType.APPEND_COMPONENT
+                        && CreatorHubComponentFilter.ShouldFilter(in message))
+                    {
+                        message.Data.Dispose();
+                        continue;
+                    }
+
+                    crdtProcessMessagesSampler.Begin();
+
+                    CRDTReconciliationResult reconciliationResult = crdtProtocol.ProcessMessage(in message);
+
+                    crdtProcessMessagesSampler.End();
+
+                    // TODO add metric to understand how many conflicts we have based on CRDTStateReconciliationResult
+
+                    // Prepare the message to be synced with the ECS World
+                    worldSyncBuffer.SyncCRDTMessage(in message, reconciliationResult.Effect);
                 }
 
-                crdtProcessMessagesSampler.Begin();
-
-                CRDTReconciliationResult reconciliationResult = crdtProtocol.ProcessMessage(in message);
-
-                crdtProcessMessagesSampler.End();
-
-                // TODO add metric to understand how many conflicts we have based on CRDTStateReconciliationResult
-
-                // Prepare the message to be synced with the ECS World
-                worldSyncBuffer.SyncCRDTMessage(in message, reconciliationResult.Effect);
+                // Deserialize messages
+                worldSyncBuffer.FinalizeAndDeserialize();
             }
-
-            // Deserialize messages
-            worldSyncBuffer.FinalizeAndDeserialize();
+            catch
+            {
+                // The buffer holds the single rent slot: release it on failure before the exception propagates
+                crdtWorldSynchronizer.AbortSyncCommandBuffer(worldSyncBuffer);
+                throw;
+            }
 
             worldSyncBufferSampler.End();
 
@@ -255,6 +264,11 @@ namespace CrdtEcsBridge.JsModulesImplementation
 
         private void ApplySyncCommandBuffer(IWorldSyncCommandBuffer worldSyncBuffer)
         {
+            // The rent slot is released by the synchronizer's ApplySyncCommandBuffer once it is entered;
+            // on any throw before that (e.g. mutex acquisition) the buffer must be aborted here instead —
+            // exactly one of the two must run, otherwise the slot either leaks or is double-released
+            var delegated = false;
+
             try
             {
                 using MultiThreadSync.Scope mutex = multiThreadSync.GetScope(syncOwner);
@@ -262,6 +276,7 @@ namespace CrdtEcsBridge.JsModulesImplementation
                 applyBufferSampler.Begin();
 
                 // Apply changes to the ECS World on the main thread
+                delegated = true;
                 crdtWorldSynchronizer.ApplySyncCommandBuffer(worldSyncBuffer);
                 applyBufferSampler.End();
 
@@ -269,7 +284,13 @@ namespace CrdtEcsBridge.JsModulesImplementation
                 // If the scene is updated more frequently than Unity Loop the gate will be effectively open all the time
                 systemGroupsUpdateGate.Open();
             }
-            catch (Exception e) { exceptionsHandler.OnEngineException(e, ReportCategory.CRDT_ECS_BRIDGE); }
+            catch (Exception e)
+            {
+                if (!delegated)
+                    crdtWorldSynchronizer.AbortSyncCommandBuffer(worldSyncBuffer);
+
+                exceptionsHandler.OnEngineException(e, ReportCategory.CRDT_ECS_BRIDGE);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/EngineAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/EngineAPIImplementation.cs
@@ -264,9 +264,8 @@ namespace CrdtEcsBridge.JsModulesImplementation
 
         private void ApplySyncCommandBuffer(IWorldSyncCommandBuffer worldSyncBuffer)
         {
-            // The rent slot is released by the synchronizer's ApplySyncCommandBuffer once it is entered;
-            // on any throw before that (e.g. mutex acquisition) the buffer must be aborted here instead —
-            // exactly one of the two must run, otherwise the slot either leaks or is double-released
+            // Exactly one of the synchronizer's ApplySyncCommandBuffer or the abort below must release the rent slot:
+            // abort only on a throw before delegation (e.g. mutex acquisition)
             var delegated = false;
 
             try

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/CommunicationControllerAPIImplementationShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/CommunicationControllerAPIImplementationShould.cs
@@ -3,7 +3,6 @@ using CRDT;
 using CrdtEcsBridge.JsModulesImplementation.Communications;
 using CrdtEcsBridge.PoolsProviders;
 using DCL.Ipfs;
-using DCL.Multiplayer.Connections.Messaging.Pipe;
 using ECS;
 using Microsoft.ClearScript;
 using Microsoft.ClearScript.V8;
@@ -17,18 +16,15 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using Utility;
-using RichTypes;
-using DCL.SceneBannedUsers;
 
 namespace CrdtEcsBridge.JsModulesImplementation.Tests
 {
     public class CommunicationControllerAPIImplementationShould
     {
-        private CommunicationsControllerAPIImplementation api;
-        private TestSceneCommunicationPipe sceneCommunicationPipe;
-        private IMessagePipe messagePipe;
-        private IJsOperations jsOperations;
-        private V8ScriptEngine engine;
+        private CommunicationsControllerAPIImplementation api = null!;
+        private TestSceneCommunicationPipe sceneCommunicationPipe = null!;
+        private IJsOperations jsOperations = null!;
+        private V8ScriptEngine engine = null!;
 
         [SetUp]
         public void SetUp()
@@ -95,8 +91,6 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
         {
             const string WALLET_ID = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
 
-            RoomMetadataCurrentScene.InitializeTest();
-
             byte[] data = GetRandomBytes(50).Prepend((byte)ISceneCommunicationPipe.MsgType.Uint8Array).ToArray();
 
             // The first payload byte is the SDK comms routing type: 1 (CRDT) and 3 (ResCRDTState) get their payload rewritten by CRDTFilter
@@ -115,6 +109,47 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
 
             CollectionAssert.AreEqual(expectedMessage,
                 api.EventsToProcess[0].Array.Take(api.EventsToProcess[0].Length));
+        }
+
+        [Test]
+        public void DropOversizedReceivedMessage()
+        {
+            // Regression: a peer-controlled payload larger than the rented receive buffer crashed the copy into it (UNITY-EXPLORER-PJA).
+            const string WALLET_ID = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+            const byte COMMS_REQ_CRDT_STATE = 2; // CommsMessageType.ReqCRDTState -> the unfiltered raw-copy path
+
+            // Exceeds even the pow2 bucket ArrayPool can round the rental up to.
+            var data = new byte[IJsOperations.LIVEKIT_MAX_SIZE + 4096];
+            data[0] = COMMS_REQ_CRDT_STATE;
+
+            Assert.DoesNotThrow(() =>
+                sceneCommunicationPipe.onSceneMessage.Invoke(
+                    new ISceneCommunicationPipe.DecodedMessage(data.AsSpan(), WALLET_ID, isTrustedSource: true)));
+
+            Assert.AreEqual(0, api.EventsToProcess.Count, "an oversized message must be dropped, not enqueued");
+        }
+
+        [Test]
+        public void DropReceivedMessageThatOverflowsOnlyWhenCombinedWithHeader()
+        {
+            // Regression: a payload that fits LIVEKIT_MAX_SIZE alone but overflows it with the prepended wallet-id header must be dropped (UNITY-EXPLORER-PJA).
+            const string WALLET_ID = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+            const byte COMMS_REQ_CRDT_STATE = 2; // CommsMessageType.ReqCRDTState -> the unfiltered raw-copy path
+
+            int walletIdBytes = Encoding.UTF8.GetByteCount(WALLET_ID);
+            int dataOffset = walletIdBytes + 1;
+
+            // Smallest payload that fits alone but overflows once the header is included.
+            var data = new byte[IJsOperations.LIVEKIT_MAX_SIZE - dataOffset + 1];
+            data[0] = COMMS_REQ_CRDT_STATE;
+
+            Assert.DoesNotThrow(() =>
+                sceneCommunicationPipe.onSceneMessage.Invoke(
+                    new ISceneCommunicationPipe.DecodedMessage(data.AsSpan(), WALLET_ID, isTrustedSource: true)));
+
+            Assert.AreEqual(0, api.EventsToProcess.Count, "a header-inclusive oversized message must be dropped, not enqueued");
+
+            Assert.DoesNotThrow(() => api.GetResult(), "GetResult() must not throw writing into the fixed-size destination array");
         }
 
         [Test]
@@ -137,9 +172,9 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
             int contentLength = 0; // No payload content for simplicity
 
             int crdtTotalLength = 1 // comms type
-                                   + PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength // VALID1
-                                   + PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength // NO_SYNC (dropped)
-                                   + PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength; // VALID2
+                                   + PUT_NETWORK_MESSAGE_HEADER_LENGTH // VALID1
+                                   + PUT_NETWORK_MESSAGE_HEADER_LENGTH // NO_SYNC (dropped)
+                                   + PUT_NETWORK_MESSAGE_HEADER_LENGTH; // VALID2
 
             var crdtMessage = new byte[crdtTotalLength];
             var crdtWrite = crdtMessage.AsSpan();
@@ -147,36 +182,33 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
             var crdtBody = crdtWrite.Slice(1);
 
             // VALID1 frame (PUT_COMPONENT_NETWORK + valid component id)
-            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength);
+            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH);
             crdtBody.Write((uint)CRDTMessageType.PUT_COMPONENT_NETWORK);
             crdtBody.Write(111); // entity id
             crdtBody.Write(1000u); // component id -> should be kept
             crdtBody.Write(1); // timestamp
             crdtBody.Write(1); // network id
             crdtBody.Write(contentLength); // content length
-            crdtBody = crdtBody.Slice(contentLength);
 
             // Droppable frame (PUT_COMPONENT_NETWORK + NO_SYNC component id)
-            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength);
+            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH);
             crdtBody.Write((uint)CRDTMessageType.PUT_COMPONENT_NETWORK);
             crdtBody.Write(222); // entity id
             crdtBody.Write(NO_SYNC_COMPONENT_ID); // component id -> this should trigger drop
             crdtBody.Write(2); // timestamp
             crdtBody.Write(2); // network id
             crdtBody.Write(contentLength); // content length
-            crdtBody = crdtBody.Slice(contentLength);
 
             // VALID2 frame (PUT_COMPONENT_NETWORK + different valid component id)
-            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength);
+            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH);
             crdtBody.Write((uint)CRDTMessageType.PUT_COMPONENT_NETWORK);
             crdtBody.Write(333); // entity id
             crdtBody.Write(2000u); // component id -> should be kept
             crdtBody.Write(3); // timestamp
             crdtBody.Write(3); // network id
             crdtBody.Write(contentLength); // content length
-            crdtBody = crdtBody.Slice(contentLength);
 
-            var inputs = new PoolableByteArray[]
+            var inputs = new[]
             {
                 new PoolableByteArray(crdtMessage, crdtMessage.Length, null),
             };
@@ -196,7 +228,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
             // Verify CRDT message was filtered (should contain VALID1 and VALID2, but not NO_SYNC)
             CollectionAssert.AreEqual(expectedCrdtEncoded, sceneCommunicationPipe.sendMessageCalls[0], "CRDT message should be filtered");
             // Verify exactly one frame was removed: original had 3 frames, filtered should have 2
-            int expectedFilteredSize = 1 + (2 * (PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength)); // type byte + 2 valid frames
+            int expectedFilteredSize = 1 + (2 * PUT_NETWORK_MESSAGE_HEADER_LENGTH); // type byte + 2 valid frames
             Assert.AreEqual(expectedFilteredSize, filteredWrite, "Filtered CRDT should contain exactly 2 frames (VALID1 and VALID2)");
         }
 
@@ -219,42 +251,39 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
 
             int contentLength = 0; // No payload content for simplicity
 
-            int crdtDataLength = PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength // VALID1
-                               + PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength // NO_SYNC (dropped)
-                               + PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength; // VALID2
+            int crdtDataLength = PUT_NETWORK_MESSAGE_HEADER_LENGTH // VALID1
+                               + PUT_NETWORK_MESSAGE_HEADER_LENGTH // NO_SYNC (dropped)
+                               + PUT_NETWORK_MESSAGE_HEADER_LENGTH; // VALID2
 
             var crdtData = new byte[crdtDataLength];
             var crdtBody = crdtData.AsSpan();
 
             // VALID1 frame (PUT_COMPONENT_NETWORK + valid component id)
-            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength);
+            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH);
             crdtBody.Write((uint)CRDTMessageType.PUT_COMPONENT_NETWORK);
             crdtBody.Write(111); // entity id
             crdtBody.Write(1000u); // component id -> should be kept
             crdtBody.Write(1); // timestamp
             crdtBody.Write(1); // network id
             crdtBody.Write(contentLength); // content length
-            crdtBody = crdtBody.Slice(contentLength);
 
             // Droppable frame (PUT_COMPONENT_NETWORK + NO_SYNC component id)
-            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength);
+            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH);
             crdtBody.Write((uint)CRDTMessageType.PUT_COMPONENT_NETWORK);
             crdtBody.Write(222); // entity id
             crdtBody.Write(NO_SYNC_COMPONENT_ID); // component id -> this should trigger drop
             crdtBody.Write(2); // timestamp
             crdtBody.Write(2); // network id
             crdtBody.Write(contentLength); // content length
-            crdtBody = crdtBody.Slice(contentLength);
 
             // VALID2 frame (PUT_COMPONENT_NETWORK + different valid component id)
-            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength);
+            crdtBody.Write(PUT_NETWORK_MESSAGE_HEADER_LENGTH);
             crdtBody.Write((uint)CRDTMessageType.PUT_COMPONENT_NETWORK);
             crdtBody.Write(333); // entity id
             crdtBody.Write(2000u); // component id -> should be kept
             crdtBody.Write(3); // timestamp
             crdtBody.Write(3); // network id
             crdtBody.Write(contentLength); // content length
-            crdtBody = crdtBody.Slice(contentLength);
 
             // RES_CRDT_STATE: Format is [type byte] + [1 byte: address length] + [address bytes] + [raw CRDT messages]
             string testAddress = "0x123";
@@ -268,7 +297,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
             addressBytes.CopyTo(resSpan.Slice(2));
             crdtData.CopyTo(resSpan.Slice(2 + addressLength));
 
-            var inputs = new PoolableByteArray[]
+            var inputs = new[]
             {
                 new PoolableByteArray(resMessage, resMessage.Length, null),
             };
@@ -288,7 +317,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
             // Verify RES_CRDT_STATE was filtered and address preserved
             CollectionAssert.AreEqual(expectedResEncoded, sceneCommunicationPipe.sendMessageCalls[0], "RES_CRDT_STATE should be filtered");
             // Verify exactly one frame was removed from RES_CRDT_STATE: original had address + 3 frames, filtered should have address + 2 frames
-            int expectedStateFilteredSize = 1 + 1 + addressLength + (2 * (PUT_NETWORK_MESSAGE_HEADER_LENGTH + contentLength)); // type + addr_len + addr + 2 valid frames
+            int expectedStateFilteredSize = 1 + 1 + addressLength + (2 * PUT_NETWORK_MESSAGE_HEADER_LENGTH); // type + addr_len + addr + 2 valid frames
             Assert.AreEqual(expectedStateFilteredSize, filteredStateWrite, "Filtered RES_CRDT_STATE should contain exactly 2 frames (VALID1 and VALID2)");
             // Verify address is still present in the filtered output
             Assert.AreEqual(addressLength, filteredStateBuffer[1], "Address length should be preserved");
@@ -354,16 +383,16 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
         private class TestSceneCommunicationPipe : ISceneCommunicationPipe
         {
             internal readonly List<byte[]> sendMessageCalls = new ();
-            internal ISceneCommunicationPipe.SceneMessageHandler onSceneMessage;
+            internal ISceneCommunicationPipe.SceneMessageHandler onSceneMessage = null!;
 
-            public void AddSceneMessageHandler(string sceneId, ISceneCommunicationPipe.MsgType msgType, ISceneCommunicationPipe.SceneMessageHandler onSceneMessage)
+            public void AddSceneMessageHandler(string sceneId, ISceneCommunicationPipe.MsgType msgType, ISceneCommunicationPipe.SceneMessageHandler handler)
             {
-                this.onSceneMessage = onSceneMessage;
+                onSceneMessage = handler;
             }
 
-            public void RemoveSceneMessageHandler(string sceneId, ISceneCommunicationPipe.MsgType msgType, ISceneCommunicationPipe.SceneMessageHandler onSceneMessage) { }
+            public void RemoveSceneMessageHandler(string sceneId, ISceneCommunicationPipe.MsgType msgType, ISceneCommunicationPipe.SceneMessageHandler handler) { }
 
-            public void SendMessage(ReadOnlySpan<byte> message, string sceneId, ISceneCommunicationPipe.ConnectivityAssertiveness assertiveness, CancellationToken ct, string specialRecipient = null)
+            public void SendMessage(ReadOnlySpan<byte> message, string sceneId, ISceneCommunicationPipe.ConnectivityAssertiveness assertiveness, CancellationToken ct, string? specialRecipient = null)
             {
                 sendMessageCalls.Add(message.ToArray());
             }

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs
@@ -1,0 +1,143 @@
+using Arch.Core;
+using CRDT;
+using CRDT.Deserializer;
+using CRDT.Memory;
+using CRDT.Protocol;
+using CRDT.Protocol.Factory;
+using CRDT.Serializer;
+using CrdtEcsBridge.Components;
+using CrdtEcsBridge.OutgoingMessages;
+using CrdtEcsBridge.PoolsProviders;
+using CrdtEcsBridge.UpdateGate;
+using CrdtEcsBridge.WorldSynchronizer;
+using DCL.Diagnostics;
+using DCL.Profiling;
+using NSubstitute;
+using NUnit.Framework;
+using SceneRunner.Scene.ExceptionsHandling;
+using System;
+using System.Collections.Generic;
+using UnityEngine.TestTools;
+using Utility.Multithreading;
+
+namespace CrdtEcsBridge.JsModulesImplementation.Tests
+{
+    /// <summary>
+    ///     The synchronizer holds a single rent slot: every buffer obtained by
+    ///     <see cref="EngineAPIImplementation.CrdtSendToRenderer" /> must free it on every path,
+    ///     including the failure ones, otherwise the scene is permanently wedged — each subsequent
+    ///     rent waits the full timeout and throws "Rent Wait Timeout".
+    /// </summary>
+    public class EngineAPISyncBufferRentShould
+    {
+        private static readonly byte[] INPUT = { 0, 3, 5, 7, 10, 19, 20, 40, 76 };
+
+        private World world = null!;
+        private MultiThreadSync multiThreadSync = null!;
+        private CRDTWorldSynchronizer crdtWorldSynchronizer = null!;
+        private ICRDTProtocol crdtProtocol = null!;
+        private ICRDTDeserializer crdtDeserializer = null!;
+
+        private EngineAPIImplementation engineApiImplementation = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+            multiThreadSync = new MultiThreadSync(new SceneShortInfo());
+
+            crdtWorldSynchronizer = new CRDTWorldSynchronizer(
+                world,
+                Substitute.For<ISDKComponentsRegistry>(),
+                Substitute.For<ISceneEntityFactory>(),
+                new Dictionary<CRDTEntity, Entity>());
+
+            crdtProtocol = Substitute.For<ICRDTProtocol>();
+            crdtDeserializer = Substitute.For<ICRDTDeserializer>();
+
+            IInstancePoolsProvider instancePoolsProvider = Substitute.For<IInstancePoolsProvider>();
+            instancePoolsProvider.GetDeserializationMessagesPool().Returns(_ => new List<CRDTMessage>());
+
+            engineApiImplementation = new EngineAPIImplementation(
+                Substitute.For<ISharedPoolsProvider>(),
+                instancePoolsProvider,
+                crdtProtocol,
+                crdtDeserializer,
+                new NoOpCRDTSerializer(),
+                crdtWorldSynchronizer,
+                Substitute.For<IOutgoingCRDTMessagesProvider>(),
+                Substitute.For<ISystemGroupsUpdateGate>(),
+
+                // Swallows like the production pipeline (EngineApiWrapper reports and continues)
+                Substitute.For<ISceneExceptionsHandler>(),
+                multiThreadSync,
+                new MultiThreadSync.Owner("TEST"),
+                new SceneRuntimeMetrics());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // A run that failed with the slot leaked also leaks the pooled collections;
+            // the resulting error log must not mask the assertion failure
+            LogAssert.ignoreFailingMessages = true;
+
+            try
+            {
+                crdtWorldSynchronizer.Dispose();
+                multiThreadSync.Dispose();
+                world.Dispose();
+            }
+            finally { LogAssert.ignoreFailingMessages = false; }
+        }
+
+        [Test]
+        public void ReleaseRentSlotWhenMutexAcquisitionFails()
+        {
+            // Deterministic stand-in for the production acquisition failures (10 s MultiThreadSync
+            // timeout / disposal race): a disposed sync throws ObjectDisposedException at the same site
+            multiThreadSync.Dispose();
+
+            // The internal catch reports to the exceptions handler and returns normally
+            engineApiImplementation.CrdtSendToRenderer(INPUT, false);
+
+            AssertRentSlotIsFree();
+        }
+
+        [Test]
+        public void ReleaseRentSlotWhenMessageProcessingThrows()
+        {
+            crdtDeserializer.When(d => d.DeserializeBatch(ref Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<IList<CRDTMessage>>()))
+                            .Do(c => c.ArgAt<IList<CRDTMessage>>(1)
+                                      .Add(new CRDTMessage(CRDTMessageType.PUT_COMPONENT, 10, 100, 1, EmptyMemoryOwner<byte>.EMPTY)));
+
+            crdtProtocol.ProcessMessage(Arg.Any<CRDTMessage>())
+                        .Returns(_ => throw new InvalidOperationException("Corrupted CRDT message"));
+
+            // Propagates to the caller (the production wrapper swallows it there)
+            Assert.Throws<InvalidOperationException>(() => engineApiImplementation.CrdtSendToRenderer(INPUT, false));
+
+            AssertRentSlotIsFree();
+        }
+
+        private void AssertRentSlotIsFree()
+        {
+            IWorldSyncCommandBuffer? recovered = null;
+
+            // A leaked slot makes this rent wait the full RENT_WAIT_TIMEOUT (5 s)
+            // and throw TimeoutException("Rent Wait Timeout: Couldn't rent command buffer")
+            Assert.DoesNotThrow(
+                () => recovered = crdtWorldSynchronizer.GetSyncCommandBuffer(),
+                "The rent slot leaked: the failed CrdtSendToRenderer call did not release the sync command buffer");
+
+            // Balance the probe rent so the synchronizer disposes cleanly
+            recovered!.FinalizeAndDeserialize();
+            crdtWorldSynchronizer.ApplySyncCommandBuffer(recovered);
+        }
+
+        private class NoOpCRDTSerializer : ICRDTSerializer
+        {
+            public void Serialize(ref Span<byte> destination, in ProcessedCRDTMessage processedMessage) { }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs
@@ -23,10 +23,8 @@ using Utility.Multithreading;
 namespace CrdtEcsBridge.JsModulesImplementation.Tests
 {
     /// <summary>
-    ///     The synchronizer holds a single rent slot: every buffer obtained by
-    ///     <see cref="EngineAPIImplementation.CrdtSendToRenderer" /> must free it on every path,
-    ///     including the failure ones, otherwise the scene is permanently wedged — each subsequent
-    ///     rent waits the full timeout and throws "Rent Wait Timeout".
+    ///     The synchronizer holds a single rent slot: <see cref="EngineAPIImplementation.CrdtSendToRenderer" />
+    ///     must free it on every path, including failures, or subsequent rents time out ("Rent Wait Timeout").
     /// </summary>
     public class EngineAPISyncBufferRentShould
     {
@@ -67,8 +65,6 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
                 crdtWorldSynchronizer,
                 Substitute.For<IOutgoingCRDTMessagesProvider>(),
                 Substitute.For<ISystemGroupsUpdateGate>(),
-
-                // Swallows like the production pipeline (EngineApiWrapper reports and continues)
                 Substitute.For<ISceneExceptionsHandler>(),
                 multiThreadSync,
                 new MultiThreadSync.Owner("TEST"),
@@ -78,8 +74,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
         [TearDown]
         public void TearDown()
         {
-            // A run that failed with the slot leaked also leaks the pooled collections;
-            // the resulting error log must not mask the assertion failure
+            // A leaked slot also leaks pooled collections; their error logs must not mask the assertion failure
             LogAssert.ignoreFailingMessages = true;
 
             try
@@ -94,8 +89,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
         [Test]
         public void ReleaseRentSlotWhenMutexAcquisitionFails()
         {
-            // Deterministic stand-in for the production acquisition failures (10 s MultiThreadSync
-            // timeout / disposal race): a disposed sync throws ObjectDisposedException at the same site
+            // A disposed sync throws ObjectDisposedException at the same site as the production acquisition failures
             multiThreadSync.Dispose();
 
             // The internal catch reports to the exceptions handler and returns normally
@@ -114,7 +108,6 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
             crdtProtocol.ProcessMessage(Arg.Any<CRDTMessage>())
                         .Returns(_ => throw new InvalidOperationException("Corrupted CRDT message"));
 
-            // Propagates to the caller (the production wrapper swallows it there)
             Assert.Throws<InvalidOperationException>(() => engineApiImplementation.CrdtSendToRenderer(INPUT, false));
 
             AssertRentSlotIsFree();
@@ -124,8 +117,7 @@ namespace CrdtEcsBridge.JsModulesImplementation.Tests
         {
             IWorldSyncCommandBuffer? recovered = null;
 
-            // A leaked slot makes this rent wait the full RENT_WAIT_TIMEOUT (5 s)
-            // and throw TimeoutException("Rent Wait Timeout: Couldn't rent command buffer")
+            // A leaked slot makes this rent wait the full RENT_WAIT_TIMEOUT and throw TimeoutException
             Assert.DoesNotThrow(
                 () => recovered = crdtWorldSynchronizer.GetSyncCommandBuffer(),
                 "The rent slot leaked: the failed CrdtSendToRenderer call did not release the sync command buffer");

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/Tests/EngineAPISyncBufferRentShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 954dac4f31db4dfcbc8a7f8601063884
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
@@ -90,5 +90,22 @@ namespace CrdtEcsBridge.WorldSynchronizer
 #endif
             }
         }
+
+        public void AbortSyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer)
+        {
+            try
+            {
+                syncCommandBuffer.Dispose();
+            }
+            finally
+            {
+#if !UNITY_WEBGL
+                // Pairs with semaphore.Wait in GetSyncCommandBuffer for buffers that never reach
+                // ApplySyncCommandBuffer; must release even if Dispose throws, otherwise the slot
+                // leaks and subsequent Rents time out forever.
+                semaphore.Release();
+#endif
+            }
+        }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/CrdtEcsSynchronizer.cs
@@ -100,9 +100,8 @@ namespace CrdtEcsBridge.WorldSynchronizer
             finally
             {
 #if !UNITY_WEBGL
-                // Pairs with semaphore.Wait in GetSyncCommandBuffer for buffers that never reach
-                // ApplySyncCommandBuffer; must release even if Dispose throws, otherwise the slot
-                // leaks and subsequent Rents time out forever.
+                // Pairs with semaphore.Wait in GetSyncCommandBuffer; must release even if Dispose throws,
+                // otherwise the slot leaks and subsequent Rents time out forever.
                 semaphore.Release();
 #endif
             }

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/ICRDTWorldSynchronizer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/ICRDTWorldSynchronizer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 
 namespace CrdtEcsBridge.WorldSynchronizer
 {
@@ -23,5 +22,15 @@ namespace CrdtEcsBridge.WorldSynchronizer
         /// </summary>
         /// <param name="syncCommandBuffer"></param>
         void ApplySyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer);
+
+        /// <summary>
+        ///     Disposes a rented command buffer that will never be applied and frees the rent slot.
+        ///     Every buffer obtained from <see cref="GetSyncCommandBuffer" /> must reach exactly one of
+        ///     <see cref="ApplySyncCommandBuffer" /> or this method, otherwise the single rent slot leaks
+        ///     and all subsequent rents time out.
+        ///     Can be called from the background thread
+        /// </summary>
+        /// <param name="syncCommandBuffer"></param>
+        void AbortSyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/ICRDTWorldSynchronizer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/WorldSynchronizer/ICRDTWorldSynchronizer.cs
@@ -24,13 +24,9 @@ namespace CrdtEcsBridge.WorldSynchronizer
         void ApplySyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer);
 
         /// <summary>
-        ///     Disposes a rented command buffer that will never be applied and frees the rent slot.
-        ///     Every buffer obtained from <see cref="GetSyncCommandBuffer" /> must reach exactly one of
-        ///     <see cref="ApplySyncCommandBuffer" /> or this method, otherwise the single rent slot leaks
-        ///     and all subsequent rents time out.
-        ///     Can be called from the background thread
+        ///     Disposes a rented command buffer that will never be applied and frees the single rent slot.
+        ///     Every rented buffer must reach exactly one of <see cref="ApplySyncCommandBuffer" /> or this method. Can be called from the background thread
         /// </summary>
-        /// <param name="syncCommandBuffer"></param>
         void AbortSyncCommandBuffer(IWorldSyncCommandBuffer syncCommandBuffer);
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
@@ -12,13 +12,14 @@ namespace ECS.Unity.AssetLoad.Cache
     public class AssetPreLoadCache : IDisposable
     {
         /// <summary>
-        ///     The never-handed-out template plus its live clones, so every copy can be released on teardown.
+        ///     The never-handed-out template. Clones handed out by <see cref="TryGetGltfInstance" /> are owned
+        ///     by the containers that checked them out and are released through
+        ///     <see cref="IGltfContainerAssetsCache.Dereference" />; this cache must never dispose them.
         /// </summary>
         private sealed class GltfTemplate
         {
             public readonly GltfContainerAsset Template;
             public readonly string Hash;
-            public readonly List<GltfContainerAsset> Copies = new ();
 
             public GltfTemplate(GltfContainerAsset template, string hash)
             {
@@ -47,21 +48,12 @@ namespace ECS.Unity.AssetLoad.Cache
             if (cache.TryGetValue(key, out object? value) && value is GltfTemplate gltfTemplate
                 && Utils.TryDuplicateGltfAssetFromTemplate(gltfTemplate.Template, gltfTemplate.Hash, out GltfContainerAsset? duplicate))
             {
-                gltfTemplate.Copies.Add(duplicate!);
                 instance = duplicate;
                 return true;
             }
 
             instance = null;
             return false;
-        }
-
-        public void ReleaseGltfInstance(string key, GltfContainerAsset instance)
-        {
-            if (cache.TryGetValue(key, out object? value) && value is GltfTemplate gltfTemplate)
-                gltfTemplate.Copies.Remove(instance);
-
-            instance.Dispose();
         }
 
         public bool TryAddVideo(string key, in VideoTemplateData data) =>
@@ -112,10 +104,10 @@ namespace ECS.Unity.AssetLoad.Cache
             foreach(var kvp in cache)
                 switch (kvp.Value)
                 {
+                    // Only the never-handed-out template is released. Checked-out clones are owned by
+                    // containers whose lifetime this cache does not control (it is global, Clear runs per
+                    // scene teardown); disposing them here would destroy live Roots under their owners.
                     case GltfTemplate gltfTemplate:
-                        foreach (GltfContainerAsset copy in gltfTemplate.Copies)
-                            copy.Dispose();
-
                         gltfCache.Dereference(kvp.Key, gltfTemplate.Template, handleAssetLoad: false);
                         break;
                     case AudioClipData audioClipData:

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Cache/AssetPreLoadCache.cs
@@ -13,8 +13,7 @@ namespace ECS.Unity.AssetLoad.Cache
     {
         /// <summary>
         ///     The never-handed-out template. Clones handed out by <see cref="TryGetGltfInstance" /> are owned
-        ///     by the containers that checked them out and are released through
-        ///     <see cref="IGltfContainerAssetsCache.Dereference" />; this cache must never dispose them.
+        ///     by their containers; this cache must never dispose them.
         /// </summary>
         private sealed class GltfTemplate
         {
@@ -104,9 +103,7 @@ namespace ECS.Unity.AssetLoad.Cache
             foreach(var kvp in cache)
                 switch (kvp.Value)
                 {
-                    // Only the never-handed-out template is released. Checked-out clones are owned by
-                    // containers whose lifetime this cache does not control (it is global, Clear runs per
-                    // scene teardown); disposing them here would destroy live Roots under their owners.
+                    // Checked-out clones are owned by their containers; disposing them here would destroy live Roots.
                     case GltfTemplate gltfTemplate:
                         gltfCache.Dereference(kvp.Key, gltfTemplate.Template, handleAssetLoad: false);
                         break;

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c28c5417c3da41ba8cddc2ebced16c1f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoad.Tests.asmref
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoad.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoad.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoad.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 38a45e759c794d46bc0c77979966cdfa
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs
@@ -1,0 +1,67 @@
+using ECS.StreamableLoading.AssetBundles;
+using ECS.Unity.AssetLoad.Cache;
+using ECS.Unity.GLTFContainer;
+using ECS.Unity.GLTFContainer.Asset.Cache;
+using ECS.Unity.GLTFContainer.Asset.Components;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace ECS.Unity.AssetLoad.Tests
+{
+    [TestFixture]
+    public class AssetPreLoadCacheShould
+    {
+        private const string KEY = "preload-key";
+        private const string HASH = "preload-hash";
+
+        private IGltfContainerAssetsCache gltfCache = null!;
+        private AssetPreLoadCache cache = null!;
+        private GameObject sourceAsset = null!;
+        private AssetBundleData assetBundleData = null!;
+        private GltfContainerAsset template = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            gltfCache = Substitute.For<IGltfContainerAssetsCache>();
+            cache = new AssetPreLoadCache(gltfCache);
+
+            // The template is built the same way the loading pipeline does: from an AssetBundleData
+            // exposing a source GameObject under the asset hash
+            sourceAsset = new GameObject(HASH);
+            assetBundleData = new AssetBundleData(null!, new Object[] { sourceAsset }, typeof(GameObject), Array.Empty<AssetBundleData>());
+            assetBundleData.AcquireRef();
+
+            Assert.That(Utils.TryCreateGltfObject(assetBundleData, HASH, out template), Is.True);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            template.Dispose();
+            Object.DestroyImmediate(sourceAsset);
+        }
+
+        [Test]
+        public void KeepCheckedOutClonesAliveOnClear()
+        {
+            Assert.That(cache.TryAddGltf(KEY, HASH, template), Is.True);
+            Assert.That(cache.TryGetGltfInstance(KEY, out GltfContainerAsset? clone), Is.True);
+
+            cache.Clear();
+
+            // The clone is owned by the container that checked it out; clearing the cache must not
+            // destroy its Root under that owner
+            Assert.That(clone!.Root == null, Is.False, "checked-out clone's Root must survive Clear()");
+
+            // The template itself is released back to the assets cache
+            gltfCache.Received(1).Dereference(KEY, template, false, false);
+            Assert.That(cache.ContainsGltf(KEY), Is.False);
+
+            clone.Dispose();
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs
@@ -29,8 +29,7 @@ namespace ECS.Unity.AssetLoad.Tests
             gltfCache = Substitute.For<IGltfContainerAssetsCache>();
             cache = new AssetPreLoadCache(gltfCache);
 
-            // The template is built the same way the loading pipeline does: from an AssetBundleData
-            // exposing a source GameObject under the asset hash
+            // Template built the way the loading pipeline does: an AssetBundleData exposing a source GameObject under the asset hash
             sourceAsset = new GameObject(HASH);
             assetBundleData = new AssetBundleData(null!, new Object[] { sourceAsset }, typeof(GameObject), Array.Empty<AssetBundleData>());
             assetBundleData.AcquireRef();
@@ -53,11 +52,8 @@ namespace ECS.Unity.AssetLoad.Tests
 
             cache.Clear();
 
-            // The clone is owned by the container that checked it out; clearing the cache must not
-            // destroy its Root under that owner
             Assert.That(clone!.Root == null, Is.False, "checked-out clone's Root must survive Clear()");
 
-            // The template itself is released back to the assets cache
             gltfCache.Received(1).Dereference(KEY, template, false, false);
             Assert.That(cache.ContainsGltf(KEY), Is.False);
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/AssetPreLoad/Tests/AssetPreLoadCacheShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8086f26b5b844d2f8b8b5287a54849d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Asset/Cache/GltfContainerAssetsCache.cs
@@ -98,7 +98,8 @@ namespace ECS.Unity.GLTFContainer.Asset.Cache
 
             if (handleAssetLoad && assetLoadCache != null && assetLoadCache.ContainsGltf(key))
             {
-                assetLoadCache.ReleaseGltfInstance(key, asset);
+                // The template is still cached: destroy the released clone rather than pooling a duplicate
+                asset.Dispose();
                 return;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
@@ -2,6 +2,7 @@
 using Arch.System;
 using Arch.SystemGroups;
 using CRDT;
+using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.Interaction.Utility;
 using DCL.Optimization.PerformanceBudgeting;
@@ -82,26 +83,39 @@ namespace ECS.Unity.GLTFContainer.Systems
                     return;
                 }
 
-                ConfigureGltfContainerColliders.SetupColliders(ref component, result.Asset!);
-                ConfigureSceneMaterial.EnableSceneBoundsAndForceCulling(in result.Asset!, in sceneCircumscribedPlanes, sceneHeight);
+                // A stale result can still reference an asset whose Root was already destroyed (e.g. drained
+                // by cache Unload/Remove). The promise is consumed at this point, so the component must still
+                // reach a terminal state; leaving it Loading would re-enter this query and throw
+                // "already consumed" on every subsequent frame.
+                if (result.Asset is not { } asset || asset.Root == null)
+                {
+                    ReportHub.LogError(GetReportData(), $"GltfContainerAsset '{component.Name}' ({component.Hash}) resolved with a destroyed Root");
+                    component.State = LoadingState.FinishedWithError;
+                    component.RootGameObject = null;
+                    eventsBuffer.Add(entity, component);
+                    return;
+                }
+
+                ConfigureGltfContainerColliders.SetupColliders(ref component, asset);
+                ConfigureSceneMaterial.EnableSceneBoundsAndForceCulling(in asset, in sceneCircumscribedPlanes, sceneHeight);
 
                 entityCollidersSceneCache.Associate(in component, entity, sdkEntity);
 
                 // Store reference to the root GameObject
-                component.RootGameObject = result.Asset!.Root;
+                component.RootGameObject = asset.Root;
 
                 // Re-parent to the current transform
-                result.Asset!.Root.transform.SetParent(transformComponent.Transform);
-                result.Asset.Root.transform.ResetLocalTRS();
-                result.Asset.Root.SetActive(true);
+                asset.Root.transform.SetParent(transformComponent.Transform);
+                asset.Root.transform.ResetLocalTRS();
+                asset.Root.SetActive(true);
 
-                result.Asset.SetRenderersActive(true);
-                result.Asset.ToggleAnimationState(true);
+                asset.SetRenderersActive(true);
+                asset.ToggleAnimationState(true);
 
                 component.State = LoadingState.Finished;
                 eventsBuffer.Add(entity, component);
 
-                if (result.Asset!.Animations.Count > 0 && result.Asset!.Animators.Count == 0)
+                if (asset.Animations.Count > 0 && asset.Animators.Count == 0)
                     World.Add(entity, new LegacyGltfAnimation());
             }
         }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/FinalizeGltfContainerLoadingSystem.cs
@@ -83,10 +83,8 @@ namespace ECS.Unity.GLTFContainer.Systems
                     return;
                 }
 
-                // A stale result can still reference an asset whose Root was already destroyed (e.g. drained
-                // by cache Unload/Remove). The promise is consumed at this point, so the component must still
-                // reach a terminal state; leaving it Loading would re-enter this query and throw
-                // "already consumed" on every subsequent frame.
+                // The asset's Root may already be destroyed (e.g. drained by cache Unload/Remove); the promise
+                // is already consumed, so the component must still reach a terminal state.
                 if (result.Asset is not { } asset || asset.Root == null)
                 {
                     ReportHub.LogError(GetReportData(), $"GltfContainerAsset '{component.Name}' ({component.Hash}) resolved with a destroyed Root");

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
@@ -8,6 +8,7 @@ using DCL.Interaction.Utility;
 using DCL.Optimization.PerformanceBudgeting;
 using ECS.Abstract;
 using ECS.Prioritization.Components;
+using ECS.StreamableLoading;
 using ECS.StreamableLoading.AssetBundles;
 using ECS.StreamableLoading.Common;
 using ECS.StreamableLoading.Common.Components;
@@ -104,6 +105,37 @@ namespace ECS.Unity.GLTFContainer.Tests
 
             component = world.Get<GltfContainerComponent>(e);
             Assert.That(component.State, Is.EqualTo(LoadingState.FinishedWithError));
+        }
+
+        [Test]
+        public void FinalizeWithErrorWhenAssetRootDestroyed()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            // A successfully-resolved result can reference an asset whose Root was destroyed
+            // while it awaited consumption
+            var asset = GltfContainerAsset.Create(new GameObject("root"), Substitute.For<IStreamableRefCountData>());
+            UnityEngine.Object.DestroyImmediate(asset.Root);
+
+            var component = new GltfContainerComponent(ColliderLayer.ClPhysics, ColliderLayer.ClPointer,
+                AssetPromise<GltfContainerAsset, GetGltfContainerAssetIntention>.Create(world, new GetGltfContainerAssetIntention(), PartitionComponent.TOP_PRIORITY));
+
+            component.State = LoadingState.Loading;
+
+            Entity e = world.Create(component, new CRDTEntity(100), new TransformComponent(), new PBGltfContainer());
+            world.Add(component.Promise.Entity, new StreamableLoadingResult<GltfContainerAsset>(asset));
+
+            // Without the destroyed-Root guard this throws EcsSystemException (NRE at Root.transform)
+            system!.Update(0);
+
+            component = world.Get<GltfContainerComponent>(e);
+            Assert.That(component.State, Is.EqualTo(LoadingState.FinishedWithError));
+            Assert.That(component.RootGameObject, Is.Null);
+            Assert.That(eventBuffer.Relations, Contains.Item(new EntityRelation<GltfContainerComponent>(e, component)));
+
+            // The consumed promise reached a terminal state: the next frame must be a no-op,
+            // not an "AssetPromise is already consumed" throw
+            Assert.DoesNotThrow(() => system!.Update(0));
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
@@ -112,8 +112,6 @@ namespace ECS.Unity.GLTFContainer.Tests
         {
             LogAssert.ignoreFailingMessages = true;
 
-            // A successfully-resolved result can reference an asset whose Root was destroyed
-            // while it awaited consumption
             var asset = GltfContainerAsset.Create(new GameObject("root"), Substitute.For<IStreamableRefCountData>());
             UnityEngine.Object.DestroyImmediate(asset.Root);
 
@@ -133,8 +131,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             Assert.That(component.RootGameObject, Is.Null);
             Assert.That(eventBuffer.Relations, Contains.Item(new EntityRelation<GltfContainerComponent>(e, component)));
 
-            // The consumed promise reached a terminal state: the next frame must be a no-op,
-            // not an "AssetPromise is already consumed" throw
+            // A second update on the consumed promise must be a no-op, not an "already consumed" throw
             Assert.DoesNotThrow(() => system!.Update(0));
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs
@@ -1,0 +1,35 @@
+using CommunicationData.URLHelpers;
+using UnityEngine;
+
+namespace ECS.StreamableLoading.AssetBundles
+{
+    /// <summary>
+    ///     Maintains the invariant that an entry in Unity's built-in <see cref="Caching" /> is either mountable or absent:
+    ///     a corrupt cached archive completes its web request successfully (cache hit, no network) yet yields a null
+    ///     bundle from the native mount, and Unity never evicts such an entry on its own.
+    /// </summary>
+    internal static class CorruptAbCacheEvictor
+    {
+        /// <summary>
+        ///     Unity's <see cref="Caching" /> keys entries by the file name of the request URL (query string excluded).
+        /// </summary>
+        internal static string CacheNameFromUrl(URLAddress url)
+        {
+            string value = url.Value;
+            int end = value.IndexOf('?');
+
+            if (end < 0)
+                end = value.Length;
+
+            int lastSlash = value.LastIndexOf('/', end - 1);
+            return value.Substring(lastSlash + 1, end - lastSlash - 1);
+        }
+
+        /// <summary>
+        ///     Main thread only. Returns false when there was no entry for that url+hash pair or the entry is in use
+        ///     (a corrupt entry never mounts, so it can never be in use).
+        /// </summary>
+        internal static bool TryEvict(URLAddress url, Hash128 cacheHash) =>
+            Caching.ClearCachedVersion(CacheNameFromUrl(url), cacheHash);
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs
@@ -4,9 +4,8 @@ using UnityEngine;
 namespace ECS.StreamableLoading.AssetBundles
 {
     /// <summary>
-    ///     Maintains the invariant that an entry in Unity's built-in <see cref="Caching" /> is either mountable or absent:
-    ///     a corrupt cached archive completes its web request successfully (cache hit, no network) yet yields a null
-    ///     bundle from the native mount, and Unity never evicts such an entry on its own.
+    ///     Evicts corrupt entries from Unity's built-in <see cref="Caching" />: a corrupt archive completes its
+    ///     web request (cache hit) yet mounts to a null bundle, and Unity never evicts it on its own.
     /// </summary>
     internal static class CorruptAbCacheEvictor
     {
@@ -26,8 +25,7 @@ namespace ECS.StreamableLoading.AssetBundles
         }
 
         /// <summary>
-        ///     Main thread only. Returns false when there was no entry for that url+hash pair or the entry is in use
-        ///     (a corrupt entry never mounts, so it can never be in use).
+        ///     Main thread only. Returns false when there was no entry for that url+hash pair or the entry is in use.
         /// </summary>
         internal static bool TryEvict(URLAddress url, Hash128 cacheHash) =>
             Caching.ClearCachedVersion(CacheNameFromUrl(url), cacheHash);

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/CorruptAbCacheEvictor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 282016f172e045b081662efe7ba292c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
@@ -3,7 +3,6 @@ using Arch.SystemGroups;
 using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
-using DCL.Optimization.PerformanceBudgeting;
 using DCL.Optimization.Pools;
 using DCL.Optimization.ThreadSafePool;
 using ECS.Prioritization.Components;
@@ -93,6 +92,29 @@ namespace ECS.StreamableLoading.AssetBundles
                     progressReporter: byteWeightedProgress ? state : null,
                     suppressErrors: true); // Suppress errors because here we have our own error handling
                 assetBundle = assetBundleResult.Value.AssetBundle;
+
+                if (assetBundle == null && intention.cacheHash.HasValue)
+                {
+                    // A corrupt entry in Unity's Caching completes the request without reaching the network yet fails
+                    // the native mount, and nothing else ever evicts it — the entry would poison this bundle across
+                    // sessions. Evicting turns the single re-request below into a real download that re-populates the
+                    // cache; for null bundles with non-cache causes it costs at most one extra attempt.
+                    await UniTask.SwitchToMainThread();
+
+                    if (CorruptAbCacheEvictor.TryEvict(intention.CommonArguments.URL, intention.cacheHash.Value))
+                        ReportHub.Log(GetReportData(), $"Evicted corrupt cached AssetBundle for {intention.Hash}, retrying download");
+
+                    assetBundleResult = await webRequestController.GetAssetBundleAsync(
+                        intention.CommonArguments,
+                        new GetAssetBundleArguments(loadingMutex, intention.cacheHash),
+                        ct,
+                        GetReportCategory(),
+                        expectedContentLength: contentLength,
+                        progressReporter: byteWeightedProgress ? state : null,
+                        suppressErrors: true);
+
+                    assetBundle = assetBundleResult.Value.AssetBundle;
+                }
             }
 
             // Release budget now to not hold it until dependencies are resolved to prevent a deadlock
@@ -111,11 +133,11 @@ namespace ECS.StreamableLoading.AssetBundles
             {
                 // get metrics
 
-                string? metadataJSON;
+                string metadataJson;
 
                 using (AssetBundleLoadingMutex.LoadingRegion _ = await loadingMutex.AcquireAsync(ct))
                 {
-                    metadataJSON = assetBundle.LoadAsset<TextAsset>(METADATA_FILENAME)?.text;
+                    metadataJson = assetBundle.LoadAsset<TextAsset>(METADATA_FILENAME)?.text ?? string.Empty;
                 }
 
                 // Switch to thread pool to parse JSONs
@@ -126,12 +148,12 @@ namespace ECS.StreamableLoading.AssetBundles
                 AssetBundleData[] dependencies;
                 var mainAsset = "";
 
-                if (!string.IsNullOrEmpty(metadataJSON))
+                if (!string.IsNullOrEmpty(metadataJson))
                 {
                     using PoolExtensions.Scope<AssetBundleMetadata> reusableMetadata = METADATA_POOL.AutoScope();
 
                     // Parse metadata
-                    JsonUtility.FromJsonOverwrite(metadataJSON, reusableMetadata.Value);
+                    JsonUtility.FromJsonOverwrite(metadataJson, reusableMetadata.Value);
                     mainAsset = reusableMetadata.Value.mainAsset;
                     dependencies = await LoadDependenciesAsync(intention, partition, reusableMetadata.Value, ct);
                 }
@@ -185,14 +207,14 @@ namespace ECS.StreamableLoading.AssetBundles
                     throw new StreamableLoadingException(LogType.Warning, nameof(LoadAssetBundleSystem), new AssetBundleContainsShaderException(assetBundle.name));
             }
 
-            Object[]? asset = await LoadAllAssetsAsync(assetBundle, expectedObjType, mainAsset, loadingMutex, reportCategory, ct);
+            Object[]? asset = await LoadAllAssetsAsync(assetBundle, expectedObjType, mainAsset, loadingMutex, ct);
 
             return new StreamableLoadingResult<AssetBundleData>(new AssetBundleData(assetBundle, asset, expectedObjType, dependencies,
                 version: version,
                 source: source));
         }
 
-        private static async UniTask<Object[]> LoadAllAssetsAsync(AssetBundle assetBundle, Type? objectType, string? mainAsset, AssetBundleLoadingMutex loadingMutex, ReportData reportCategory, CancellationToken ct)
+        private static async UniTask<Object[]> LoadAllAssetsAsync(AssetBundle assetBundle, Type? objectType, string? mainAsset, AssetBundleLoadingMutex loadingMutex, CancellationToken ct)
         {
             using AssetBundleLoadingMutex.LoadingRegion _ = await loadingMutex.AcquireAsync(ct);
 
@@ -215,12 +237,12 @@ namespace ECS.StreamableLoading.AssetBundles
         private async UniTask<AssetBundleData> WaitForDependencyAsync(
             string hash,
             AssetBundleManifestVersion assetBundleManifestVersion,
-            string parentEntityID,
+            string parentEntityId,
             URLSubdirectory customEmbeddedSubdirectory,
             IPartitionComponent partition, CancellationToken ct)
         {
             // Inherit partition from the parent promise
-            var assetBundlePromise = AssetPromise<AssetBundleData, GetAssetBundleIntention>.Create(World, GetAssetBundleIntention.FromHash(hash, assetBundleManifestVersion: assetBundleManifestVersion, parentEntityID: parentEntityID, customEmbeddedSubDirectory: customEmbeddedSubdirectory, isDependency : true), partition);
+            var assetBundlePromise = AssetPromise<AssetBundleData, GetAssetBundleIntention>.Create(World, GetAssetBundleIntention.FromHash(hash, assetBundleManifestVersion: assetBundleManifestVersion, parentEntityID: parentEntityId, customEmbeddedSubDirectory: customEmbeddedSubdirectory, isDependency : true), partition);
 
             try
             {
@@ -229,10 +251,10 @@ namespace ECS.StreamableLoading.AssetBundles
                 if (!assetBundlePromise.TryGetResult(World, out StreamableLoadingResult<AssetBundleData> depResult))
                     throw new Exception($"Dependency {hash} is not resolved");
 
-                if (!depResult.Succeeded)
+                if (depResult is not { Succeeded: true, Asset: { } depAsset })
                     throw new Exception($"Dependency {hash} resolution failed", depResult.Exception);
 
-                return depResult.Asset;
+                return depAsset;
             }
             catch (OperationCanceledException)
             {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/LoadAssetBundleSystem.cs
@@ -95,10 +95,8 @@ namespace ECS.StreamableLoading.AssetBundles
 
                 if (assetBundle == null && intention.cacheHash.HasValue)
                 {
-                    // A corrupt entry in Unity's Caching completes the request without reaching the network yet fails
-                    // the native mount, and nothing else ever evicts it — the entry would poison this bundle across
-                    // sessions. Evicting turns the single re-request below into a real download that re-populates the
-                    // cache; for null bundles with non-cache causes it costs at most one extra attempt.
+                    // A corrupt Caching entry mounts to a null bundle and is never evicted, poisoning this bundle
+                    // across sessions; evict so the single re-request below re-populates the cache.
                     await UniTask.SwitchToMainThread();
 
                     if (CorruptAbCacheEvictor.TryEvict(intention.CommonArguments.URL, intention.cacheHash.Value))

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs
@@ -1,0 +1,193 @@
+using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.WebRequests;
+using ECS.Prioritization.Components;
+using ECS.StreamableLoading.Cache;
+using ECS.StreamableLoading.Cache.Disk;
+using ECS.StreamableLoading.Common.Components;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.TestTools;
+
+namespace ECS.StreamableLoading.AssetBundles.Tests
+{
+    /// <summary>
+    ///     Covers the recovery invariant for corrupt entries in Unity's built-in <see cref="Caching" />:
+    ///     a corrupt cached archive completes its web request successfully (cache hit, no network) yet
+    ///     yields a null bundle from the native mount ("Unable to open archive file"), and since nothing
+    ///     evicts the entry, the bundle stays broken for the user across sessions. The load flow must
+    ///     evict the entry and re-request once so the cache is re-populated with a whole archive.
+    /// </summary>
+    [TestFixture]
+    public class CorruptAbCacheRecoveryShould
+    {
+        private const string BUNDLE_CACHE_NAME = "bafkreid3xecd44iujaz5qekbdrt5orqdqj3wivg5zc5mya3zkorjhyrkda";
+
+        private static string bundlePath => $"{Application.dataPath}/../TestResources/AssetBundles/{BUNDLE_CACHE_NAME}";
+        private static string bundleUrl => $"file://{bundlePath}";
+
+        private World world = null!;
+        private IStreamableCache<AssetBundleData, GetAssetBundleIntention> cache = null!;
+        private ExposedLoadAssetBundleSystem? system;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+            cache = Substitute.For<IStreamableCache<AssetBundleData, GetAssetBundleIntention>>();
+            Caching.ClearAllCachedVersions(BUNDLE_CACHE_NAME);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            LogAssert.ignoreFailingMessages = false;
+            AssetBundle.UnloadAllAssetBundles(true);
+            Caching.ClearAllCachedVersions(BUNDLE_CACHE_NAME);
+            system?.Dispose();
+            world.Dispose();
+        }
+
+        [Test]
+        public async Task RecoverFromCorruptCachedArchive()
+        {
+            // The native "Unable to open archive file" error raised by the corrupt mount is the expected symptom
+            LogAssert.ignoreFailingMessages = true;
+
+            Hash128 cacheHash = Hash128.Compute("corrupt-ab-cache-recovery");
+
+            await SeedCacheAsync(cacheHash);
+
+            string dataFile = FindCachedDataFile();
+            byte[] original = File.ReadAllBytes(dataFile);
+            var garbage = new byte[original.Length];
+
+            for (var i = 0; i < garbage.Length; i++)
+                garbage[i] = 0xAB;
+
+            // Same-length corruption models the real defect: presence checks still hit, only the mount fails
+            File.WriteAllBytes(dataFile, garbage);
+
+            system = new ExposedLoadAssetBundleSystem(world, cache, IWebRequestController.TEST);
+
+            // Without the eviction retry this await faults with NullReferenceException: the corrupt entry is
+            // served from the cache, DownloadHandlerAssetBundle.GetContent returns null and no recovery exists,
+            // while the corrupt entry stays cached for every future attempt.
+            StreamableLoadingResult<AssetBundleData> result = await system.FlowAsync(
+                NewWebIntention(bundleUrl, cacheHash), StreamableLoadingState.Create(), PartitionComponent.TOP_PRIORITY, CancellationToken.None);
+
+            Assert.That(result.Succeeded, Is.True, result.Exception?.ToString());
+            Assert.That(result.Asset, Is.Not.Null);
+
+            // The corrupt entry was evicted and re-downloaded: the cached archive is whole again
+            Assert.That(Caching.IsVersionCached(bundleUrl, cacheHash), Is.True);
+
+            byte[] repaired = File.ReadAllBytes(FindCachedDataFile());
+            Assert.That(repaired[..8], Is.EqualTo(original[..8]), "the cached archive must be re-populated with real content");
+
+            await PumpAsync();
+        }
+
+        [Test]
+        public async Task RetryExactlyOnceAfterEvictingWhenCachedRequestYieldsNullBundle()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            IWebRequestController controller = Substitute.For<IWebRequestController>();
+            var requests = 0;
+            AssetBundle? retryBundle = null;
+
+            controller.SendAsync<GetAssetBundleWebRequest, GetAssetBundleArguments, GetAssetBundleWebRequest.CreateAssetBundleOp, AssetBundleLoadingResult>(
+                           Arg.Any<RequestEnvelope<GetAssetBundleWebRequest, GetAssetBundleArguments>>(),
+                           Arg.Any<GetAssetBundleWebRequest.CreateAssetBundleOp>(),
+                           Arg.Any<long>(),
+                           Arg.Any<IProgress<float>?>())
+                      .Returns(_ =>
+                       {
+                           requests++;
+
+                           // The first response models a corrupt cache-served archive: the request "succeeds", the bundle is null
+                           if (requests == 1)
+                               return UniTask.FromResult(new AssetBundleLoadingResult(null, "Unable to open archive file"));
+
+                           retryBundle ??= AssetBundle.LoadFromFile(bundlePath);
+                           return UniTask.FromResult(new AssetBundleLoadingResult(retryBundle, null));
+                       });
+
+            system = new ExposedLoadAssetBundleSystem(world, cache, controller);
+
+            // Without the eviction retry this await faults with NullReferenceException after a single request
+            StreamableLoadingResult<AssetBundleData> result = await system.FlowAsync(
+                NewWebIntention("https://ab-cdn.decentraland.test/v49/assets/corrupt_stub_windows", Hash128.Compute("corrupt-stub")),
+                StreamableLoadingState.Create(), PartitionComponent.TOP_PRIORITY, CancellationToken.None);
+
+            Assert.That(requests, Is.EqualTo(2), "a cache-eligible null bundle must be followed by exactly one evict-and-retry re-request");
+            Assert.That(result.Succeeded, Is.True, result.Exception?.ToString());
+            Assert.That(result.Asset, Is.Not.Null);
+
+            await PumpAsync();
+        }
+
+        private static GetAssetBundleIntention NewWebIntention(string url, Hash128 cacheHash) =>
+            new (new CommonLoadingArguments(url, attempts: 1)) { cacheHash = cacheHash };
+
+        private static async Task SeedCacheAsync(Hash128 cacheHash)
+        {
+            using UnityWebRequest webRequest = UnityWebRequestAssetBundle.GetAssetBundle(bundleUrl, cacheHash);
+            UnityWebRequestAsyncOperation operation = webRequest.SendWebRequest();
+
+            while (!operation.isDone)
+                await UniTask.Yield();
+
+            Assume.That(webRequest.result, Is.EqualTo(UnityWebRequest.Result.Success), "seeding Unity's AssetBundle cache failed");
+
+            AssetBundle? seeded = DownloadHandlerAssetBundle.GetContent(webRequest);
+            Assume.That(seeded, Is.Not.Null, "seeding Unity's AssetBundle cache produced no bundle");
+            seeded!.Unload(true);
+
+            Assume.That(Caching.IsVersionCached(bundleUrl, cacheHash), Is.True, "Editor Caching did not store the seeded bundle");
+        }
+
+        private static string FindCachedDataFile()
+        {
+            string bundleRoot = Path.Combine(Caching.currentCacheForWriting.path, BUNDLE_CACHE_NAME);
+            Assume.That(Directory.Exists(bundleRoot), Is.True, $"no cache folder at {bundleRoot}");
+
+            string[] entries = Directory.GetDirectories(bundleRoot);
+
+            for (var i = 0; i < entries.Length; i++)
+            {
+                string candidate = Path.Combine(entries[i], "__data");
+
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            Assume.That(false, $"no cached __data found under {bundleRoot}");
+            return null!;
+        }
+
+        private static async Task PumpAsync()
+        {
+            // Land detached continuations inside the test window instead of after it (EditMode harness requirement)
+            for (var i = 0; i < 10; i++)
+                await UniTask.Yield();
+        }
+
+        private class ExposedLoadAssetBundleSystem : LoadAssetBundleSystem
+        {
+            public ExposedLoadAssetBundleSystem(World world, IStreamableCache<AssetBundleData, GetAssetBundleIntention> cache, IWebRequestController webRequestController)
+                : base(world, cache, webRequestController, ArrayPool<byte>.Shared, new AssetBundleLoadingMutex(), Substitute.For<IDiskCache<PartialLoadingState>>(), byteWeightedProgress: false) { }
+
+            public UniTask<StreamableLoadingResult<AssetBundleData>> FlowAsync(GetAssetBundleIntention intention, StreamableLoadingState state, IPartitionComponent partition, CancellationToken ct) =>
+                FlowInternalAsync(intention, state, partition, ct);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs
@@ -19,11 +19,8 @@ using UnityEngine.TestTools;
 namespace ECS.StreamableLoading.AssetBundles.Tests
 {
     /// <summary>
-    ///     Covers the recovery invariant for corrupt entries in Unity's built-in <see cref="Caching" />:
-    ///     a corrupt cached archive completes its web request successfully (cache hit, no network) yet
-    ///     yields a null bundle from the native mount ("Unable to open archive file"), and since nothing
-    ///     evicts the entry, the bundle stays broken for the user across sessions. The load flow must
-    ///     evict the entry and re-request once so the cache is re-populated with a whole archive.
+    ///     A corrupt entry in Unity's <see cref="Caching" /> mounts to a null bundle and is never evicted;
+    ///     the load flow must evict it and re-request once so the cache is re-populated with a whole archive.
     /// </summary>
     [TestFixture]
     public class CorruptAbCacheRecoveryShould
@@ -77,16 +74,13 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
 
             system = new ExposedLoadAssetBundleSystem(world, cache, IWebRequestController.TEST);
 
-            // Without the eviction retry this await faults with NullReferenceException: the corrupt entry is
-            // served from the cache, DownloadHandlerAssetBundle.GetContent returns null and no recovery exists,
-            // while the corrupt entry stays cached for every future attempt.
+            // Without the eviction retry this await faults with NullReferenceException (cache-served null bundle)
             StreamableLoadingResult<AssetBundleData> result = await system.FlowAsync(
                 NewWebIntention(bundleUrl, cacheHash), StreamableLoadingState.Create(), PartitionComponent.TOP_PRIORITY, CancellationToken.None);
 
             Assert.That(result.Succeeded, Is.True, result.Exception?.ToString());
             Assert.That(result.Asset, Is.Not.Null);
 
-            // The corrupt entry was evicted and re-downloaded: the cached archive is whole again
             Assert.That(Caching.IsVersionCached(bundleUrl, cacheHash), Is.True);
 
             byte[] repaired = File.ReadAllBytes(FindCachedDataFile());

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/EditModeTests/CorruptAbCacheRecoveryShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68a774edbf304f41bdc2a346e87cd9dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Common/Components/StreamableLoadingResult.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Common/Components/StreamableLoadingResult.cs
@@ -1,8 +1,6 @@
-﻿using AssetManagement;
-using DCL.Diagnostics;
+﻿using DCL.Diagnostics;
 using System;
 using UnityEngine;
-using System.Runtime.CompilerServices;
 
 namespace ECS.StreamableLoading.Common.Components
 {
@@ -25,14 +23,14 @@ namespace ECS.StreamableLoading.Common.Components
 
             /// <summary>
             ///     True when the request reached a terminal successful (or fallback-acceptable) state.
-            ///     False when the request failed or was cancelled; check <see cref="Cancelled"/>
-            ///     to distinguish a transient cancellation from a sticky failure.
+            ///     False when the request failed or was cancelled; the value describes that single
+            ///     attempt only.
             /// </summary>
             public readonly bool Succeeded;
 
             /// <summary>
-            ///     True when the request was cancelled mid-flight (transient state — consumers can
-            ///     clear the slot and retry). False for both genuine successes and sticky failures.
+            ///     True when the request was cancelled mid-flight. False for both genuine
+            ///     successes and failures (e.g. a consumer timeout).
             /// </summary>
             public readonly bool Cancelled;
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Common/Components/StreamableLoadingResult.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Common/Components/StreamableLoadingResult.cs
@@ -22,9 +22,8 @@ namespace ECS.StreamableLoading.Common.Components
             private readonly bool initialized;
 
             /// <summary>
-            ///     True when the request reached a terminal successful (or fallback-acceptable) state.
-            ///     False when the request failed or was cancelled; the value describes that single
-            ///     attempt only.
+            ///     True when the request reached a terminal successful (or fallback-acceptable) state;
+            ///     false when it failed or was cancelled. Describes that single attempt only.
             /// </summary>
             public readonly bool Succeeded;
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
@@ -128,7 +128,7 @@ namespace Global.Dynamic
             {
                 container.reportHandlingSettings = ProvideReportHandlingSettingsAsync(container.settings, applicationParametersParser);
 
-                container.DiagnosticsContainer = DiagnosticsContainer.Create(container.ReportHandlingSettings);
+                container.DiagnosticsContainer = DiagnosticsContainer.Create(container.ReportHandlingSettings, realmLaunchSettings.CurrentMode is DCL.Utility.LaunchMode.LocalSceneDevelopment);
                 container.DiagnosticsContainer.AddSentryScopeConfigurator(AddIdentityToSentryScope);
 
                 if (container.IdentityCache != null)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -31,6 +31,7 @@ using Unity.Mathematics;
 using UnityEngine;
 using DCL.UserInAppInitializationFlow.StartupOperations;
 using Utility;
+using Utility.Multithreading;
 
 namespace Global.Dynamic
 {
@@ -51,6 +52,7 @@ namespace Global.Dynamic
 
         private readonly List<ISceneFacade> allScenes = new (PoolConstants.SCENES_COUNT);
         private readonly ServerAbout serverAbout = new ();
+        private readonly DCLSemaphoreSlim realmChangeSemaphore = new ();
         private readonly IWebRequestController webRequestController;
         private readonly IReadOnlyList<int2> staticLoadPositions;
         private readonly RealmData realmData;
@@ -121,6 +123,17 @@ namespace Global.Dynamic
         }
 
         public async UniTask SetRealmAsync(URLDomain realm, CancellationToken ct)
+        {
+            // Realm changes must be mutually exclusive: each one relies on its unload phase leaving no
+            // realm entity alive, so that at most one realm entity (and one ProcessedScenePointers
+            // scene-pointer dedup pipeline) exists afterwards
+            await realmChangeSemaphore.WaitAsync(ct);
+
+            try { await SetRealmExclusiveAsync(realm, ct); }
+            finally { realmChangeSemaphore.Release(); }
+        }
+
+        private async UniTask SetRealmExclusiveAsync(URLDomain realm, CancellationToken ct)
         {
             World world = globalWorld!.EcsWorld;
 
@@ -197,12 +210,10 @@ namespace Global.Dynamic
 
         public async UniTask<List<SceneEntityDefinition>> WaitForFixedScenePromisesAsync(CancellationToken ct)
         {
-            FixedScenePointers fixedScenePointers = default;
-
-            await UniTask.WaitUntil(() => GlobalWorld.EcsWorld.TryGet(realmEntity, out fixedScenePointers)
+            await UniTask.WaitUntil(() => GlobalWorld.EcsWorld.TryGet(realmEntity, out FixedScenePointers fixedScenePointers)
                                           && fixedScenePointers.AllPromisesResolved, cancellationToken: ct);
 
-            return fixedScenePointers.SceneResults;
+            return GlobalWorld.EcsWorld.Get<FixedScenePointers>(realmEntity).SceneResults;
         }
 
         public async UniTask<SceneDefinitions?> WaitForStaticScenesEntityDefinitionsAsync(CancellationToken ct)
@@ -310,19 +321,19 @@ namespace Global.Dynamic
             return parsed;
         }
 
-        private void ComplimentWithVolatilePointers(World world, Entity realmEntity)
+        private void ComplimentWithVolatilePointers(World world, Entity targetRealmEntity)
         {
-            world.Add(realmEntity, VolatileScenePointers.Create(partitionComponentPool.Get()));
+            world.Add(targetRealmEntity, VolatileScenePointers.Create(partitionComponentPool.Get()));
         }
 
-        private bool ComplimentWithStaticPointers(World world, Entity realmEntity)
+        private bool ComplimentWithStaticPointers(World world, Entity targetRealmEntity)
         {
             IReadOnlyList<int2> positions = localSceneParcels.Count > 0 ? localSceneParcels : staticLoadPositions;
 
             if (positions is { Count: > 0 })
             {
                 // Static scene pointers don't replace the logic of fixed pointers loading but compliment it
-                world.Add(realmEntity, new StaticScenePointers(positions));
+                world.Add(targetRealmEntity, new StaticScenePointers(positions));
                 return true;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/RealmController.cs
@@ -124,9 +124,8 @@ namespace Global.Dynamic
 
         public async UniTask SetRealmAsync(URLDomain realm, CancellationToken ct)
         {
-            // Realm changes must be mutually exclusive: each one relies on its unload phase leaving no
-            // realm entity alive, so that at most one realm entity (and one ProcessedScenePointers
-            // scene-pointer dedup pipeline) exists afterwards
+            // Realm changes must be mutually exclusive: overlapping changes can leave more than one
+            // realm entity (and scene-pointer dedup pipeline) alive after the unload phase
             await realmChangeSemaphore.WaitAsync(ct);
 
             try { await SetRealmExclusiveAsync(realm, ct); }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/PlayMode/IntegrationTestsSuite.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/PlayMode/IntegrationTestsSuite.cs
@@ -74,7 +74,7 @@ namespace Global.Tests.PlayMode
             IReportsHandlingSettings? reportSettings = Substitute.For<IReportsHandlingSettings>();
             reportSettings.IsEnabled(ReportHandler.DebugLog).Returns(true);
 
-            var diagnosticsContainer = DiagnosticsContainer.Create(reportSettings);
+            var diagnosticsContainer = DiagnosticsContainer.Create(reportSettings, false);
 
             var world = World.Create();
             var cameraEntity = world.Create();

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -37,7 +37,12 @@ namespace MVC
         public void Dispose()
         {
             foreach (IController controllersValue in controllers.Values)
-                controllersValue.Dispose();
+            {
+                // One controller's failing Dispose must not abort disposal of the remaining
+                // controllers, the destruction CTS and the windows stack.
+                try { controllersValue.Dispose(); }
+                catch (Exception e) { ReportHub.LogException(e, ReportCategory.MVC); }
+            }
 
             destructionCancellationTokenSource.SafeCancelAndDispose();
             windowsStackManager.Dispose();

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Manager/MVCManager.cs
@@ -38,8 +38,7 @@ namespace MVC
         {
             foreach (IController controllersValue in controllers.Values)
             {
-                // One controller's failing Dispose must not abort disposal of the remaining
-                // controllers, the destruction CTS and the windows stack.
+                // One failing Dispose must not abort disposal of the remaining controllers and the windows stack
                 try { controllersValue.Dispose(); }
                 catch (Exception e) { ReportHub.LogException(e, ReportCategory.MVC); }
             }

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs
@@ -1,0 +1,52 @@
+using MVC.PopupsController.PopupCloser;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using UnityEngine.TestTools;
+
+namespace MVC.Tests
+{
+    [TestFixture]
+    public class MVCManagerDisposeShould
+    {
+        private IWindowsStackManager windowsStackManager = null!;
+        private MVCManager mvcManager = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            windowsStackManager = Substitute.For<IWindowsStackManager>();
+            mvcManager = new MVCManager(windowsStackManager, new CancellationTokenSource(), Substitute.For<IPopupCloserView>());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            LogAssert.ignoreFailingMessages = false;
+        }
+
+        [Test]
+        public void DisposeRemainingControllersAndStackWhenOneControllerThrows()
+        {
+            // The guarded disposal loop reports the throwing controller via ReportHub (error-level log).
+            LogAssert.ignoreFailingMessages = true;
+
+            IController<ITestView, TestInputData> throwingController = Substitute.For<IController<ITestView, TestInputData>>();
+            throwingController.When(c => c.Dispose()).Do(_ => throw new InvalidOperationException("dispose failure"));
+            IController<IOtherTestView, TestInputData> otherController = Substitute.For<IController<IOtherTestView, TestInputData>>();
+
+            mvcManager.RegisterController(throwingController);
+            mvcManager.RegisterController(otherController);
+
+            Assert.DoesNotThrow(mvcManager.Dispose);
+
+            // Order-independent: whichever controller is disposed first, both must be reached
+            // and the windows stack must be disposed after the loop.
+            otherController.Received(1).Dispose();
+            windowsStackManager.Received(1).Dispose();
+        }
+    }
+
+    public interface IOtherTestView : IView { }
+}

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs
@@ -41,8 +41,6 @@ namespace MVC.Tests
 
             Assert.DoesNotThrow(mvcManager.Dispose);
 
-            // Order-independent: whichever controller is disposed first, both must be reached
-            // and the windows stack must be disposed after the loop.
             otherController.Received(1).Dispose();
             windowsStackManager.Received(1).Dispose();
         }

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Tests/MVCManagerDisposeShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1019d41ca774ef9a96de237c26e737b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
@@ -12,7 +12,9 @@ using ECS.SceneLifeCycle.Reporting;
 using ECS.SceneLifeCycle.SceneDefinition;
 using SceneRunner.Scene;
 using System;
+using System.Collections.Generic;
 using System.Threading;
+using UnityEngine;
 using ScenePromise = ECS.StreamableLoading.Common.AssetPromise<SceneRunner.Scene.ISceneFacade, ECS.SceneLifeCycle.Components.GetSceneFacadeIntention>;
 using Utility.Multithreading;
 
@@ -54,7 +56,7 @@ namespace ECS.SceneLifeCycle.Systems
 
         protected override void Update(float t)
         {
-            ChangeSceneFPSQuery(World);
+            ChangeSceneFpsQuery(World);
             HandleNotCreatedScenesQuery(World);
             HandleSmartWearableScenesQuery(World);
         }
@@ -76,9 +78,28 @@ namespace ECS.SceneLifeCycle.Systems
             if (!promise.TryConsume(World, out var result) || !result.Succeeded) return;
 
             ISceneFacade scene = result.Asset!;
+
+            // At most one facade may own a parcel: a duplicate definition entity is left facade-less
+            // so its unload cannot remove the live scene's parcel mappings from the cache
+            if (!definitionComponent.IsPortableExperience && AnyParcelHasLiveScene(definitionComponent.Parcels))
+            {
+                ReportHub.LogWarning(GetReportData(), $"Duplicate scene definition for '{definitionComponent.Definition.GetLogSceneName()}': discarding its facade");
+                scene.DisposeAsync().Forget();
+                return;
+            }
+
             StartAndUpdateSceneAsync(definitionComponent, partition, scene).Forget();
 
             World.Add(entity, scene);
+        }
+
+        private bool AnyParcelHasLiveScene(IReadOnlyList<Vector2Int> parcels)
+        {
+            for (var i = 0; i < parcels.Count; i++)
+                if (scenesCache.TryGetByParcel(parcels[i], out _))
+                    return true;
+
+            return false;
         }
 
         [Query]
@@ -93,7 +114,7 @@ namespace ECS.SceneLifeCycle.Systems
 
         [Query]
         [None(typeof(DeleteEntityIntention))]
-        private void ChangeSceneFPS(ref ISceneFacade sceneFacade, in PartitionComponent partition)
+        private void ChangeSceneFps(ref ISceneFacade sceneFacade, in PartitionComponent partition)
         {
             if (!partition.IsDirty) return;
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Systems/ControlSceneUpdateLoopSystem.cs
@@ -3,6 +3,7 @@ using Arch.System;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
+using DCL.Utilities.Extensions;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
 using ECS.Prioritization;
@@ -80,11 +81,10 @@ namespace ECS.SceneLifeCycle.Systems
             ISceneFacade scene = result.Asset!;
 
             // At most one facade may own a parcel: a duplicate definition entity is left facade-less
-            // so its unload cannot remove the live scene's parcel mappings from the cache
             if (!definitionComponent.IsPortableExperience && AnyParcelHasLiveScene(definitionComponent.Parcels))
             {
                 ReportHub.LogWarning(GetReportData(), $"Duplicate scene definition for '{definitionComponent.Definition.GetLogSceneName()}': discarding its facade");
-                scene.DisposeAsync().Forget();
+                scene.DisposeAsync().SuppressToResultAsync(ReportCategory.SCENE_LOADING).Forget();
                 return;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/Tests/ControlSceneUpdateLoopSystemShould.cs
@@ -1,7 +1,9 @@
 ﻿using Arch.Core;
+using Cysharp.Threading.Tasks;
 using DCL.Ipfs;
 using DCL.Utilities;
 using ECS;
+using ECS.LifeCycle.Components;
 using ECS.Prioritization;
 using ECS.Prioritization.Components;
 using ECS.SceneLifeCycle;
@@ -62,7 +64,7 @@ namespace DCL.SceneLifeCycle.Tests
 
             Entity e = world.Create(promise, PartitionComponent.TOP_PRIORITY, sceneDefinitionComponent);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -72,7 +74,7 @@ namespace DCL.SceneLifeCycle.Tests
         }
 
         [Test]
-        public async Task StartSceneWithCorrectFPS()
+        public async Task StartSceneWithCorrectFps()
         {
             ISceneFacade scene = Substitute.For<ISceneFacade>();
 
@@ -93,7 +95,7 @@ namespace DCL.SceneLifeCycle.Tests
             Entity e = world.Create(promise, partition, sceneDefinitionComponent);
             realmPartitionSettings.GetSceneUpdateFrequency(in partition).Returns(15);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -107,7 +109,7 @@ namespace DCL.SceneLifeCycle.Tests
         {
             ISceneFacade scene = CreateWorldScenePendingStart(isRoomSettled: false, hasReadinessReport: true);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -120,7 +122,7 @@ namespace DCL.SceneLifeCycle.Tests
         {
             ISceneFacade scene = CreateWorldScenePendingStart(isRoomSettled: true, hasReadinessReport: true);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -133,7 +135,7 @@ namespace DCL.SceneLifeCycle.Tests
         {
             ISceneFacade scene = CreateWorldScenePendingStart(isRoomSettled: false, hasReadinessReport: false);
 
-            system?.Update(0f);
+            system.Update(0f);
 
             // let the system switch to the thread pool
             await Task.Delay(100);
@@ -142,7 +144,7 @@ namespace DCL.SceneLifeCycle.Tests
         }
 
         [Test]
-        public void ChangeSceneFPS()
+        public void ChangeSceneFps()
         {
             ISceneFacade scene = Substitute.For<ISceneFacade>();
 
@@ -151,9 +153,98 @@ namespace DCL.SceneLifeCycle.Tests
 
             world.Create(scene, partition, new SceneDefinitionComponent());
 
-            system?.Update(0f);
+            system.Update(0f);
 
             scene.Received(1).SetTargetFPS(15);
+        }
+
+        [Test]
+        public async Task DiscardDuplicateSceneForSameParcelsKeepingLiveFacade()
+        {
+            var scenesCache = new ScenesCache();
+
+            system = new ControlSceneUpdateLoopSystem(world, realmPartitionSettings, CancellationToken.None, scenesCache, sceneReadinessReportQueue,
+                realmData, sceneRoomStatus);
+
+            ISceneFacade scene1 = Substitute.For<ISceneFacade>();
+            ISceneFacade scene2 = Substitute.For<ISceneFacade>();
+
+            Entity e1 = CreateResolvedSceneEntity(scene1);
+            Entity e2 = CreateResolvedSceneEntity(scene2);
+
+            // a structural World.Add during query iteration can defer the sibling entity to the next update
+            system.Update(0f);
+            system.Update(0f);
+
+            // let the started scene switch to the thread pool
+            await Task.Delay(100);
+
+            // whichever entity was consumed first owns the parcel; the sibling must be discarded
+            bool firstEntityKept = world.Has<ISceneFacade>(e1);
+            (Entity discardedEntity, ISceneFacade keptScene, ISceneFacade discardedScene) = firstEntityKept ? (e2, scene1, scene2) : (e1, scene2, scene1);
+
+            Assert.That(world.Has<ISceneFacade>(discardedEntity), Is.False);
+
+            discardedScene.Received(1).DisposeAsync().Forget();
+            await discardedScene.DidNotReceive().StartUpdateLoopAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            keptScene.DidNotReceive().DisposeAsync().Forget();
+            await keptScene.Received(1).StartUpdateLoopAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            Assert.That(scenesCache.Scenes.Count, Is.EqualTo(1));
+            Assert.That(scenesCache.TryGetByParcel(Vector3.zero.ToParcel(), out ISceneFacade cached), Is.True);
+            Assert.That(cached, Is.SameAs(keptScene));
+        }
+
+        [Test]
+        public async Task KeepLiveSceneCacheMappingWhenDuplicateEntityUnloads()
+        {
+            var scenesCache = new ScenesCache();
+
+            system = new ControlSceneUpdateLoopSystem(world, realmPartitionSettings, CancellationToken.None, scenesCache, sceneReadinessReportQueue,
+                realmData, sceneRoomStatus);
+
+            ISceneFacade scene1 = Substitute.For<ISceneFacade>();
+            ISceneFacade scene2 = Substitute.For<ISceneFacade>();
+
+            Entity e1 = CreateResolvedSceneEntity(scene1);
+            Entity e2 = CreateResolvedSceneEntity(scene2);
+
+            // a structural World.Add during query iteration can defer the sibling entity to the next update
+            system.Update(0f);
+            system.Update(0f);
+
+            // let the started scene switch to the thread pool
+            await Task.Delay(100);
+
+            bool firstEntityKept = world.Has<ISceneFacade>(e1);
+            (Entity discardedEntity, ISceneFacade keptScene) = firstEntityKept ? (e2, scene1) : (e1, scene2);
+
+            var unloadSystem = new UnloadSceneSystem(world, scenesCache, false);
+            world.Add(discardedEntity, new DeleteEntityIntention());
+            unloadSystem.Update(0f);
+
+            Assert.That(scenesCache.TryGetByParcel(Vector3.zero.ToParcel(), out ISceneFacade cached), Is.True);
+            Assert.That(cached, Is.SameAs(keptScene));
+            Assert.That(scenesCache.Scenes.Count, Is.EqualTo(1));
+        }
+
+        private Entity CreateResolvedSceneEntity(ISceneFacade scene)
+        {
+            var promise = AssetPromise<ISceneFacade, GetSceneFacadeIntention>.Create(world, new GetSceneFacadeIntention(), PartitionComponent.TOP_PRIORITY);
+
+            SceneDefinitionComponent sceneDefinitionComponent = SceneDefinitionComponentFactory.CreateFromDefinition(new SceneEntityDefinition
+            {
+                metadata = new SceneMetadata
+                {
+                    scene = new SceneMetadataScene
+                        { DecodedParcels = new[] { Vector3.zero.ToParcel() } },
+                },
+            }, new IpfsPath());
+
+            world.Add(promise.Entity, new StreamableLoadingResult<ISceneFacade>(scene));
+
+            return world.Create(promise, PartitionComponent.TOP_PRIORITY, sceneDefinitionComponent);
         }
 
         private ISceneFacade CreateWorldScenePendingStart(bool isRoomSettled, bool hasReadinessReport)

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
@@ -8,6 +8,7 @@ using SceneRunner.Scene;
 using SceneRunner.Scene.ExceptionsHandling;
 using System;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -40,6 +41,14 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         private readonly DCLConcurrentDictionary<string, DCLConcurrentQueue<BufferedDataMessage>> topicBuffers = new ();
         private readonly DCLConcurrentDictionary<string, (int count, int windowStartMs)> publishRateLimiters = new ();
 
+        private readonly object topicLookupLock = new ();
+
+        // Copy-on-write byte-keyed snapshot of topicBuffers (queues shared, not copied) so OnDataReceived
+        // can match the wire topic without allocating a string per message (Unity's BCL has no span-keyed
+        // dictionary lookup). Writers rebuild under topicLookupLock; the volatile publish guarantees the
+        // LiveKit-thread reader a complete snapshot, never a partial one.
+        private volatile TopicLookupEntry[] topicLookup = Array.Empty<TopicLookupEntry>();
+
         public CommsApiWrap(
             IRoomHub roomHub,
             ISceneCommunicationPipe sceneCommunicationPipe,
@@ -60,6 +69,12 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         {
             sceneCommunicationPipe.RemoveSceneMessageHandler(sceneId, ISceneCommunicationPipe.MsgType.CommsData, onDataReceivedCached);
             topicBuffers.Clear();
+
+            lock (topicLookupLock)
+            {
+                topicLookup = Array.Empty<TopicLookupEntry>();
+            }
+
             publishRateLimiters.Clear();
             commsWriter.Dispose();
         }
@@ -128,7 +143,7 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         /// Called from JS via ClearScript. Rate-limited to <see cref="MAX_MESSAGES_PER_SECOND"/> per topic.
         /// </summary>
         [UsedImplicitly]
-        public void PublishData(string topic, string data)
+        public void PublishData(string topic, string? data)
         {
             try
             {
@@ -191,7 +206,8 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         public void SubscribeToTopic(string topic)
         {
             // method is called relatively rare, allocation new Queue is acceptable, pooling not required
-            topicBuffers.TryAdd(topic, new DCLConcurrentQueue<BufferedDataMessage>());
+            if (topicBuffers.TryAdd(topic, new DCLConcurrentQueue<BufferedDataMessage>()))
+                RebuildTopicLookup();
         }
 
         /// <summary>
@@ -201,8 +217,10 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         [UsedImplicitly]
         public void UnsubscribeFromTopic(string topic)
         {
-            topicBuffers.TryRemove(topic, out DCLConcurrentQueue<BufferedDataMessage> _output);
-            // 'output' object is droped and will be collected by GC (it's assumed nothing else holds the reference)
+            if (topicBuffers.TryRemove(topic, out _))
+                RebuildTopicLookup();
+
+            // the removed queue is dropped and will be collected by GC (it's assumed nothing else holds the reference)
         }
 
         /// <summary>
@@ -247,14 +265,12 @@ namespace SceneRuntime.Apis.Modules.CommsApi
         }
 
         /// <summary>
-        /// Runs on the LiveKit callback thread (ORIGIN_THREAD), not the main thread.
-        /// Only thread-safe types (DCLConcurrentQueue, Encoding) are used here.
+        /// Runs on the LiveKit callback thread (ORIGIN_THREAD) for all scene CommsData traffic;
+        /// must not allocate for messages on unsubscribed topics.
         /// Decodes wire format: [topicLen 2 bytes LE][topic UTF-8][data UTF-8].
         /// </summary>
         private void OnDataReceived(ISceneCommunicationPipe.DecodedMessage message)
         {
-            // TODO: implement GetAlternateLookup on ReadOnlySpan<char/byte> to avoid allocation of temp string instances
-            // Reference: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.getalternatelookup
             ReadOnlySpan<byte> span = message.Data;
 
             if (span.Length < TOPIC_LENGTH_PREFIX_BYTES) return;
@@ -263,10 +279,18 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
             if (span.Length < TOPIC_LENGTH_PREFIX_BYTES + topicLength) return;
 
-            string topic = Encoding.UTF8.GetString(span.Slice(TOPIC_LENGTH_PREFIX_BYTES, topicLength));
+            ReadOnlySpan<byte> topicSpan = span.Slice(TOPIC_LENGTH_PREFIX_BYTES, topicLength);
 
-            if (topicBuffers.TryGetValue(topic, out DCLConcurrentQueue<BufferedDataMessage> queue))
+            // Scenes subscribe to a handful of topics; a linear scan avoids the string key a hash lookup would need.
+            TopicLookupEntry[] lookup = topicLookup;
+
+            for (var i = 0; i < lookup.Length; i++)
             {
+                if (!topicSpan.SequenceEqual(lookup[i].Utf8Topic))
+                    continue;
+
+                DCLConcurrentQueue<BufferedDataMessage> queue = lookup[i].Queue;
+
                 // DROP OLD POLICY. Dequeues oldest item to insert new one
                 if (queue.Count >= TOPIC_BUFFER_MAX_MESSAGE_COUNT)
                 {
@@ -275,6 +299,23 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
                 string data = Encoding.UTF8.GetString(span[(TOPIC_LENGTH_PREFIX_BYTES + topicLength)..]);
                 queue.Enqueue(new BufferedDataMessage(message.FromWalletId, data));
+                return;
+            }
+        }
+
+        private void RebuildTopicLookup()
+        {
+            // Allocates freely (list, byte[] per topic, final array): it only runs on subscribe/unsubscribe,
+            // which happens a handful of times per scene lifetime. COW trades allocation on this rare write
+            // path for allocation-free reads in OnDataReceived; published arrays are never mutated or reused.
+            lock (topicLookupLock)
+            {
+                var entries = new List<TopicLookupEntry>(topicBuffers.Count);
+
+                foreach ((string topic, DCLConcurrentQueue<BufferedDataMessage> queue) in topicBuffers)
+                    entries.Add(new TopicLookupEntry(Encoding.UTF8.GetBytes(topic), queue));
+
+                topicLookup = entries.ToArray();
             }
         }
 
@@ -301,6 +342,18 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
             publishRateLimiters[topic] = (limiter.count + 1, limiter.windowStartMs);
             return true;
+        }
+
+        private readonly struct TopicLookupEntry
+        {
+            public readonly byte[] Utf8Topic;
+            public readonly DCLConcurrentQueue<BufferedDataMessage> Queue;
+
+            public TopicLookupEntry(byte[] utf8Topic, DCLConcurrentQueue<BufferedDataMessage> queue)
+            {
+                Utf8Topic = utf8Topic;
+                Queue = queue;
+            }
         }
 
         private readonly struct BufferedDataMessage

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/CommsApi/CommsApiWrap.cs
@@ -43,10 +43,8 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
         private readonly object topicLookupLock = new ();
 
-        // Copy-on-write byte-keyed snapshot of topicBuffers (queues shared, not copied) so OnDataReceived
-        // can match the wire topic without allocating a string per message (Unity's BCL has no span-keyed
-        // dictionary lookup). Writers rebuild under topicLookupLock; the volatile publish guarantees the
-        // LiveKit-thread reader a complete snapshot, never a partial one.
+        // Copy-on-write byte-keyed snapshot of topicBuffers so OnDataReceived can match the wire topic
+        // without allocating a string per message; the volatile publish gives readers a complete snapshot.
         private volatile TopicLookupEntry[] topicLookup = Array.Empty<TopicLookupEntry>();
 
         public CommsApiWrap(
@@ -305,9 +303,7 @@ namespace SceneRuntime.Apis.Modules.CommsApi
 
         private void RebuildTopicLookup()
         {
-            // Allocates freely (list, byte[] per topic, final array): it only runs on subscribe/unsubscribe,
-            // which happens a handful of times per scene lifetime. COW trades allocation on this rare write
-            // path for allocation-free reads in OnDataReceived; published arrays are never mutated or reused.
+            // Runs only on subscribe/unsubscribe (rare), so allocating here is fine; published arrays are never mutated.
             lock (topicLookupLock)
             {
                 var entries = new List<TopicLookupEntry>(topicBuffers.Count);

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
@@ -174,6 +174,9 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                 method ?? string.Empty
             );
 
+            // Read before the main-thread hop: disposeCts can be disposed while the request is still hopping
+            CancellationToken token = disposeCts.Token;
+
             async UniTask<FlatFetchResponse> ExecuteRequestAsync()
             {
                 await UniTask.SwitchToMainThread();
@@ -190,7 +193,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                                 new FlatFetchResponse<GenericPostRequest>(),
                                 signatureMetadata,
                                 GetReportData(),
-                                disposeCts.Token);
+                                token);
 
                             break;
                         case "post":
@@ -198,7 +201,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                                 request.url,
                                 new FlatFetchResponse<GenericPostRequest>(),
                                 GenericPostArguments.CreateJsonOrDefault(request.init?.body),
-                                disposeCts.Token,
+                                token,
                                 headersInfo: headers,
                                 signInfo: signInfo,
                                 reportCategory: GetReportData());
@@ -208,7 +211,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                             response = await webController.GetAsync<FlatFetchResponse<GenericGetRequest>, FlatFetchResponse>(
                                 request.url,
                                 new FlatFetchResponse<GenericGetRequest>(),
-                                disposeCts.Token,
+                                token,
                                 headersInfo: headers,
                                 signInfo: signInfo,
                                 reportData: GetReportData());
@@ -219,7 +222,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                                 request.url,
                                 new FlatFetchResponse<GenericPutRequest>(),
                                 GenericPostArguments.CreateJsonOrDefault(request.init?.body),
-                                disposeCts.Token,
+                                token,
                                 headersInfo: headers,
                                 signInfo: signInfo,
                                 reportCategory: GetReportData());
@@ -230,7 +233,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                                 request.url,
                                 new FlatFetchResponse<GenericDeleteRequest>(),
                                 GenericPostArguments.CreateJsonOrDefault(request.init?.body),
-                                disposeCts.Token,
+                                token,
                                 headersInfo: headers,
                                 signInfo: signInfo,
                                 reportCategory: GetReportData());

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/Tests/SignedFetchWrapShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/Tests/SignedFetchWrapShould.cs
@@ -13,14 +13,21 @@ using NUnit.Framework;
 using SceneRuntime.Apis.Modules.SignedFetch.Messages;
 using SceneRunner.Scene;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace SceneRuntime.Apis.Modules.SignedFetch.Tests
 {
     public class SignedFetchWrapShould
     {
+        /// <summary>
+        ///     Player loop ticks granted to a dispatched request to resume after the main thread is released.
+        /// </summary>
+        private const int MAX_CONTINUATION_TICKS = 10;
+
         private IWebRequestController webController;
         private ISceneData sceneData;
         private IRealmData realmData;
@@ -189,7 +196,63 @@ namespace SceneRuntime.Apis.Modules.SignedFetch.Tests
             DoAssertions(metadata);
         }
 
+        /// <summary>
+        ///     Regression: reading <c>disposeCts.Token</c> after the main-thread hop raced runtime disposal and dropped the request.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator DispatchRequestWithTokenCapturedBeforeMainThreadHop()
+        {
+            // Arrange
+            string url = "https://example.com/api";
+            string body = "";
+            string headers = "{}";
+            string method = "get";
 
+            CancellationToken tokenBeforeDisposal = disposeCts.Token;
+            CancellationToken dispatchedToken = default;
+            var dispatched = false;
+
+            webController.RequestHub.Returns(Substitute.For<IRequestHub>());
+
+            webController.When(controller =>
+                            controller.SendAsync<GenericGetRequest, GenericGetArguments, FlatFetchResponse<GenericGetRequest>, FlatFetchResponse>(
+                                Arg.Any<RequestEnvelope<GenericGetRequest, GenericGetArguments>>(),
+                                Arg.Any<FlatFetchResponse<GenericGetRequest>>(),
+                                Arg.Any<long>(),
+                                Arg.Any<IProgress<float>>()))
+                         .Do(callInfo =>
+                          {
+                              dispatchedToken = callInfo.Arg<RequestEnvelope<GenericGetRequest, GenericGetArguments>>().Ct;
+                              dispatched = true;
+                          });
+
+            Exception? dispatchFailure = null;
+
+            // Join() parks the main thread for the whole dispatch, so disposal always lands before the hop resumes
+            var sceneThread = new Thread(() =>
+            {
+                try { signedFetchWrap.SignedFetch(url, body, headers, method); }
+                catch (ArgumentNullException)
+                {
+                    // No script engine in EditMode to build the returned promise; the request is already dispatched by then
+                }
+                catch (Exception e) { dispatchFailure = e; }
+
+                disposeCts.Dispose();
+            });
+
+            // Act
+            sceneThread.Start();
+            sceneThread.Join();
+
+            for (var i = 0; i < MAX_CONTINUATION_TICKS && !dispatched; i++)
+                yield return null;
+
+            // Assert
+            Assert.IsNull(dispatchFailure, $"Dispatching the request threw {dispatchFailure}");
+            Assert.IsTrue(dispatched, "The request never reached the web request controller.");
+            Assert.AreEqual(tokenBeforeDisposal, dispatchedToken, "The request must carry the token read before the source was disposed.");
+        }
     }
 }
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/Tests/SignedFetchWrapShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/Tests/SignedFetchWrapShould.cs
@@ -202,7 +202,6 @@ namespace SceneRuntime.Apis.Modules.SignedFetch.Tests
         [UnityTest]
         public IEnumerator DispatchRequestWithTokenCapturedBeforeMainThreadHop()
         {
-            // Arrange
             string url = "https://example.com/api";
             string body = "";
             string headers = "{}";
@@ -241,14 +240,12 @@ namespace SceneRuntime.Apis.Modules.SignedFetch.Tests
                 disposeCts.Dispose();
             });
 
-            // Act
             sceneThread.Start();
             sceneThread.Join();
 
             for (var i = 0; i < MAX_CONTINUATION_TICKS && !dispatched; i++)
                 yield return null;
 
-            // Assert
             Assert.IsNull(dispatchFailure, $"Dispatching the request threw {dispatchFailure}");
             Assert.IsTrue(dispatched, "The request never reached the web request controller.");
             Assert.AreEqual(tokenBeforeDisposal, dispatchedToken, "The request must carry the token read before the source was disposed.");

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/SceneRuntimeImpl.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/SceneRuntimeImpl.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using UnityEngine.Assertions;
+using Utility.Multithreading;
 
 namespace SceneRuntime
 {
@@ -29,6 +30,7 @@ namespace SceneRuntime
         private readonly JSTaskResolverResetable resetableSource;
 
         private readonly CancellationTokenSource isDisposingTokenSource = new ();
+        private readonly InterlockedFlag isDisposing = new ();
         private int nextUint8Array;
 
         private ScriptObject updateFunc;
@@ -132,8 +134,14 @@ namespace SceneRuntime
             jsApiBunch.AddHostObject(itemName, target);
         }
 
+        /// <remarks>
+        ///     Entered concurrently from more than one thread, so the single-entry guard is atomic.
+        /// </remarks>
         public void SetIsDisposing()
         {
+            if (!isDisposing.Set())
+                return;
+
             isDisposingTokenSource.Cancel();
             isDisposingTokenSource.Dispose();
         }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/CommsApiWrapShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/CommsApiWrapShould.cs
@@ -5,12 +5,12 @@ using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Scene;
 using SceneRunner.Scene.ExceptionsHandling;
-using SceneRuntime;
 using SceneRuntime.Apis.Modules.CommsApi;
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using UnityEngine.Profiling;
 
 namespace SceneRuntime.Tests
 {
@@ -18,11 +18,11 @@ namespace SceneRuntime.Tests
     {
         private const string TEST_SCENE_ID = "test-scene-123";
 
-        private CommsApiWrap commsApi;
-        private TestSceneCommunicationPipe pipe;
-        private IRoomHub roomHub;
-        private ISceneExceptionsHandler exceptionsHandler;
-        private CancellationTokenSource cts;
+        private CommsApiWrap commsApi = null!;
+        private TestSceneCommunicationPipe pipe = null!;
+        private IRoomHub roomHub = null!;
+        private ISceneExceptionsHandler exceptionsHandler = null!;
+        private CancellationTokenSource cts = null!;
 
         [SetUp]
         public void SetUp()
@@ -52,7 +52,7 @@ namespace SceneRuntime.Tests
             //Assert
             Assert.AreEqual(TEST_SCENE_ID, pipe.registeredSceneId);
             Assert.AreEqual(ISceneCommunicationPipe.MsgType.CommsData, pipe.registeredMsgType);
-            Assert.IsNotNull(pipe.onSceneMessage);
+            Assert.IsNotNull(pipe.sceneMessageHandler);
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace SceneRuntime.Tests
 
             // Simulate receive: SceneCommunicationPipe.DecodeMessage strips byte[0] (MsgType).
             ReadOnlySpan<byte> afterMsgType = wireBytes.AsSpan(1);
-            pipe.onSceneMessage.Invoke(new ISceneCommunicationPipe.DecodedMessage(afterMsgType, senderIdentity, isTrustedSource: true));
+            pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(afterMsgType, senderIdentity, isTrustedSource: true));
 
             //Assert — ConsumeMessages returns JSON; inner data string is JSON-escaped by JsonTextWriter.
             string json = commsApi.ConsumeMessages(topic);
@@ -173,6 +173,78 @@ namespace SceneRuntime.Tests
 
             //Assert
             Assert.AreEqual("[]", result, "Messages before subscription should be dropped.");
+        }
+
+        [Test]
+        public void ReceiveForUnsubscribedTopicDoesNotAllocate()
+        {
+            // GC.GetAllocatedBytesForCurrentThread is inert on the editor Mono runtime, and the
+            // strict AllocatingGCMemory constraint trips on runtime noise outside OnDataReceived —
+            // so this uses the budgeted GC.Alloc Recorder idiom with a liveness canary: the bug
+            // allocates at least one sample per message, the budget stays far under one per message.
+            const int MEASURED_INVOKES = 1000;
+            const int CANARY_ALLOCS = 16;
+            const int ALLOC_SAMPLE_BUDGET = 100;
+
+            //Arrange — capture real wire bytes via PublishData (round-trip pattern); topic is never subscribed.
+            commsApi.PublishData("never-subscribed-topic", "{\"type\":\"noise\"}");
+            Assert.AreEqual(1, pipe.sendMessageCalls.Count);
+            byte[] wireBytes = pipe.sendMessageCalls[0];
+
+            // SceneCommunicationPipe.DecodeMessage strips byte[0] (MsgType) before the handler sees it.
+            // DecodedMessage is a ref struct, so the span is rebuilt per call instead of captured.
+            // Warm-up: JIT the receive path outside the measured region.
+            for (var i = 0; i < 64; i++)
+                pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(wireBytes.AsSpan(1), "0xSENDER", isTrustedSource: true));
+
+            Recorder gcAllocRecorder = Recorder.Get("GC.Alloc");
+            gcAllocRecorder.FilterToCurrentThread();
+            gcAllocRecorder.enabled = false;
+            gcAllocRecorder.enabled = true;
+
+            //Act
+            for (var i = 0; i < MEASURED_INVOKES; i++)
+                pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(wireBytes.AsSpan(1), "0xSENDER", isTrustedSource: true));
+
+            byte[]? canary = null;
+
+            for (var i = 0; i < CANARY_ALLOCS; i++)
+                canary = new byte[16];
+
+            gcAllocRecorder.enabled = false;
+            int measured = gcAllocRecorder.sampleBlockCount;
+            GC.KeepAlive(canary);
+
+            Assert.GreaterOrEqual(measured, CANARY_ALLOCS,
+                "GC.Alloc recorder did not observe the deliberate canary allocations — the probe is inert on this runtime.");
+
+            //Assert — OnDataReceived runs on the LiveKit callback thread for ALL scene CommsData
+            // traffic; the unsubscribed-topic path must not allocate (e.g. a temp topic string).
+            Assert.Less(measured, ALLOC_SAMPLE_BUDGET,
+                $"OnDataReceived allocated GC memory for messages on a topic that was never subscribed ({measured} GC.Alloc samples over {MEASURED_INVOKES} messages).");
+        }
+
+        [Test]
+        public void ResubscribeAfterUnsubscribeReceivesAgain()
+        {
+            //Arrange
+            const string TOPIC = "flip-flop";
+
+            commsApi.SubscribeToTopic(TOPIC);
+            SimulateIncomingMessage(TOPIC, "{\"v\":1}", "sender1");
+
+            //Act — unsubscribe drops both the buffer and delivery; resubscribe restores delivery.
+            commsApi.UnsubscribeFromTopic(TOPIC);
+            SimulateIncomingMessage(TOPIC, "{\"v\":2}", "sender2");
+            commsApi.SubscribeToTopic(TOPIC);
+            SimulateIncomingMessage(TOPIC, "{\"v\":3}", "sender3");
+
+            string json = commsApi.ConsumeMessages(TOPIC);
+
+            //Assert — only the post-resubscribe message survives.
+            Assert.That(json, Does.Not.Contain("sender1"));
+            Assert.That(json, Does.Not.Contain("sender2"));
+            Assert.That(json, Does.Contain("sender3"));
         }
 
         [Test]
@@ -248,7 +320,7 @@ namespace SceneRuntime.Tests
             System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(encoded, (ushort)topicBytes.Length);
             topicBytes.CopyTo(encoded, 2);
             dataBytes.CopyTo(encoded, 2 + topicBytes.Length);
-            pipe.onSceneMessage.Invoke(new ISceneCommunicationPipe.DecodedMessage(encoded, senderIdentity, isTrustedSource: true));
+            pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(encoded, senderIdentity, isTrustedSource: true));
         }
 
         /// <summary>
@@ -258,8 +330,8 @@ namespace SceneRuntime.Tests
         private class TestSceneCommunicationPipe : ISceneCommunicationPipe
         {
             internal readonly List<byte[]> sendMessageCalls = new ();
-            internal ISceneCommunicationPipe.SceneMessageHandler onSceneMessage;
-            internal string registeredSceneId;
+            internal ISceneCommunicationPipe.SceneMessageHandler sceneMessageHandler = null!;
+            internal string registeredSceneId = null!;
             internal ISceneCommunicationPipe.MsgType registeredMsgType;
             internal bool handlerRemoved;
 
@@ -267,7 +339,7 @@ namespace SceneRuntime.Tests
             {
                 registeredSceneId = sceneId;
                 registeredMsgType = msgType;
-                this.onSceneMessage = onSceneMessage;
+                sceneMessageHandler = onSceneMessage;
             }
 
             public void RemoveSceneMessageHandler(string sceneId, ISceneCommunicationPipe.MsgType msgType, ISceneCommunicationPipe.SceneMessageHandler onSceneMessage)
@@ -275,7 +347,7 @@ namespace SceneRuntime.Tests
                 handlerRemoved = true;
             }
 
-            public void SendMessage(ReadOnlySpan<byte> message, string sceneId, ISceneCommunicationPipe.ConnectivityAssertiveness assertiveness, CancellationToken ct, string specialRecipient = null)
+            public void SendMessage(ReadOnlySpan<byte> message, string sceneId, ISceneCommunicationPipe.ConnectivityAssertiveness assertiveness, CancellationToken ct, string? specialRecipient = null)
             {
                 sendMessageCalls.Add(message.ToArray());
             }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/CommsApiWrapShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/CommsApiWrapShould.cs
@@ -178,21 +178,18 @@ namespace SceneRuntime.Tests
         [Test]
         public void ReceiveForUnsubscribedTopicDoesNotAllocate()
         {
-            // GC.GetAllocatedBytesForCurrentThread is inert on the editor Mono runtime, and the
-            // strict AllocatingGCMemory constraint trips on runtime noise outside OnDataReceived —
-            // so this uses the budgeted GC.Alloc Recorder idiom with a liveness canary: the bug
-            // allocates at least one sample per message, the budget stays far under one per message.
+            // Budgeted GC.Alloc Recorder with a liveness canary: GetAllocatedBytesForCurrentThread is inert
+            // on editor Mono, and the strict AllocatingGCMemory constraint trips on noise outside OnDataReceived.
             const int MEASURED_INVOKES = 1000;
             const int CANARY_ALLOCS = 16;
             const int ALLOC_SAMPLE_BUDGET = 100;
 
-            //Arrange — capture real wire bytes via PublishData (round-trip pattern); topic is never subscribed.
+            // Capture real wire bytes via a PublishData round-trip; the topic is never subscribed.
             commsApi.PublishData("never-subscribed-topic", "{\"type\":\"noise\"}");
             Assert.AreEqual(1, pipe.sendMessageCalls.Count);
             byte[] wireBytes = pipe.sendMessageCalls[0];
 
-            // SceneCommunicationPipe.DecodeMessage strips byte[0] (MsgType) before the handler sees it.
-            // DecodedMessage is a ref struct, so the span is rebuilt per call instead of captured.
+            // AsSpan(1) skips the MsgType byte that SceneCommunicationPipe.DecodeMessage strips.
             // Warm-up: JIT the receive path outside the measured region.
             for (var i = 0; i < 64; i++)
                 pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(wireBytes.AsSpan(1), "0xSENDER", isTrustedSource: true));
@@ -202,7 +199,6 @@ namespace SceneRuntime.Tests
             gcAllocRecorder.enabled = false;
             gcAllocRecorder.enabled = true;
 
-            //Act
             for (var i = 0; i < MEASURED_INVOKES; i++)
                 pipe.sceneMessageHandler.Invoke(new ISceneCommunicationPipe.DecodedMessage(wireBytes.AsSpan(1), "0xSENDER", isTrustedSource: true));
 
@@ -218,8 +214,6 @@ namespace SceneRuntime.Tests
             Assert.GreaterOrEqual(measured, CANARY_ALLOCS,
                 "GC.Alloc recorder did not observe the deliberate canary allocations — the probe is inert on this runtime.");
 
-            //Assert — OnDataReceived runs on the LiveKit callback thread for ALL scene CommsData
-            // traffic; the unsubscribed-topic path must not allocate (e.g. a temp topic string).
             Assert.Less(measured, ALLOC_SAMPLE_BUDGET,
                 $"OnDataReceived allocated GC memory for messages on a topic that was never subscribed ({measured} GC.Alloc samples over {MEASURED_INVOKES} messages).");
         }
@@ -227,13 +221,11 @@ namespace SceneRuntime.Tests
         [Test]
         public void ResubscribeAfterUnsubscribeReceivesAgain()
         {
-            //Arrange
             const string TOPIC = "flip-flop";
 
             commsApi.SubscribeToTopic(TOPIC);
             SimulateIncomingMessage(TOPIC, "{\"v\":1}", "sender1");
 
-            //Act — unsubscribe drops both the buffer and delivery; resubscribe restores delivery.
             commsApi.UnsubscribeFromTopic(TOPIC);
             SimulateIncomingMessage(TOPIC, "{\"v\":2}", "sender2");
             commsApi.SubscribeToTopic(TOPIC);
@@ -241,7 +233,6 @@ namespace SceneRuntime.Tests
 
             string json = commsApi.ConsumeMessages(TOPIC);
 
-            //Assert — only the post-resubscribe message survives.
             Assert.That(json, Does.Not.Contain("sender1"));
             Assert.That(json, Does.Not.Contain("sender2"));
             Assert.That(json, Does.Contain("sender3"));

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/SceneRuntimeShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/SceneRuntimeShould.cs
@@ -167,6 +167,24 @@ namespace SceneRuntime.Tests
                 }
             });
 
+        // Regression (Sentry UNITY-EXPLORER-NQG): a racing double dispose cancelled an already-disposed CTS
+        [UnityTest]
+        public IEnumerator NotThrowOnSecondSetIsDisposing() =>
+            UniTask.ToCoroutine(async () =>
+            {
+                var code = @"
+            exports.onStart = async function() {};
+            exports.onUpdate = async function(dt) {};
+        ";
+
+                var sceneRuntimeFactory = NewSceneRuntimeFactory();
+                SceneRuntimeImpl sceneRuntime = await sceneRuntimeFactory.CreateBySourceCodeAsync(code, poolsProvider, new SceneShortInfo(), CancellationToken.None);
+
+                sceneRuntime.SetIsDisposing();
+
+                Assert.DoesNotThrow(() => sceneRuntime.SetIsDisposing());
+            });
+
         public class TestUtilCheckOk
         {
             private bool value;

--- a/Explorer/Assets/DCL/Infrastructure/Utility/EventBus/EventBus.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/EventBus/EventBus.cs
@@ -1,6 +1,8 @@
 using Cysharp.Threading.Tasks;
+using DCL.Diagnostics;
 using System;
 using System.Collections.Generic;
+using Utility.Multithreading;
 
 namespace Utility
 {
@@ -28,9 +30,7 @@ namespace Utility
                 var typedDelegate = (Action<T>)del;
 
                 if (invokeSubscribersOnMainThread && !PlayerLoopHelper.IsMainThread)
-
-                    // TODO find a way to prevent an allocation from capture
-                    PlayerLoopHelper.AddContinuation(PlayerLoopTiming.Update, () => typedDelegate?.Invoke(evt));
+                    PooledContinuation<T>.Schedule(typedDelegate, evt);
                 else
                     typedDelegate?.Invoke(evt);
             }
@@ -44,6 +44,56 @@ namespace Utility
                 handler
             );
             return new Unsubscriber<T>(this, handler);
+        }
+
+        /// <summary>
+        ///     Carries the delegate snapshot and event payload across the main-thread hop without a
+        ///     compiler-synthesized closure; entries are pooled so steady-state publishes allocate nothing.
+        ///     State is copied to locals and the entry recycled before the handlers run, so reentrant
+        ///     publishes are safe and class-typed payloads are not retained by the pool.
+        ///     The pool is a <see cref="DCLConcurrentQueue{T}" /> because Schedule takes entries
+        ///     from it on background threads while Run recycles them on the main thread.
+        /// </summary>
+        private sealed class PooledContinuation<T>
+        {
+            private static readonly DCLConcurrentQueue<PooledContinuation<T>> POOL = new ();
+
+            private readonly Action run;
+            private Action<T>? typedDelegate;
+            private T evt = default!;
+
+            private PooledContinuation()
+            {
+                run = Run;
+            }
+
+            public static void Schedule(Action<T> typedDelegate, T evt)
+            {
+                if (!POOL.TryDequeue(out PooledContinuation<T>? continuation))
+                    continuation = new PooledContinuation<T>();
+
+                continuation.typedDelegate = typedDelegate;
+                continuation.evt = evt;
+                PlayerLoopHelper.AddContinuation(PlayerLoopTiming.Update, continuation.run);
+            }
+
+            private void Run()
+            {
+                // Reachable only if the player loop ran the same continuation twice; recycling the
+                // entry on that path would double-enqueue it into the pool and corrupt it.
+                if (typedDelegate is not { } invokeTarget)
+                {
+                    ReportHub.LogError(ReportCategory.UNSPECIFIED, "EventBus pooled continuation ran without a stamped delegate: exactly-once scheduling was violated and an event was dropped");
+                    return;
+                }
+
+                T payload = evt;
+                typedDelegate = null;
+                evt = default!;
+                POOL.Enqueue(this);
+
+                invokeTarget.Invoke(payload);
+            }
         }
 
         private class Unsubscriber<T> : IDisposable

--- a/Explorer/Assets/DCL/Infrastructure/Utility/EventBus/EventBus.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/EventBus/EventBus.cs
@@ -47,12 +47,8 @@ namespace Utility
         }
 
         /// <summary>
-        ///     Carries the delegate snapshot and event payload across the main-thread hop without a
-        ///     compiler-synthesized closure; entries are pooled so steady-state publishes allocate nothing.
-        ///     State is copied to locals and the entry recycled before the handlers run, so reentrant
-        ///     publishes are safe and class-typed payloads are not retained by the pool.
-        ///     The pool is a <see cref="DCLConcurrentQueue{T}" /> because Schedule takes entries
-        ///     from it on background threads while Run recycles them on the main thread.
+        ///     Pooled, closure-free carrier for the main-thread hop. State is copied to locals and the
+        ///     entry recycled before handlers run, so reentrant publishes are safe and payloads are not retained.
         /// </summary>
         private sealed class PooledContinuation<T>
         {
@@ -60,6 +56,7 @@ namespace Utility
 
             private readonly Action run;
             private Action<T>? typedDelegate;
+            // Stamped by Schedule() before Run() reads it; default! suppresses the unconstrained-T nullable warning
             private T evt = default!;
 
             private PooledContinuation()
@@ -79,8 +76,7 @@ namespace Utility
 
             private void Run()
             {
-                // Reachable only if the player loop ran the same continuation twice; recycling the
-                // entry on that path would double-enqueue it into the pool and corrupt it.
+                // Reachable only if the player loop ran the same continuation twice; recycling here would double-enqueue the entry.
                 if (typedDelegate is not { } invokeTarget)
                 {
                     ReportHub.LogError(ReportCategory.UNSPECIFIED, "EventBus pooled continuation ran without a stamped delegate: exactly-once scheduling was violated and an event was dropped");

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
@@ -5,9 +5,8 @@ using Cysharp.Threading.Tasks;
 namespace Utility.Networking
 {
     /// <summary>
-    ///     Desktop / WebGL friendly implementation. CloseAsync, Abort and Dispose may run on a
-    ///     different thread than a pending ConnectAsync await; failing a pending connection
-    ///     completes that await instead of leaving it parked.
+    ///     Desktop / WebGL friendly implementation. Failing a pending connection (CloseAsync, Abort,
+    ///     Dispose, from any thread) completes the pending ConnectAsync await instead of leaving it parked.
     /// </summary>
     public class DCLWebSocket : IDisposable
     {
@@ -93,7 +92,7 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 await ws.ConnectAsync(uri, cancellationToken);
 #else
-                // Main-thread callers need the continuation back on their context (their receive loops feed main-thread-only UI); context-less ones (the V8 script-invoke thread) would throw in TaskScheduler.FromCurrentSynchronizationContext.
+                // Resume on the caller's context when there is one; a context-less thread would throw in TaskScheduler.FromCurrentSynchronizationContext.
                 bool marshalBackToIssuingContext = SynchronizationContext.Current != null;
                 using CancellationTokenSource linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, connectAbort.Token);
 
@@ -141,7 +140,7 @@ namespace Utility.Networking
             try { connectAbort.Cancel(); }
             catch (ObjectDisposedException)
             {
-                // A racing Dispose() (scene teardown vs a JS close()) may have already disposed the CTS.
+                // A racing Dispose() may have already disposed the CTS.
             }
 
             ws.Abort();

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
@@ -4,15 +4,21 @@ using Cysharp.Threading.Tasks;
 
 namespace Utility.Networking
 {
-    // Desktop / WebGL friendly implementation
+    /// <summary>
+    ///     Desktop / WebGL friendly implementation. CloseAsync, Abort and Dispose may run on a
+    ///     different thread than a pending ConnectAsync await; failing a pending connection
+    ///     completes that await instead of leaving it parked.
+    /// </summary>
     public class DCLWebSocket : IDisposable
     {
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
         private DCL.WebSockets.JS.WebGLWebSocket ws = new ();
 #else
         private System.Net.WebSockets.ClientWebSocket ws = new ();
-#endif
 
+        // Once TCP connects, neither Abort() nor a CancellationToken unparks mono's ConnectAsync, so failing a pending connection means abandoning its await via this token.
+        private readonly CancellationTokenSource connectAbort = new ();
+#endif
 
         public WebSocketState State
         {
@@ -21,14 +27,19 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 return ws.State;
 #else
-                return (WebSocketState) ws.State; // Direct mapping
+                return (WebSocketState) ws.State;
 #endif
             }
         }
 
         public void Dispose()
         {
+#if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
             ws.Dispose();
+#else
+            connectAbort.SafeCancelAndDispose();
+            ws.Dispose();
+#endif
         }
 
         public async UniTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
@@ -79,7 +90,16 @@ namespace Utility.Networking
         {
             try
             {
+#if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 await ws.ConnectAsync(uri, cancellationToken);
+#else
+                // Main-thread callers need the continuation back on their context (their receive loops feed main-thread-only UI); context-less ones (the V8 script-invoke thread) would throw in TaskScheduler.FromCurrentSynchronizationContext.
+                bool marshalBackToIssuingContext = SynchronizationContext.Current != null;
+                using CancellationTokenSource linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, connectAbort.Token);
+
+                // Only AttachExternalCancellation can complete this await once the BCL task parks mid-upgrade (see connectAbort).
+                await ws.ConnectAsync(uri, linked.Token).AsUniTask(useCurrentSynchronizationContext: marshalBackToIssuingContext).AttachExternalCancellation(linked.Token);
+#endif
             }
             catch (System.Net.WebSockets.WebSocketException e)
             {
@@ -87,7 +107,7 @@ namespace Utility.Networking
             }
         }
 
-        public async UniTask CloseAsync(WebSocketCloseStatus status, String? description, CancellationToken cancellationToken)
+        public async UniTask CloseAsync(WebSocketCloseStatus status, string? description, CancellationToken cancellationToken)
         {
             try
             {
@@ -95,6 +115,13 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 await ws.CloseAsync(status, description, cancellationToken);
 #else
+                // Mono's close path derefs an inner socket that only exists after a successful upgrade; per WHATWG, close() outside an established connection aborts instead.
+                if (State is not (WebSocketState.Open or WebSocketState.CloseReceived or WebSocketState.CloseSent))
+                {
+                    Abort();
+                    return;
+                }
+
                 System.Net.WebSockets.WebSocketCloseStatus statusType = (System.Net.WebSockets.WebSocketCloseStatus)status;
                 await ws.CloseAsync(statusType, description, cancellationToken);
 #endif
@@ -108,8 +135,15 @@ namespace Utility.Networking
         public void Abort()
         {
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
-            // Ignore, WebGL doesn't expose raw TCP sockets to hard interrupt
+            // WebGL doesn't expose raw TCP sockets to hard-interrupt.
 #else
+            // ws.Abort() alone leaves a parked connect hanging on mono; cancelling after a completed connect is inert.
+            try { connectAbort.Cancel(); }
+            catch (ObjectDisposedException)
+            {
+                // A racing Dispose() (scene teardown vs a JS close()) may have already disposed the CTS.
+            }
+
             ws.Abort();
 #endif
         }

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs
@@ -14,9 +14,8 @@ using Utility.Networking;
 namespace Utility.Tests
 {
     /// <summary>
-    ///     The JS WebSocket polyfill allows close() while still CONNECTING (WHATWG: it fails the
-    ///     connection), but mono's close path derefs an inner socket that only exists after a
-    ///     successful upgrade — so CloseAsync on a pending connection must abort, not handshake.
+    ///     Mono's close path derefs an inner socket that only exists after a successful upgrade, so
+    ///     CloseAsync on a pending connection must abort (WHATWG: close() while CONNECTING fails the connection).
     /// </summary>
     [TestFixture]
     public class DCLWebSocketCloseAsyncShould
@@ -26,7 +25,6 @@ namespace Utility.Tests
         [Test]
         public async Task AbortInsteadOfThrowingWhenClosedDuringHandshake()
         {
-            // Arrange
             // Never answering the HTTP upgrade parks the client mid-handshake with its inner managed socket unassigned.
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
@@ -46,10 +44,8 @@ namespace Utility.Tests
                 Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
                     "Precondition: the socket must be observed mid-handshake (the JS readyState CONNECTING window)");
 
-                // Act
                 Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
 
-                // Assert
                 Assert.That(thrown, Is.Null,
                     $"CloseAsync during the connect handshake must fail the connection, not throw, but threw {thrown?.GetType()}: {thrown?.Message}");
 
@@ -70,7 +66,6 @@ namespace Utility.Tests
         [Test]
         public async Task UnparkAPendingConnectWhenAborted()
         {
-            // Arrange
             // Never answering the HTTP upgrade parks the client mid-handshake.
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
@@ -90,10 +85,8 @@ namespace Utility.Tests
                 Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
                     "Precondition: the socket must be observed mid-handshake");
 
-                // Act
                 webSocket.Abort();
 
-                // Assert
                 Task completed = await Task.WhenAny(connectObserved, Task.Delay(TIMEOUT_MS));
                 Assert.That(completed, Is.SameAs(connectObserved), "Abort() must complete a parked connect instead of leaving it hanging");
             }
@@ -111,7 +104,6 @@ namespace Utility.Tests
         [Test]
         public async Task ConnectFromAThreadWithoutSynchronizationContext()
         {
-            // Arrange
             // The production caller, the ClearScript/V8 script-invoke thread, carries no SynchronizationContext.
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
@@ -126,7 +118,6 @@ namespace Utility.Tests
                 Task? connectTask = null;
                 Exception? synchronousThrow = null;
 
-                // Act
                 await Task.Run(() =>
                 {
                     SynchronizationContext.SetSynchronizationContext(null);
@@ -135,7 +126,6 @@ namespace Utility.Tests
                     catch (Exception e) { synchronousThrow = e; }
                 });
 
-                // Assert
                 Assert.That(synchronousThrow, Is.Null,
                     $"ConnectAsync must not throw on a thread without a SynchronizationContext, but threw {synchronousThrow?.GetType()}: {synchronousThrow?.Message}");
 
@@ -147,10 +137,8 @@ namespace Utility.Tests
                 Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
                     "Precondition: the socket must be observed mid-handshake");
 
-                // Act
                 Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
 
-                // Assert
                 Assert.That(thrown, Is.Null,
                     $"CloseAsync after an off-context connect must fail the connection, not throw, but threw {thrown?.GetType()}: {thrown?.Message}");
 
@@ -171,7 +159,6 @@ namespace Utility.Tests
         [Test]
         public async Task CompleteCleanlyOnANeverConnectedSocket()
         {
-            // Arrange
             var webSocket = new DCLWebSocket();
 
             try
@@ -179,10 +166,8 @@ namespace Utility.Tests
                 Assert.That(webSocket.State, Is.EqualTo(WebSocketState.None),
                     "Precondition: no connect attempt was started");
 
-                // Act
                 Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
 
-                // Assert
                 Assert.That(thrown, Is.Null,
                     $"CloseAsync on a never-connected socket must be a no-op abort, but threw {thrown?.GetType()}: {thrown?.Message}");
             }
@@ -195,7 +180,6 @@ namespace Utility.Tests
         [Test]
         public async Task StillPerformTheCloseHandshakeOnAnOpenSocket()
         {
-            // Arrange
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
             int port = ((IPEndPoint)listener.LocalEndpoint).Port;
@@ -212,10 +196,8 @@ namespace Utility.Tests
 
                 Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Open), "Precondition: the upgrade completed");
 
-                // Act
                 Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
 
-                // Assert
                 Assert.That(thrown, Is.Null,
                     $"CloseAsync on an open socket must run the close handshake, but threw {thrown?.GetType()}: {thrown?.Message}");
 
@@ -233,7 +215,6 @@ namespace Utility.Tests
         [Test]
         public async Task ResumeOnTheCallerSynchronizationContextAfterConnecting()
         {
-            // Arrange
             // The connect continuation starts receive loops that feed main-thread-only UI, so a connect issued on a SynchronizationContext must resume on it.
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
@@ -270,7 +251,6 @@ namespace Utility.Tests
 
                 await AwaitWithTimeoutAsync(done.Task, "connect on a SynchronizationContext");
 
-                // Assert
                 Assert.That(failure, Is.Null, $"ConnectAsync on a SynchronizationContext must not fault, but threw {failure?.GetType()}: {failure?.Message}");
                 Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Open), "Precondition: the upgrade completed");
                 Assert.That(resumeThreadId, Is.EqualTo(context.ThreadId),

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs
@@ -1,0 +1,414 @@
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Utility.Networking;
+
+namespace Utility.Tests
+{
+    /// <summary>
+    ///     The JS WebSocket polyfill allows close() while still CONNECTING (WHATWG: it fails the
+    ///     connection), but mono's close path derefs an inner socket that only exists after a
+    ///     successful upgrade — so CloseAsync on a pending connection must abort, not handshake.
+    /// </summary>
+    [TestFixture]
+    public class DCLWebSocketCloseAsyncShould
+    {
+        private const int TIMEOUT_MS = 10_000;
+
+        [Test]
+        public async Task AbortInsteadOfThrowingWhenClosedDuringHandshake()
+        {
+            // Arrange
+            // Never answering the HTTP upgrade parks the client mid-handshake with its inner managed socket unassigned.
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task<Socket> serverAccept = listener.AcceptSocketAsync();
+            Task acceptObserved = serverAccept.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                Task connectTask = webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask();
+
+                // Observe the abandoned connect's fault so it can't surface as unobserved.
+                Task connectObserved = connectTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
+                    "Precondition: the socket must be observed mid-handshake (the JS readyState CONNECTING window)");
+
+                // Act
+                Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
+
+                // Assert
+                Assert.That(thrown, Is.Null,
+                    $"CloseAsync during the connect handshake must fail the connection, not throw, but threw {thrown?.GetType()}: {thrown?.Message}");
+
+                Task completed = await Task.WhenAny(connectObserved, Task.Delay(TIMEOUT_MS));
+                Assert.That(completed, Is.SameAs(connectObserved), "The aborted connect must complete instead of hanging");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+                await Task.WhenAny(acceptObserved, Task.Delay(TIMEOUT_MS));
+
+                if (serverAccept.Status == TaskStatus.RanToCompletion)
+                    serverAccept.Result.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task UnparkAPendingConnectWhenAborted()
+        {
+            // Arrange
+            // Never answering the HTTP upgrade parks the client mid-handshake.
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task<Socket> serverAccept = listener.AcceptSocketAsync();
+            Task acceptObserved = serverAccept.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                Task connectTask = webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask();
+
+                // Observe the abandoned connect's fault so it can't surface as unobserved.
+                Task connectObserved = connectTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
+                    "Precondition: the socket must be observed mid-handshake");
+
+                // Act
+                webSocket.Abort();
+
+                // Assert
+                Task completed = await Task.WhenAny(connectObserved, Task.Delay(TIMEOUT_MS));
+                Assert.That(completed, Is.SameAs(connectObserved), "Abort() must complete a parked connect instead of leaving it hanging");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+                await Task.WhenAny(acceptObserved, Task.Delay(TIMEOUT_MS));
+
+                if (serverAccept.Status == TaskStatus.RanToCompletion)
+                    serverAccept.Result.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task ConnectFromAThreadWithoutSynchronizationContext()
+        {
+            // Arrange
+            // The production caller, the ClearScript/V8 script-invoke thread, carries no SynchronizationContext.
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task<Socket> serverAccept = listener.AcceptSocketAsync();
+            Task acceptObserved = serverAccept.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                Task? connectTask = null;
+                Exception? synchronousThrow = null;
+
+                // Act
+                await Task.Run(() =>
+                {
+                    SynchronizationContext.SetSynchronizationContext(null);
+
+                    try { connectTask = webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask(); }
+                    catch (Exception e) { synchronousThrow = e; }
+                });
+
+                // Assert
+                Assert.That(synchronousThrow, Is.Null,
+                    $"ConnectAsync must not throw on a thread without a SynchronizationContext, but threw {synchronousThrow?.GetType()}: {synchronousThrow?.Message}");
+
+                Task connectObserved = connectTask!.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+                Assert.That(connectTask.IsFaulted, Is.False,
+                    $"ConnectAsync must not fault on a thread without a SynchronizationContext, but faulted with {connectTask.Exception?.GetBaseException().GetType()}: {connectTask.Exception?.GetBaseException().Message}");
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Connecting),
+                    "Precondition: the socket must be observed mid-handshake");
+
+                // Act
+                Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
+
+                // Assert
+                Assert.That(thrown, Is.Null,
+                    $"CloseAsync after an off-context connect must fail the connection, not throw, but threw {thrown?.GetType()}: {thrown?.Message}");
+
+                Task completed = await Task.WhenAny(connectObserved, Task.Delay(TIMEOUT_MS));
+                Assert.That(completed, Is.SameAs(connectObserved), "The aborted connect must complete instead of hanging");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+                await Task.WhenAny(acceptObserved, Task.Delay(TIMEOUT_MS));
+
+                if (serverAccept.Status == TaskStatus.RanToCompletion)
+                    serverAccept.Result.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task CompleteCleanlyOnANeverConnectedSocket()
+        {
+            // Arrange
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.None),
+                    "Precondition: no connect attempt was started");
+
+                // Act
+                Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
+
+                // Assert
+                Assert.That(thrown, Is.Null,
+                    $"CloseAsync on a never-connected socket must be a no-op abort, but threw {thrown?.GetType()}: {thrown?.Message}");
+            }
+            finally
+            {
+                webSocket.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task StillPerformTheCloseHandshakeOnAnOpenSocket()
+        {
+            // Arrange
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task serverTask = ServeUpgradeThenEchoCloseAsync(listener);
+
+            // Observed on a background continuation so no unobserved fault leaks if the test fails early.
+            _ = serverTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            var webSocket = new DCLWebSocket();
+
+            try
+            {
+                await AwaitWithTimeoutAsync(webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None).AsTask(), "connect");
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Open), "Precondition: the upgrade completed");
+
+                // Act
+                Exception? thrown = await CaptureAsync(() => webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None));
+
+                // Assert
+                Assert.That(thrown, Is.Null,
+                    $"CloseAsync on an open socket must run the close handshake, but threw {thrown?.GetType()}: {thrown?.Message}");
+
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Closed), "The close handshake must complete both ways");
+
+                await AwaitWithTimeoutAsync(serverTask, "server close echo");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+            }
+        }
+
+        [Test]
+        public async Task ResumeOnTheCallerSynchronizationContextAfterConnecting()
+        {
+            // Arrange
+            // The connect continuation starts receive loops that feed main-thread-only UI, so a connect issued on a SynchronizationContext must resume on it.
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task serverTask = ServeUpgradeThenEchoCloseAsync(listener);
+            _ = serverTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+
+            using var context = new SingleThreadSynchronizationContext();
+            var webSocket = new DCLWebSocket();
+
+            var resumeThreadId = 0;
+            Exception? failure = null;
+
+            try
+            {
+                var done = new TaskCompletionSource<bool>();
+
+                context.Post(_ =>
+                {
+                    ConnectAndCaptureAsync().Forget();
+                    return;
+
+                    async UniTaskVoid ConnectAndCaptureAsync()
+                    {
+                        try
+                        {
+                            await webSocket.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None);
+                            resumeThreadId = Thread.CurrentThread.ManagedThreadId;
+                        }
+                        catch (Exception e) { failure = e; }
+                        finally { done.TrySetResult(true); }
+                    }
+                }, null);
+
+                await AwaitWithTimeoutAsync(done.Task, "connect on a SynchronizationContext");
+
+                // Assert
+                Assert.That(failure, Is.Null, $"ConnectAsync on a SynchronizationContext must not fault, but threw {failure?.GetType()}: {failure?.Message}");
+                Assert.That(webSocket.State, Is.EqualTo(WebSocketState.Open), "Precondition: the upgrade completed");
+                Assert.That(resumeThreadId, Is.EqualTo(context.ThreadId),
+                    "ConnectAsync must resume on the caller's SynchronizationContext so the receive loop it starts stays on that thread");
+            }
+            finally
+            {
+                webSocket.Dispose();
+                listener.Stop();
+                await Task.WhenAny(serverTask, Task.Delay(TIMEOUT_MS));
+            }
+        }
+
+        private static async Task<Exception?> CaptureAsync(Func<UniTask> operation)
+        {
+            try { await operation(); }
+            catch (Exception e) { return e; }
+
+            return null;
+        }
+
+        private static async Task AwaitWithTimeoutAsync(Task task, string what)
+        {
+            Task completed = await Task.WhenAny(task, Task.Delay(TIMEOUT_MS));
+            Assert.That(completed, Is.SameAs(task), $"{what} did not complete within {TIMEOUT_MS}ms");
+            await task;
+        }
+
+        private static async Task ServeUpgradeThenEchoCloseAsync(TcpListener listener)
+        {
+            using Socket socket = await listener.AcceptSocketAsync();
+            using var stream = new NetworkStream(socket, ownsSocket: false);
+
+            string request = await ReadHeadersAsync(stream);
+            var key = string.Empty;
+
+            foreach (string line in request.Split(new[] { "\r\n" }, StringSplitOptions.None))
+                if (line.StartsWith("Sec-WebSocket-Key:", StringComparison.OrdinalIgnoreCase))
+                    key = line.Substring("Sec-WebSocket-Key:".Length).Trim();
+
+            string acceptKey;
+
+            using (var sha1 = SHA1.Create())
+                acceptKey = Convert.ToBase64String(sha1.ComputeHash(Encoding.ASCII.GetBytes(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")));
+
+            byte[] response = Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Accept: {acceptKey}\r\n\r\n");
+
+            await stream.WriteAsync(response, 0, response.Length);
+
+            // Echoing the client's masked close frame (FIN+opcode 0x8) back unmasked lets the client-side close handshake complete.
+            var header = new byte[2];
+            await ReadExactAsync(stream, header, header.Length);
+            int payloadLength = header[1] & 0x7F;
+            var maskAndPayload = new byte[4 + payloadLength];
+            await ReadExactAsync(stream, maskAndPayload, maskAndPayload.Length);
+
+            var closeReply = new byte[2 + payloadLength];
+            closeReply[0] = 0x88;
+            closeReply[1] = (byte)payloadLength;
+
+            for (var i = 0; i < payloadLength; i++)
+                closeReply[2 + i] = (byte)(maskAndPayload[4 + i] ^ maskAndPayload[i % 4]);
+
+            await stream.WriteAsync(closeReply, 0, closeReply.Length);
+        }
+
+        private static async Task<string> ReadHeadersAsync(NetworkStream stream)
+        {
+            var builder = new StringBuilder();
+            var single = new byte[1];
+
+            while (!EndsWithHeaderTerminator(builder))
+            {
+                int read = await stream.ReadAsync(single, 0, 1);
+
+                if (read == 0)
+                    throw new IOException("Connection closed before the upgrade request completed");
+
+                builder.Append((char)single[0]);
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool EndsWithHeaderTerminator(StringBuilder builder) =>
+            builder.Length >= 4
+            && builder[builder.Length - 4] == '\r' && builder[builder.Length - 3] == '\n'
+            && builder[builder.Length - 2] == '\r' && builder[builder.Length - 1] == '\n';
+
+        private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, int count)
+        {
+            var offset = 0;
+
+            while (offset < count)
+            {
+                int read = await stream.ReadAsync(buffer, offset, count - offset);
+
+                if (read == 0)
+                    throw new IOException("Connection closed mid-frame");
+
+                offset += read;
+            }
+        }
+
+        /// <summary>
+        ///     Stands in for Unity's single-threaded main-thread context: continuations posted here run
+        ///     on one dedicated thread, so a test can assert an await resumed where it was issued.
+        /// </summary>
+        private sealed class SingleThreadSynchronizationContext : SynchronizationContext, IDisposable
+        {
+            private readonly BlockingCollection<(SendOrPostCallback callback, object? state)> queue = new ();
+            private readonly Thread thread;
+
+            public int ThreadId => thread.ManagedThreadId;
+
+            public SingleThreadSynchronizationContext()
+            {
+                thread = new Thread(Pump) { IsBackground = true, Name = nameof(SingleThreadSynchronizationContext) };
+                thread.Start();
+            }
+
+            public override void Post(SendOrPostCallback d, object? state) =>
+                queue.Add((d, state));
+
+            public override void Send(SendOrPostCallback d, object? state) =>
+                throw new NotSupportedException();
+
+            public void Dispose() =>
+                queue.CompleteAdding();
+
+            private void Pump()
+            {
+                SetSynchronizationContext(this);
+
+                foreach ((SendOrPostCallback callback, object? state) in queue.GetConsumingEnumerable())
+                    callback(state);
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6f9ee9ed9db437fb0a1ce1946f06c42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs
@@ -1,0 +1,204 @@
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Threading;
+using UnityEngine.Profiling;
+using UnityEngine.TestTools;
+
+namespace Utility.Tests
+{
+    public class EventBusShould
+    {
+        private const int WARMUP_PUBLISHES = 20_000;
+        private const int MEASURED_PUBLISHES = 10_000;
+
+        // Rounds published while the main thread is parked (blocked, never yielding): each forces
+        // MEASURED_PUBLISHES continuations in flight simultaneously, priming the pooled-hop free
+        // list to >= the window size. Two rounds are needed because every physical buffer of
+        // UniTask's continuation queue must have grown past the window before measuring,
+        // regardless of how the editor pumped the initial burst.
+        private const int PARKED_ROUNDS = 2;
+
+        // The window counts GC.Alloc profiler samples on the publishing thread — allocation events,
+        // not bytes, because byte counters are unreliable on the Boehm editor runtime
+        // (GC.GetAllocatedBytesForCurrentThread is inert; GC.GetTotalMemory hides small-object
+        // churn behind lazy sweep). The unpooled hop emits 2 events per publish (closure + delegate,
+        // ~20k over the window); the pooled hop emits none — its worst case is ~10 regrowth events
+        // if an unrelated editor continuation forces a queue-buffer regrowth between the parked
+        // rounds; pool misses are impossible because the rounds prime the pool deterministically.
+        // The budget sits between the two, so the assertion discriminates under every editor-pump
+        // schedule.
+        private const int ALLOC_SAMPLE_BUDGET = 2_000;
+
+        // Must all register on the GC.Alloc recorder for the budget assertion to be meaningful.
+        private const int CANARY_ALLOCS = 64;
+
+        private static readonly TimeSpan PUMP_TIMEOUT = TimeSpan.FromSeconds(60);
+
+        private int invoked;
+
+        [UnityTest]
+        public IEnumerator NotAllocatePerOffMainThreadPublish()
+        {
+            //Arrange — a main-thread-invoking bus with one subscriber; publishing from a dedicated
+            // thread guarantees every Publish takes the thread-hop (AddContinuation) branch.
+            invoked = 0;
+            var bus = new EventBus(invokeSubscribersOnMainThread: true);
+            using IDisposable subscription = bus.Subscribe<TestEvent>(_ => Interlocked.Increment(ref invoked));
+
+            var measuredAllocSamples = -1;
+            Exception? threadError = null;
+            var warmupPublished = new ManualResetEventSlim(false);
+            var warmupDrained = new ManualResetEventSlim(false);
+            var roundPublished = new ManualResetEventSlim[PARKED_ROUNDS];
+            var roundDrained = new ManualResetEventSlim[PARKED_ROUNDS];
+
+            for (var i = 0; i < PARKED_ROUNDS; i++)
+            {
+                roundPublished[i] = new ManualResetEventSlim(false);
+                roundDrained[i] = new ManualResetEventSlim(false);
+            }
+
+            var publisher = new Thread(() =>
+            {
+                try
+                {
+                    // Warm-up burst: JITs the publish path; the editor may drain it on any schedule.
+                    for (var i = 0; i < WARMUP_PUBLISHES; i++)
+                        bus.Publish(new TestEvent { Value = i });
+
+                    warmupPublished.Set();
+
+                    if (!warmupDrained.Wait(PUMP_TIMEOUT))
+                        throw new TimeoutException("main thread never drained the warm-up publishes");
+
+                    // Parked rounds: the main thread is blocked (no drains can run), so the whole
+                    // round is in flight at once when it finishes.
+                    for (var round = 0; round < PARKED_ROUNDS; round++)
+                    {
+                        for (var i = 0; i < MEASURED_PUBLISHES; i++)
+                            bus.Publish(new TestEvent { Value = i });
+
+                        roundPublished[round].Set();
+
+                        if (!roundDrained[round].Wait(PUMP_TIMEOUT))
+                            throw new TimeoutException($"main thread never drained parked round {round}");
+                    }
+
+                    // Same recorder pattern as UnityEngine.TestTools' AllocatingGCMemory
+                    // constraint, run on the publishing thread: FilterToCurrentThread binds it to
+                    // this thread and the enabled toggle resets the sample count. The whole window
+                    // sits inside one editor frame because the main thread is parked in Join.
+                    Recorder gcAllocRecorder = Recorder.Get("GC.Alloc");
+                    gcAllocRecorder.FilterToCurrentThread();
+                    gcAllocRecorder.enabled = false;
+                    gcAllocRecorder.enabled = true;
+
+                    // Canary allocations: the budget assertion would be vacuous on a recorder that
+                    // does not register events from this thread.
+                    object? canarySink = null;
+
+                    for (var i = 0; i < CANARY_ALLOCS; i++)
+                        canarySink = new object();
+
+                    for (var i = 0; i < MEASURED_PUBLISHES; i++)
+                        bus.Publish(new TestEvent { Value = i });
+
+                    gcAllocRecorder.enabled = false;
+                    measuredAllocSamples = gcAllocRecorder.sampleBlockCount;
+                    GC.KeepAlive(canarySink);
+                }
+                catch (Exception e) { threadError = e; }
+            });
+
+            try
+            {
+                publisher.Start();
+
+                // Pump the editor loop until the warm-up continuations have all run on the main thread.
+                DateTime deadline = DateTime.UtcNow + PUMP_TIMEOUT;
+
+                while ((!warmupPublished.IsSet || Volatile.Read(ref invoked) < WARMUP_PUBLISHES) && DateTime.UtcNow < deadline)
+                    yield return null;
+
+                Assert.IsNull(threadError, threadError?.ToString());
+
+                Assert.AreEqual(WARMUP_PUBLISHES, Volatile.Read(ref invoked),
+                    "editor loop did not pump the queued main-thread continuations — environment failure, not the allocation regression under test");
+
+                warmupDrained.Set();
+
+                for (var round = 0; round < PARKED_ROUNDS; round++)
+                {
+                    // A blocking Wait (no yield) is what parks the editor loop while the round publishes.
+                    bool roundReady = roundPublished[round].Wait(PUMP_TIMEOUT);
+                    Assert.IsNull(threadError, threadError?.ToString());
+                    Assert.IsTrue(roundReady, $"publisher thread never finished parked round {round}");
+
+                    int expected = WARMUP_PUBLISHES + ((round + 1) * MEASURED_PUBLISHES);
+                    deadline = DateTime.UtcNow + PUMP_TIMEOUT;
+
+                    while (Volatile.Read(ref invoked) < expected && DateTime.UtcNow < deadline)
+                        yield return null;
+
+                    Assert.AreEqual(expected, Volatile.Read(ref invoked),
+                        $"editor loop did not drain parked round {round} — environment failure, not the allocation regression under test");
+
+                    roundDrained[round].Set();
+                }
+
+                //Act — the recorder is bound to the publishing thread and needs no pumping; the bounded
+                // Join parks the main thread so no drain, recycle, or buffer swap can land inside the window.
+                Assert.IsTrue(publisher.Join(PUMP_TIMEOUT), "publisher thread did not finish");
+                Assert.IsNull(threadError, threadError?.ToString());
+
+                //Assert
+                Assert.GreaterOrEqual(measuredAllocSamples, CANARY_ALLOCS,
+                    "GC.Alloc recorder registered fewer events than the canary allocated — environment failure, not the allocation regression under test");
+
+                Assert.Less(measuredAllocSamples, ALLOC_SAMPLE_BUDGET,
+                    $"off-main-thread Publish emitted {measuredAllocSamples} GC.Alloc events over {MEASURED_PUBLISHES} publishes");
+
+                // Drain the measured publishes: exactly-once delivery — nothing lost or duplicated by the hop.
+                const int TOTAL_PUBLISHES = WARMUP_PUBLISHES + ((PARKED_ROUNDS + 1) * MEASURED_PUBLISHES);
+                deadline = DateTime.UtcNow + PUMP_TIMEOUT;
+
+                while (Volatile.Read(ref invoked) < TOTAL_PUBLISHES && DateTime.UtcNow < deadline)
+                    yield return null;
+
+                Assert.AreEqual(TOTAL_PUBLISHES, Volatile.Read(ref invoked));
+            }
+            finally
+            {
+                // Set before Join before Dispose: setting every event releases the publisher from any
+                // Wait it is parked in on an early (assert-failure) exit, and an event may only be
+                // disposed once no other thread can still touch it.
+                warmupPublished.Set();
+                warmupDrained.Set();
+
+                for (var i = 0; i < PARKED_ROUNDS; i++)
+                {
+                    roundPublished[i].Set();
+                    roundDrained[i].Set();
+                }
+
+                if (publisher.IsAlive)
+                    publisher.Join(PUMP_TIMEOUT);
+
+                warmupPublished.Dispose();
+                warmupDrained.Dispose();
+
+                for (var i = 0; i < PARKED_ROUNDS; i++)
+                {
+                    roundPublished[i].Dispose();
+                    roundDrained[i].Dispose();
+                }
+            }
+        }
+
+        private struct TestEvent
+        {
+            public int Value;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs
@@ -12,22 +12,12 @@ namespace Utility.Tests
         private const int WARMUP_PUBLISHES = 20_000;
         private const int MEASURED_PUBLISHES = 10_000;
 
-        // Rounds published while the main thread is parked (blocked, never yielding): each forces
-        // MEASURED_PUBLISHES continuations in flight simultaneously, priming the pooled-hop free
-        // list to >= the window size. Two rounds are needed because every physical buffer of
-        // UniTask's continuation queue must have grown past the window before measuring,
-        // regardless of how the editor pumped the initial burst.
+        // Rounds published while the main thread is parked: they prime the pooled-hop free list and
+        // grow UniTask's continuation-queue buffers past the window size before measuring.
         private const int PARKED_ROUNDS = 2;
 
-        // The window counts GC.Alloc profiler samples on the publishing thread — allocation events,
-        // not bytes, because byte counters are unreliable on the Boehm editor runtime
-        // (GC.GetAllocatedBytesForCurrentThread is inert; GC.GetTotalMemory hides small-object
-        // churn behind lazy sweep). The unpooled hop emits 2 events per publish (closure + delegate,
-        // ~20k over the window); the pooled hop emits none — its worst case is ~10 regrowth events
-        // if an unrelated editor continuation forces a queue-buffer regrowth between the parked
-        // rounds; pool misses are impossible because the rounds prime the pool deterministically.
-        // The budget sits between the two, so the assertion discriminates under every editor-pump
-        // schedule.
+        // Counts GC.Alloc events, not bytes (byte counters are unreliable on the Boehm editor runtime).
+        // The unpooled hop emits ~2 events per publish (~20k over the window), the pooled hop near zero; the budget sits between.
         private const int ALLOC_SAMPLE_BUDGET = 2_000;
 
         // Must all register on the GC.Alloc recorder for the budget assertion to be meaningful.
@@ -40,8 +30,7 @@ namespace Utility.Tests
         [UnityTest]
         public IEnumerator NotAllocatePerOffMainThreadPublish()
         {
-            //Arrange — a main-thread-invoking bus with one subscriber; publishing from a dedicated
-            // thread guarantees every Publish takes the thread-hop (AddContinuation) branch.
+            // Publishing from a dedicated thread guarantees every Publish takes the thread-hop (AddContinuation) branch.
             invoked = 0;
             var bus = new EventBus(invokeSubscribersOnMainThread: true);
             using IDisposable subscription = bus.Subscribe<TestEvent>(_ => Interlocked.Increment(ref invoked));
@@ -63,7 +52,7 @@ namespace Utility.Tests
             {
                 try
                 {
-                    // Warm-up burst: JITs the publish path; the editor may drain it on any schedule.
+                    // Warm-up burst: JITs the publish path.
                     for (var i = 0; i < WARMUP_PUBLISHES; i++)
                         bus.Publish(new TestEvent { Value = i });
 
@@ -72,8 +61,7 @@ namespace Utility.Tests
                     if (!warmupDrained.Wait(PUMP_TIMEOUT))
                         throw new TimeoutException("main thread never drained the warm-up publishes");
 
-                    // Parked rounds: the main thread is blocked (no drains can run), so the whole
-                    // round is in flight at once when it finishes.
+                    // The main thread is blocked, so the whole round is in flight at once when it finishes.
                     for (var round = 0; round < PARKED_ROUNDS; round++)
                     {
                         for (var i = 0; i < MEASURED_PUBLISHES; i++)
@@ -85,17 +73,13 @@ namespace Utility.Tests
                             throw new TimeoutException($"main thread never drained parked round {round}");
                     }
 
-                    // Same recorder pattern as UnityEngine.TestTools' AllocatingGCMemory
-                    // constraint, run on the publishing thread: FilterToCurrentThread binds it to
-                    // this thread and the enabled toggle resets the sample count. The whole window
-                    // sits inside one editor frame because the main thread is parked in Join.
+                    // FilterToCurrentThread binds the recorder to this thread; the enabled toggle resets the sample count.
                     Recorder gcAllocRecorder = Recorder.Get("GC.Alloc");
                     gcAllocRecorder.FilterToCurrentThread();
                     gcAllocRecorder.enabled = false;
                     gcAllocRecorder.enabled = true;
 
-                    // Canary allocations: the budget assertion would be vacuous on a recorder that
-                    // does not register events from this thread.
+                    // Canary allocations prove the recorder registers events from this thread.
                     object? canarySink = null;
 
                     for (var i = 0; i < CANARY_ALLOCS; i++)
@@ -115,7 +99,6 @@ namespace Utility.Tests
             {
                 publisher.Start();
 
-                // Pump the editor loop until the warm-up continuations have all run on the main thread.
                 DateTime deadline = DateTime.UtcNow + PUMP_TIMEOUT;
 
                 while ((!warmupPublished.IsSet || Volatile.Read(ref invoked) < WARMUP_PUBLISHES) && DateTime.UtcNow < deadline)
@@ -147,19 +130,17 @@ namespace Utility.Tests
                     roundDrained[round].Set();
                 }
 
-                //Act — the recorder is bound to the publishing thread and needs no pumping; the bounded
-                // Join parks the main thread so no drain, recycle, or buffer swap can land inside the window.
+                // Join parks the main thread so no drain, recycle, or buffer swap can land inside the measured window.
                 Assert.IsTrue(publisher.Join(PUMP_TIMEOUT), "publisher thread did not finish");
                 Assert.IsNull(threadError, threadError?.ToString());
 
-                //Assert
                 Assert.GreaterOrEqual(measuredAllocSamples, CANARY_ALLOCS,
                     "GC.Alloc recorder registered fewer events than the canary allocated — environment failure, not the allocation regression under test");
 
                 Assert.Less(measuredAllocSamples, ALLOC_SAMPLE_BUDGET,
                     $"off-main-thread Publish emitted {measuredAllocSamples} GC.Alloc events over {MEASURED_PUBLISHES} publishes");
 
-                // Drain the measured publishes: exactly-once delivery — nothing lost or duplicated by the hop.
+                // Exactly-once delivery: nothing lost or duplicated by the hop.
                 const int TOTAL_PUBLISHES = WARMUP_PUBLISHES + ((PARKED_ROUNDS + 1) * MEASURED_PUBLISHES);
                 deadline = DateTime.UtcNow + PUMP_TIMEOUT;
 
@@ -170,9 +151,8 @@ namespace Utility.Tests
             }
             finally
             {
-                // Set before Join before Dispose: setting every event releases the publisher from any
-                // Wait it is parked in on an early (assert-failure) exit, and an event may only be
-                // disposed once no other thread can still touch it.
+                // Set releases the publisher from any Wait on an early exit; Dispose only after Join,
+                // once no other thread can still touch the events.
                 warmupPublished.Set();
                 warmupDrained.Set();
 

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Tests/EventBusShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 25a839409bf3425085142cc70873da27

--- a/Explorer/Assets/DCL/MapRenderer/ConsumerUtils/PixelPerfectMapRendererTextureProvider.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ConsumerUtils/PixelPerfectMapRendererTextureProvider.cs
@@ -10,25 +10,34 @@ namespace DCL.MapRenderer.ConsumerUtils
     public class PixelPerfectMapRendererTextureProvider : MonoBehaviour
     {
         [NonSerialized]
-        private RectTransform cachedRectTransform;
+        private RectTransform? cachedRectTransform;
         private RectTransform rectTransform => cachedRectTransform ??= (RectTransform)transform;
 
-        private RawImage rawImage;
+        private RawImage? rawImage;
         private RawImage targetImage => rawImage ??= GetComponent<RawImage>();
 
-        private IMapCameraController cameraController;
-        private Camera hudCamera;
+        private IMapCameraController? cameraController;
+        private Camera? hudCamera;
+
+        // Resolution last applied to the render texture; seeded in Activate so an unchanged
+        // size never triggers a redundant resize.
+        private Vector2Int lastResolution;
 
         private static Vector3[] worldCorners = new Vector3[4];
 
-        public void Activate(IMapCameraController cameraController)
+        /// <summary>
+        /// Arms pixel-perfect resizing. The controller's render texture must already be sized
+        /// with <see cref="GetPixelPerfectTextureResolution"/> when this is called.
+        /// </summary>
+        public void Activate(IMapCameraController newCameraController)
         {
-            this.cameraController = cameraController;
+            cameraController = newCameraController;
+            lastResolution = GetPixelPerfectTextureResolution();
         }
 
-        public void SetHudCamera(Camera hudCamera)
+        public void SetHudCamera(Camera newHudCamera)
         {
-            this.hudCamera = hudCamera;
+            hudCamera = newHudCamera;
         }
 
         public void Deactivate()
@@ -40,9 +49,6 @@ namespace DCL.MapRenderer.ConsumerUtils
         {
             // assumes CanvasScale Match Height = 1;
 
-            var rectSize = rectTransform.rect.size;
-            var ratio = rectSize.x / rectSize.y;
-
             // translate rect to screen space
             rectTransform.GetWorldCorners(worldCorners);
 
@@ -53,12 +59,31 @@ namespace DCL.MapRenderer.ConsumerUtils
             return new Vector2Int((int) screenSize.x, (int) screenSize.y);
         }
 
+        // Screen-resolution or canvas-scale changes (e.g. windowed -> fullscreen) alter the
+        // on-screen pixel size without changing the rect, so OnRectTransformDimensionsChange
+        // alone cannot keep the render texture pixel-perfect: poll every frame.
+        private void LateUpdate()
+        {
+            ApplyPixelPerfectResolution();
+        }
+
         private void OnRectTransformDimensionsChange()
+        {
+            ApplyPixelPerfectResolution();
+        }
+
+        private void ApplyPixelPerfectResolution()
         {
             if (cameraController == null)
                 return;
 
-            cameraController.ResizeTexture(GetPixelPerfectTextureResolution());
+            Vector2Int resolution = GetPixelPerfectTextureResolution();
+
+            if (resolution == lastResolution)
+                return;
+
+            lastResolution = resolution;
+            cameraController.ResizeTexture(resolution);
 
             targetImage.SetAllDirty();
         }

--- a/Explorer/Assets/DCL/MapRenderer/ConsumerUtils/PixelPerfectMapRendererTextureProvider.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ConsumerUtils/PixelPerfectMapRendererTextureProvider.cs
@@ -19,15 +19,12 @@ namespace DCL.MapRenderer.ConsumerUtils
         private IMapCameraController? cameraController;
         private Camera? hudCamera;
 
-        // Resolution last applied to the render texture; seeded in Activate so an unchanged
-        // size never triggers a redundant resize.
         private Vector2Int lastResolution;
 
         private static Vector3[] worldCorners = new Vector3[4];
 
         /// <summary>
-        /// Arms pixel-perfect resizing. The controller's render texture must already be sized
-        /// with <see cref="GetPixelPerfectTextureResolution"/> when this is called.
+        /// Arms pixel-perfect resizing; the controller's render texture must already be sized with <see cref="GetPixelPerfectTextureResolution"/>.
         /// </summary>
         public void Activate(IMapCameraController newCameraController)
         {
@@ -59,9 +56,8 @@ namespace DCL.MapRenderer.ConsumerUtils
             return new Vector2Int((int) screenSize.x, (int) screenSize.y);
         }
 
-        // Screen-resolution or canvas-scale changes (e.g. windowed -> fullscreen) alter the
-        // on-screen pixel size without changing the rect, so OnRectTransformDimensionsChange
-        // alone cannot keep the render texture pixel-perfect: poll every frame.
+        // Screen-resolution or canvas-scale changes (e.g. windowed -> fullscreen) alter the on-screen
+        // pixel size without a rect change, so OnRectTransformDimensionsChange alone is not enough
         private void LateUpdate()
         {
             ApplyPixelPerfectResolution();

--- a/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils.meta
+++ b/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42368490db9c4535869fa959000f7998
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs
+++ b/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs
@@ -1,0 +1,104 @@
+﻿using DCL.MapRenderer.ConsumerUtils;
+using DCL.MapRenderer.MapCameraController;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace DCL.MapRenderer.Tests.ConsumerUtils
+{
+    public class PixelPerfectMapRendererTextureProviderShould
+    {
+        private const float RECT_SIZE = 300f;
+
+        private GameObject root = null!;
+        private GameObject providerGo = null!;
+        private PixelPerfectMapRendererTextureProvider provider = null!;
+        private IMapCameraController cameraController = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            root = new GameObject("root", typeof(RectTransform));
+            providerGo = new GameObject("provider", typeof(RectTransform));
+            providerGo.transform.SetParent(root.transform, false);
+            ((RectTransform)providerGo.transform).sizeDelta = new Vector2(RECT_SIZE, RECT_SIZE);
+            providerGo.AddComponent<RawImage>();
+            provider = providerGo.AddComponent<PixelPerfectMapRendererTextureProvider>();
+
+            // Null hud camera = overlay-canvas branch of WorldToScreenPoint: screen size == world size,
+            // deterministic in a headless EditMode run.
+            cameraController = Substitute.For<IMapCameraController>();
+            provider.Activate(cameraController);
+            cameraController.ClearReceivedCalls();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(providerGo);
+            Object.DestroyImmediate(root);
+        }
+
+        private void PumpLateUpdate() =>
+            providerGo.SendMessage("LateUpdate", SendMessageOptions.DontRequireReceiver);
+
+        private void ScaleCanvasBy2()
+        {
+            // Windowed -> fullscreen as production sees it: the scale-with-screen-size canvas absorbs
+            // the new pixel resolution into its scale factor, the provider's own rect (canvas units)
+            // keeps identical dimensions, so Unity never sends OnRectTransformDimensionsChange.
+            root.transform.localScale = 2f * Vector3.one;
+        }
+
+        [Test]
+        public void ResizeWhenScreenSpaceSizeChangesWithoutRectChange()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            ScaleCanvasBy2();
+
+            PumpLateUpdate();
+            PumpLateUpdate();
+
+            cameraController.Received(1).ResizeTexture(new Vector2Int(600, 600));
+        }
+
+        [Test]
+        public void NotResizeWhenScreenSpaceSizeUnchanged()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            PumpLateUpdate();
+            PumpLateUpdate();
+
+            cameraController.DidNotReceive().ResizeTexture(Arg.Any<Vector2Int>());
+        }
+
+        [Test]
+        public void ResizeOnRectDimensionsChangeMessage()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            ScaleCanvasBy2();
+
+            providerGo.SendMessage("OnRectTransformDimensionsChange", SendMessageOptions.DontRequireReceiver);
+
+            cameraController.Received(1).ResizeTexture(new Vector2Int(600, 600));
+        }
+
+        [Test]
+        public void NotResizeAfterDeactivate()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            provider.Deactivate();
+            ScaleCanvasBy2();
+
+            PumpLateUpdate();
+
+            cameraController.DidNotReceive().ResizeTexture(Arg.Any<Vector2Int>());
+        }
+    }
+}

--- a/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs
+++ b/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs
@@ -27,8 +27,7 @@ namespace DCL.MapRenderer.Tests.ConsumerUtils
             providerGo.AddComponent<RawImage>();
             provider = providerGo.AddComponent<PixelPerfectMapRendererTextureProvider>();
 
-            // Null hud camera = overlay-canvas branch of WorldToScreenPoint: screen size == world size,
-            // deterministic in a headless EditMode run.
+            // Null hud camera = overlay-canvas branch of WorldToScreenPoint: screen size == world size, deterministic in headless EditMode
             cameraController = Substitute.For<IMapCameraController>();
             provider.Activate(cameraController);
             cameraController.ClearReceivedCalls();
@@ -46,9 +45,8 @@ namespace DCL.MapRenderer.Tests.ConsumerUtils
 
         private void ScaleCanvasBy2()
         {
-            // Windowed -> fullscreen as production sees it: the scale-with-screen-size canvas absorbs
-            // the new pixel resolution into its scale factor, the provider's own rect (canvas units)
-            // keeps identical dimensions, so Unity never sends OnRectTransformDimensionsChange.
+            // Windowed -> fullscreen as production sees it: the canvas scale changes while the rect
+            // (canvas units) keeps identical dimensions, so Unity never sends OnRectTransformDimensionsChange
             root.transform.localScale = 2f * Vector3.one;
         }
 

--- a/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs.meta
+++ b/Explorer/Assets/DCL/MapRenderer/Tests/ConsumerUtils/PixelPerfectMapRendererTextureProviderShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11ab2bebbfe549679281d63a2b7ab104
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Systems/LiveKitMovementMessageBus.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Systems/LiveKitMovementMessageBus.cs
@@ -48,6 +48,9 @@ namespace DCL.Multiplayer.Movement
 
         public void Dispose()
         {
+            if (isDisposed)
+                return;
+
             isDisposed = true;
             cancellationTokenSource.Cancel();
             cancellationTokenSource.Dispose();

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Tests/LiveKitMovementMessageBusDisposalShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Tests/LiveKitMovementMessageBusDisposalShould.cs
@@ -1,0 +1,56 @@
+﻿using Arch.Core;
+using DCL.Multiplayer.Connections.GateKeeper.Rooms;
+using DCL.Multiplayer.Connections.Messaging.Hubs;
+using DCL.Multiplayer.Connections.Messaging.Pipe;
+using DCL.Multiplayer.Connections.Pulse;
+using DCL.Multiplayer.Profiles.BroadcastProfiles;
+using DCL.Multiplayer.Profiles.Tables;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DCL.Multiplayer.Movement.Tests
+{
+    /// <summary>
+    ///     Regression (Sentry UNITY-EXPLORER-NQG): the bus has two owners that both dispose it on shutdown,
+    ///     and the second call cancelled an already-disposed CTS.
+    /// </summary>
+    [TestFixture]
+    public class LiveKitMovementMessageBusDisposalShould
+    {
+        private World world;
+        private LiveKitMovementMessageBus bus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            world = World.Create();
+
+            IMessagePipesHub messagePipesHub = Substitute.For<IMessagePipesHub>();
+            messagePipesHub.IslandPipe().Returns(Substitute.For<IMessagePipe>());
+            messagePipesHub.ScenePipe().Returns(Substitute.For<IMessagePipe>());
+
+            var movementInbox = new MovementInbox(Substitute.For<IReadOnlyEntityParticipantTable>(), world);
+
+            var broadcaster = new LiveKitMessagesBroadcaster(
+                Substitute.For<IGateKeeperSceneRoom>(),
+                messagePipesHub,
+                new PulseActivation(false));
+
+            bus = new LiveKitMovementMessageBus(messagePipesHub, movementInbox, broadcaster);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            world.Dispose();
+        }
+
+        [Test]
+        public void NotThrowOnSecondDispose()
+        {
+            bus.Dispose();
+
+            Assert.DoesNotThrow(() => bus.Dispose());
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Tests/LiveKitMovementMessageBusDisposalShould.cs.meta
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Tests/LiveKitMovementMessageBusDisposalShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7711fa8b88424e53a2b737864967729a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -94,7 +94,7 @@ namespace DCL.Notifications
 
         public async UniTask StartGettingNewNotificationsOverTimeAsync(CancellationToken ct)
         {
-            // Loop-local so a cancelled run can't race the next one's Clear(); reused across iterations and never escapes the loop
+            // Loop-local so a cancelled run can't race the next one's Clear()
             var pollNotificationsBuffer = new List<INotification>();
 
             do

--- a/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationsRequestController.cs
@@ -31,6 +31,7 @@ namespace DCL.Notifications
         private readonly URLParameter onlyUnreadParameter = new ("onlyUnread", "true");
         private readonly URLParameter limitParameter = new ("limit", "50");
         private readonly URLBuilder urlBuilder = new ();
+        private readonly URLDomain notificationsUrl;
         private CommonArguments commonArguments;
         private ulong unixTimestamp;
         private ulong lastPolledTimestamp;
@@ -52,6 +53,8 @@ namespace DCL.Notifications
 
             lastPolledTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
+            notificationsUrl = URLDomain.FromString($"{urlsSource.Url(DecentralandUrl.Notifications)}/notifications");
+
             commonArgumentsForSetRead = new CommonArguments(
                 new URLBuilder()
                    .AppendDomain(
@@ -70,13 +73,14 @@ namespace DCL.Notifications
 
             urlBuilder.Clear();
 
-            urlBuilder.AppendDomain(URLDomain.FromString($"{urlsSource.Url(DecentralandUrl.Notifications)}/notifications"))
+            urlBuilder.AppendDomain(notificationsUrl)
                       .AppendParameter(limitParameter);
 
             commonArguments = new CommonArguments(urlBuilder.Build(), RetryPolicy.Enforce());
             unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
-            List<INotification> notifications =
+            // Null when the identity disappears before the signed request runs
+            List<INotification>? notifications =
                 await webRequestController.GetAsync(
                                                commonArguments,
                                                ct,
@@ -85,11 +89,14 @@ namespace DCL.Notifications
                                                headersInfo: new WebRequestHeadersInfo().WithSign(string.Empty, unixTimestamp))
                                           .CreateFromNewtonsoftJsonAsync<List<INotification>>(serializerSettings: serializerSettings);
 
-            return notifications;
+            return notifications ?? new List<INotification>();
         }
 
         public async UniTask StartGettingNewNotificationsOverTimeAsync(CancellationToken ct)
         {
+            // Loop-local so a cancelled run can't race the next one's Clear(); reused across iterations and never escapes the loop
+            var pollNotificationsBuffer = new List<INotification>();
+
             do
             {
                 try
@@ -101,7 +108,7 @@ namespace DCL.Notifications
 
                     urlBuilder.Clear();
 
-                    urlBuilder.AppendDomain(URLDomain.FromString($"{urlsSource.Url(DecentralandUrl.Notifications)}/notifications"))
+                    urlBuilder.AppendDomain(notificationsUrl)
                               .AppendParameter(onlyUnreadParameter)
                               .AppendParameter(new URLParameter("from", lastPolledTimestamp.ToString()));
 
@@ -109,17 +116,19 @@ namespace DCL.Notifications
 
                     unixTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();
 
-                    // TODO remove allocation of List on serialization
-                    List<INotification> notifications =
+                    pollNotificationsBuffer.Clear();
+
+                    // Null when the identity disappears before the signed request runs
+                    List<INotification>? notifications =
                         await webRequestController.GetAsync(
                                                        commonArguments,
                                                        ct,
                                                        ReportCategory.UI,
                                                        signInfo: WebRequestSignInfo.NewFromUrl(urlsSource.GetOriginalUrl(commonArguments.URL), unixTimestamp, "get"),
                                                        headersInfo: new WebRequestHeadersInfo().WithSign(string.Empty, unixTimestamp))
-                                                  .CreateFromNewtonsoftJsonAsync<List<INotification>>(serializerSettings: serializerSettings);
+                                                  .OverwriteFromNewtonsoftJsonAsync(pollNotificationsBuffer, serializerSettings: serializerSettings);
 
-                    if (notifications.Count == 0)
+                    if (notifications == null || notifications.Count == 0)
                         continue;
 
                     lastPolledTimestamp = DateTime.UtcNow.UnixTimeAsMilliseconds();

--- a/Explorer/Assets/DCL/Notifications/Tests.meta
+++ b/Explorer/Assets/DCL/Notifications/Tests.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fc1928b0ba9f4aa38be9185acf2140cd
+timeCreated: 1786852140

--- a/Explorer/Assets/DCL/Notifications/Tests/DCL.Notifications.Tests.asmref
+++ b/Explorer/Assets/DCL/Notifications/Tests/DCL.Notifications.Tests.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:da80994a355e49d5b84f91c0a84a721f"
+}

--- a/Explorer/Assets/DCL/Notifications/Tests/DCL.Notifications.Tests.asmref.meta
+++ b/Explorer/Assets/DCL/Notifications/Tests/DCL.Notifications.Tests.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e566805b12114b19bdf45c17086748d1
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs
@@ -1,0 +1,102 @@
+using Cysharp.Threading.Tasks;
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.NotificationsBus;
+using DCL.NotificationsBus.NotificationTypes;
+using DCL.Web3.Identities;
+using DCL.WebRequests;
+using ECS.TestSuite;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DCL.Notifications.Tests
+{
+    public class NotificationsRequestControllerShould
+    {
+        // Window for two real 5s poll ticks; the wait exits early once both are observed
+        private static readonly TimeSpan POLL_OBSERVATION_TIMEOUT = TimeSpan.FromSeconds(30);
+
+        private NotificationsRequestController controller = null!;
+        private IWebRequestController webRequestController = null!;
+        private IWeb3IdentityCache identityCache = null!;
+        private IDecentralandUrlsSource urlsSource = null!;
+
+        private readonly List<List<INotification>> capturedTargets = new ();
+        private readonly List<int> callTimeCounts = new ();
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp() =>
+            EcsTestsUtils.SetUpFeaturesRegistry();
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown() =>
+            EcsTestsUtils.TearDownFeaturesRegistry();
+
+        [SetUp]
+        public void SetUp()
+        {
+            NotificationsBusController.Initialize(new NotificationsBusController());
+
+            capturedTargets.Clear();
+            callTimeCounts.Clear();
+
+            urlsSource = Substitute.For<IDecentralandUrlsSource>();
+            urlsSource.Url(DecentralandUrl.Notifications).Returns("https://notifications.test");
+            urlsSource.GetOriginalUrl(Arg.Any<string>()).Returns("https://notifications.test/notifications");
+
+            identityCache = Substitute.For<IWeb3IdentityCache>();
+            IWeb3Identity identity = Substitute.For<IWeb3Identity>();
+            identity.IsExpired.Returns(false);
+            identityCache.Identity.Returns(identity);
+
+            INotification cannedNotification = Substitute.For<INotification>();
+            cannedNotification.Id.Returns("notification-1");
+
+            webRequestController = Substitute.For<IWebRequestController>();
+
+            webRequestController.SendAsync<GenericGetRequest, GenericGetArguments, GenericDownloadHandlerUtils.OverwriteFromJsonAsyncOp<List<INotification>, GenericGetRequest>, List<INotification>>(
+                                     Arg.Any<RequestEnvelope<GenericGetRequest, GenericGetArguments>>(),
+                                     Arg.Any<GenericDownloadHandlerUtils.OverwriteFromJsonAsyncOp<List<INotification>, GenericGetRequest>>())!
+                                .Returns(callInfo =>
+                                 {
+                                     GenericDownloadHandlerUtils.OverwriteFromJsonAsyncOp<List<INotification>, GenericGetRequest> op =
+                                         callInfo.ArgAt<GenericDownloadHandlerUtils.OverwriteFromJsonAsyncOp<List<INotification>, GenericGetRequest>>(1);
+
+                                     capturedTargets.Add(op.Target);
+                                     callTimeCounts.Add(op.Target.Count);
+                                     op.Target.Add(cannedNotification);
+                                     return UniTask.FromResult(op.Target);
+                                 });
+
+            controller = new NotificationsRequestController(webRequestController, urlsSource, identityCache);
+        }
+
+        [Test]
+        public async Task ReuseSingleListInstanceAcrossPollIterations()
+        {
+            var cts = new CancellationTokenSource();
+            UniTask loopTask = controller.StartGettingNewNotificationsOverTimeAsync(cts.Token);
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
+
+            while (capturedTargets.Count < 2 && stopwatch.Elapsed < POLL_OBSERVATION_TIMEOUT)
+                await UniTask.Yield();
+
+            cts.Cancel();
+            await loopTask;
+
+            Assert.That(capturedTargets.Count, Is.GreaterThanOrEqualTo(2),
+                "the poll loop must parse into a reusable buffer via the Overwrite op instead of allocating a fresh List per poll");
+
+            Assert.That(capturedTargets[1], Is.SameAs(capturedTargets[0]),
+                "the same buffer instance must be reused across poll iterations");
+
+            Assert.That(callTimeCounts, Is.All.EqualTo(0),
+                "the buffer must be cleared before each poll so already-dispatched notifications are not delivered again");
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs.meta
+++ b/Explorer/Assets/DCL/Notifications/Tests/NotificationsRequestControllerShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9bfc0940c4e54a24b9b0ac066c7b7456
+timeCreated: 1786852140

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Analytics/DecoratorBased/ChatMessagesBusAnalyticsDecorator.cs
@@ -10,7 +10,6 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 {
     public class ChatMessagesBusAnalyticsDecorator : IChatMessagesBus
     {
-        private static readonly JArray MENTION_WALLET_IDS = new ();
         private static readonly Regex USERNAME_REGEX = new (@"(?<=^|\s)@([A-Za-z0-9]{1,15}(?:#[A-Za-z0-9]{4})?)(?=\s|!|\?|\.|,|$)", RegexOptions.Compiled);
 
         private readonly IChatMessagesBus core;
@@ -42,7 +41,9 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
         {
             core.Send(channel, message, origin, timestamp);
 
-            bool isMentionMessage = CheckIfIsMention(message);
+            // Each tracked JObject takes ownership of its own mentions array
+            JArray mentionWalletIds = new ();
+            bool isMentionMessage = CheckIfIsMention(message, mentionWalletIds);
 
             JObject jsonObject = new JObject
                 {
@@ -50,13 +51,13 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
                     { "length", message.Length },
                     { "origin", origin.ToStringValue() },
                     { "is_mention", isMentionMessage},
-                    { "mentions", MENTION_WALLET_IDS },
+                    { "mentions", mentionWalletIds },
                     { "is_private", channel.ChannelType == ChatChannel.ChatChannelType.USER},
                     // { "emoji_count", emoji_count },
                 };
 
             if (timestamp > 0 && selfProfile is { OwnProfile: not null })
-                jsonObject.Add("message_id", ChatUtils.GetId(selfProfile.OwnProfile.UserId, timestamp));
+                jsonObject.Add("message_id", ChatUtils.GetId(selfProfile.OwnProfile.UserId.Value, timestamp));
 
             if (channel.ChannelType == ChatChannel.ChatChannelType.USER)
                 jsonObject.Add("receiver_id", channel.Id.Id);
@@ -67,9 +68,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
             analytics.Track(AnalyticsEvents.Ui.MESSAGE_SENT, jsonObject);
         }
 
-        private bool CheckIfIsMention(string message)
+        private bool CheckIfIsMention(string message, JArray mentionWalletIds)
         {
-            MENTION_WALLET_IDS.Clear();
             var isValidMention = false;
             var matches = USERNAME_REGEX.Matches(message);
 
@@ -83,7 +83,8 @@ namespace DCL.PerformanceAndDiagnostics.Analytics
 
                 if (profile != null)
                 {
-                    MENTION_WALLET_IDS.Add(profile.Value.UserId);
+                    // Extract the wallet-address string; JArray.Add(object) boxes without implicit conversion
+                    mentionWalletIds.Add(profile.Value.UserId.Value);
                     //returning a valid mention only if at least one of the mentions are a real user
                     isValidMention = true;
                 }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/Container/DiagnosticsContainer.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/Container/DiagnosticsContainer.cs
@@ -40,7 +40,7 @@ namespace DCL.Diagnostics
             Sentry?.AddScopeConfigurator(configureScope);
         }
 
-        public static DiagnosticsContainer Create(IReportsHandlingSettings settings, params IReportHandler[] additionalHandlers)
+        public static DiagnosticsContainer Create(IReportsHandlingSettings settings, bool isLocalSceneDevelopment, params IReportHandler[] additionalHandlers)
         {
             settings.NotifyErrorDebugLogDisabled();
 
@@ -55,7 +55,14 @@ namespace DCL.Diagnostics
             SentrySampler? sentrySampler = null;
 
             if (settings.IsEnabled(ReportHandler.Sentry))
-                handlers.Add(sentryReportHandler = new SentryReportHandler(settings.GetMatrix(ReportHandler.Sentry), sentrySampler = new SentrySampler(), settings.DebounceEnabled));
+            {
+                ICategorySeverityMatrix sentryMatrix = settings.GetMatrix(ReportHandler.Sentry);
+
+                if (isLocalSceneDevelopment)
+                    sentryMatrix = new CategoryExclusionMatrix(sentryMatrix, ReportCategory.JAVASCRIPT);
+
+                handlers.Add(sentryReportHandler = new SentryReportHandler(sentryMatrix, sentrySampler = new SentrySampler(), settings.DebounceEnabled));
+            }
 
             var logger = new ReportHubLogger(handlers);
 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
@@ -15,6 +15,7 @@ namespace DCL.Diagnostics.Sentry
         public delegate void ConfigureScope(Scope scope);
 
         private static readonly TimeSpan SESSION_FLUSH_TIMEOUT = TimeSpan.FromSeconds(2);
+        private const string UNKNOWN_SCENE_NAME = "unknown-scene";
 
 #if UNITY_EDITOR
         private const string EDITOR_DSN_ENV_VAR = "DCL_SENTRY_DSN";
@@ -132,7 +133,7 @@ namespace DCL.Diagnostics.Sentry
 
         internal override void LogExceptionInternal(Exception exception, ReportData reportData, Object? context)
         {
-            using PoolExtensions.Scope<PerReportScope> reportScope = scopesPool.Scope(reportData);
+            using PoolExtensions.Scope<PerReportScope> reportScope = scopesPool.Scope(reportData, exception);
             SentrySdk.CaptureException(exception, reportScope.Value.ExecuteCached);
         }
 
@@ -194,13 +195,45 @@ namespace DCL.Diagnostics.Sentry
             }
         }
 
+        internal static void AddSceneJsFingerprint(Scope scope, in ReportData data, Exception? exception)
+        {
+            if (exception == null)
+                return;
+
+            if (!data.Category.Equals(ReportCategory.JAVASCRIPT))
+                return;
+
+            // Exception.Message is virtual and may build its string lazily, so reports filtered out above never pay for it
+            string message = exception.Message;
+
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            scope.SetFingerprint("scene-js", data.SceneShortInfo.Name ?? UNKNOWN_SCENE_NAME, FirstLine(message));
+        }
+
+        private static string FirstLine(string message)
+        {
+            int end = message.IndexOf('\n');
+
+            if (end < 0)
+                return message;
+
+            // Excluding the '\r' of a "\r\n" ending here spares the extra string a TrimEnd would allocate
+            if (end > 0 && message[end - 1] == '\r')
+                end--;
+
+            return message.Substring(0, end);
+        }
+
         private class PerReportScope
         {
             public readonly Action<Scope> ExecuteCached;
 
             private readonly IReadOnlyList<ConfigureScope> scopeConfigurators;
 
-            internal ReportData reportData { private get; set; }
+            private ReportData reportData { get; set; }
+            private Exception? exception { get; set; }
 
             private PerReportScope(IReadOnlyList<ConfigureScope> scopeConfigurators)
             {
@@ -220,6 +253,7 @@ namespace DCL.Diagnostics.Sentry
 
                 AddCategoryTag(scope, reportData);
                 AddSceneInfo(scope, reportData);
+                AddSceneJsFingerprint(scope, reportData, exception);
             }
 
             private static void AddCategoryTag(Scope scope, ReportData data) =>
@@ -239,10 +273,11 @@ namespace DCL.Diagnostics.Sentry
                 public Pool(IReadOnlyList<ConfigureScope> scopeConfigurators) : base(
                     () => new PerReportScope(scopeConfigurators), defaultCapacity: 3, collectionCheck: PoolConstants.CHECK_COLLECTIONS) { }
 
-                public PoolExtensions.Scope<PerReportScope> Scope(ReportData reportData)
+                public PoolExtensions.Scope<PerReportScope> Scope(ReportData reportData, Exception? exception = null)
                 {
                     PoolExtensions.Scope<PerReportScope> scope = this.AutoScope();
                     scope.Value.reportData = reportData;
+                    scope.Value.exception = exception;
                     return scope;
                 }
             }

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Settings/CategoryExclusionMatrix.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Settings/CategoryExclusionMatrix.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace DCL.Diagnostics
+{
+    public class CategoryExclusionMatrix : ICategorySeverityMatrix
+    {
+        private readonly ICategorySeverityMatrix baseMatrix;
+        private readonly string excludedCategory;
+
+        public CategoryExclusionMatrix(ICategorySeverityMatrix baseMatrix, string excludedCategory)
+        {
+            this.baseMatrix = baseMatrix;
+            this.excludedCategory = excludedCategory;
+        }
+
+        public bool IsEnabled(string category, LogType severity) =>
+            category != excludedCategory && baseMatrix.IsEnabled(category, severity);
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Settings/CategoryExclusionMatrix.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Settings/CategoryExclusionMatrix.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42a9dbc6be6542bb996caf0e302990c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/CategoryExclusionMatrixShould.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/CategoryExclusionMatrixShould.cs
@@ -1,0 +1,43 @@
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace DCL.Diagnostics.Tests
+{
+    public class CategoryExclusionMatrixShould
+    {
+        private ICategorySeverityMatrix baseMatrix;
+        private CategoryExclusionMatrix matrix;
+
+        [SetUp]
+        public void SetUp()
+        {
+            baseMatrix = Substitute.For<ICategorySeverityMatrix>();
+            matrix = new CategoryExclusionMatrix(baseMatrix, ReportCategory.JAVASCRIPT);
+        }
+
+        [Test]
+        public void ReturnFalseForExcludedCategoryRegardlessOfBaseMatrix([Values(true, false)] bool baseResult, [Values(LogType.Log, LogType.Exception)] LogType severity)
+        {
+            baseMatrix.IsEnabled(ReportCategory.JAVASCRIPT, Arg.Any<LogType>()).Returns(baseResult);
+
+            Assert.That(matrix.IsEnabled(ReportCategory.JAVASCRIPT, severity), Is.False);
+        }
+
+        [Test]
+        public void DelegateToBaseMatrixForNonExcludedCategory_WhenEnabled()
+        {
+            baseMatrix.IsEnabled(ReportCategory.ENGINE, LogType.Exception).Returns(true);
+
+            Assert.That(matrix.IsEnabled(ReportCategory.ENGINE, LogType.Exception), Is.True);
+        }
+
+        [Test]
+        public void DelegateToBaseMatrixForNonExcludedCategory_WhenDisabled()
+        {
+            baseMatrix.IsEnabled(ReportCategory.ENGINE, LogType.Exception).Returns(false);
+
+            Assert.That(matrix.IsEnabled(ReportCategory.ENGINE, LogType.Exception), Is.False);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/CategoryExclusionMatrixShould.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/CategoryExclusionMatrixShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c6523d403864685a52c1dccd6e5fe4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/SentryReportHandlerShould.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/SentryReportHandlerShould.cs
@@ -1,0 +1,86 @@
+using DCL.Diagnostics.Sentry;
+using NUnit.Framework;
+using Sentry;
+using System;
+using UnityEngine;
+
+namespace DCL.Diagnostics.Tests
+{
+    public class SentryReportHandlerShould
+    {
+        private static readonly SceneShortInfo SCENE_INFO = new (Vector2Int.zero, "kingdom-of-antrom");
+
+        private static Scope NewScope() =>
+            new (new SentryOptions());
+
+        [Test]
+        public void SetFingerprintForJavaScriptExceptionWithSceneAndMultilineMessage()
+        {
+            Scope scope = NewScope();
+            var reportData = new ReportData(ReportCategory.JAVASCRIPT, sceneShortInfo: SCENE_INFO);
+            var exception = new Exception("ReferenceError: applyPartMaterial is not defined\n    at childPart (Script [19]:65573:5)");
+
+            SentryReportHandler.AddSceneJsFingerprint(scope, reportData, exception);
+
+            CollectionAssert.AreEqual(new[] { "scene-js", "kingdom-of-antrom", "ReferenceError: applyPartMaterial is not defined" }, scope.Fingerprint);
+        }
+
+        [Test]
+        public void TrimCarriageReturnFromFirstLineOfWindowsLineEndingMessage()
+        {
+            Scope scope = NewScope();
+            var reportData = new ReportData(ReportCategory.JAVASCRIPT, sceneShortInfo: SCENE_INFO);
+            var exception = new Exception("TypeError: Vector33.Create is not a function\r\n    at updateWarpBall (Script [19]:40371:51)");
+
+            SentryReportHandler.AddSceneJsFingerprint(scope, reportData, exception);
+
+            CollectionAssert.AreEqual(new[] { "scene-js", "kingdom-of-antrom", "TypeError: Vector33.Create is not a function" }, scope.Fingerprint);
+        }
+
+        [Test]
+        public void NotSetFingerprintWhenExceptionIsNull()
+        {
+            Scope scope = NewScope();
+            var reportData = new ReportData(ReportCategory.JAVASCRIPT, sceneShortInfo: SCENE_INFO);
+
+            SentryReportHandler.AddSceneJsFingerprint(scope, reportData, null);
+
+            CollectionAssert.IsEmpty(scope.Fingerprint);
+        }
+
+        [Test]
+        public void NotSetFingerprintWhenExceptionMessageIsEmpty()
+        {
+            Scope scope = NewScope();
+            var reportData = new ReportData(ReportCategory.JAVASCRIPT, sceneShortInfo: SCENE_INFO);
+
+            SentryReportHandler.AddSceneJsFingerprint(scope, reportData, new Exception(string.Empty));
+
+            CollectionAssert.IsEmpty(scope.Fingerprint);
+        }
+
+        [Test]
+        public void NotSetFingerprintForNonJavaScriptCategory()
+        {
+            Scope scope = NewScope();
+            var reportData = new ReportData(ReportCategory.ENGINE, sceneShortInfo: SCENE_INFO);
+
+            SentryReportHandler.AddSceneJsFingerprint(scope, reportData, new Exception("Error: boom"));
+
+            CollectionAssert.IsEmpty(scope.Fingerprint);
+        }
+
+        [Test]
+        public void SetFingerprintWithFallbackSceneNameWhenSceneShortInfoIsMissing()
+        {
+            Scope scope = NewScope();
+
+            // Omitting sceneShortInfo leaves default(SceneShortInfo)'s null Name, the only state that triggers the fallback
+            var reportData = new ReportData(ReportCategory.JAVASCRIPT);
+
+            SentryReportHandler.AddSceneJsFingerprint(scope, reportData, new Exception("Error: boom"));
+
+            CollectionAssert.AreEqual(new[] { "scene-js", "unknown-scene", "Error: boom" }, scope.Fingerprint);
+        }
+    }
+}

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/SentryReportHandlerShould.cs.meta
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/SentryReportHandlerShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5264d710d6834c2a832010a4df5fe2a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/PluginSystem/World/NFTShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/NFTShapePlugin.cs
@@ -77,7 +77,8 @@ namespace DCL.PluginSystem.World
         {
             var buffer = sharedDependencies.EntityEventsBuilder.Rent<NftShapeRendererComponent>();
 
-            bool isKtxEnabled = FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.KTX2_CONVERSION);
+            // A converter content-info result is only meaningful when the native decoder can actually run.
+            bool isKtxEnabled = FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.KTX2_CONVERSION) && KtxNativeSupport.IsSupported;
 
             LoadNFTTypeSystem.InjectToWorld(ref builder, NoCache<NftTypeResult, GetNFTTypeIntention>.INSTANCE, webRequestController, isKtxEnabled, decentralandUrlsSource);
             LoadCycleNftShapeSystem.InjectToWorld(ref builder, new BasedURNSource(decentralandUrlsSource), mediaFactory.CreateForScene(builder.World, sharedDependencies, systemsDependencies.RoomHub, placeholderSource: null));

--- a/Explorer/Assets/DCL/PluginSystem/World/SceneUIPlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/SceneUIPlugin.cs
@@ -98,7 +98,7 @@ namespace DCL.PluginSystem.World
             UIDropdownInstantiationSystem.InjectToWorld(ref builder, componentPoolsRegistry, sharedDependencies.EcsToCRDTWriter, styleFontDefinitions);
             UIDropdownReleaseSystem.InjectToWorld(ref builder, componentPoolsRegistry);
             UIPointerEventsSystem.InjectToWorld(ref builder, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter);
-            UICanvasInformationSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter);
+            UICanvasInformationSystem.InjectToWorld(ref builder, sharedDependencies.EcsToCRDTWriter, uiDocument);
             UIFixPbPointerEventsSystem.InjectToWorld(ref builder);
 
             ResetDirtyFlagSystem<PBUiTransform>.InjectToWorld(ref builder);

--- a/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs
@@ -1,0 +1,143 @@
+using DCL.AvatarRendering.Emotes;
+using DCL.AvatarRendering.Wearables.Components;
+using DCL.AvatarRendering.Wearables.Helpers;
+using DCL.Optimization.PerformanceBudgeting;
+using ECS.StreamableLoading;
+using ECS.StreamableLoading.Common.Components;
+using ECS.StreamableLoading.Textures;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DCL.ResourcesUnloading.Tests
+{
+    /// <summary>
+    ///     Storage Unload must evict entries whose terminal thumbnail result never acquired a
+    ///     refcounted reference (failed/cancelled carry a default <see cref="SpriteData" />),
+    ///     and must release exactly one reference for succeeded thumbnails.
+    /// </summary>
+    public class StorageThumbnailDisposalShould
+    {
+        private const string WEARABLE_URN = "urn:decentraland:matic:collections-v2:0xstoragetest:1";
+        private const string EMOTE_URN = "urn:decentraland:matic:collections-v2:0xstoragetest:2";
+
+        private IReleasablePerformanceBudget budget = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            budget = Substitute.For<IReleasablePerformanceBudget>();
+            budget.TrySpendBudget().Returns(true);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EvictTrimmedWearableWithUnacquiredThumbnail(bool cancelled)
+        {
+            var storage = new TrimmedWearableStorage();
+            ITrimmedWearable wearable = storage.GetOrAddByDTO(TrimmedWearableDto(WEARABLE_URN));
+            wearable.ThumbnailAssetResult = UnacquiredThumbnail(cancelled);
+
+            Assert.DoesNotThrow(() => storage.Unload(budget));
+
+            Assert.That(storage.TryGetElement(WEARABLE_URN, out _), Is.False);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EvictWearableWithUnacquiredThumbnail(bool cancelled)
+        {
+            var storage = new WearableStorage();
+            IWearable wearable = storage.AddWearable(WEARABLE_URN, new Wearable(), qualifiedForUnloading: true);
+            wearable.ThumbnailAssetResult = UnacquiredThumbnail(cancelled);
+
+            Assert.DoesNotThrow(() => storage.Unload(budget));
+
+            Assert.That(storage.TryGetElement(WEARABLE_URN, out _), Is.False);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EvictEmoteWithUnacquiredThumbnail(bool cancelled)
+        {
+            var storage = new MemoryEmotesStorage();
+            IEmote emote = storage.GetOrAddByDTO(EmoteDto(EMOTE_URN));
+            emote.ThumbnailAssetResult = UnacquiredThumbnail(cancelled);
+
+            Assert.DoesNotThrow(() => storage.Unload(budget));
+
+            Assert.That(storage.TryGetElement(EMOTE_URN, out _), Is.False);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EvictTrimmedEmoteWithUnacquiredThumbnail(bool cancelled)
+        {
+            var storage = new TrimmedEmoteStorage();
+            ITrimmedEmote emote = storage.GetOrAddByDTO(TrimmedEmoteDto(EMOTE_URN));
+            emote.ThumbnailAssetResult = UnacquiredThumbnail(cancelled);
+
+            Assert.DoesNotThrow(() => storage.Unload(budget));
+
+            Assert.That(storage.TryGetElement(EMOTE_URN, out _), Is.False);
+        }
+
+        [Test]
+        public void DereferenceSucceededThumbnailExactlyOnceOnUnload()
+        {
+            var trimmedWearableSpy = new RefCountSpy();
+            var trimmedWearableStorage = new TrimmedWearableStorage();
+            trimmedWearableStorage.GetOrAddByDTO(TrimmedWearableDto(WEARABLE_URN)).ThumbnailAssetResult = SucceededThumbnail(trimmedWearableSpy);
+
+            var wearableSpy = new RefCountSpy();
+            var wearableStorage = new WearableStorage();
+            wearableStorage.AddWearable(WEARABLE_URN, new Wearable(), qualifiedForUnloading: true).ThumbnailAssetResult = SucceededThumbnail(wearableSpy);
+
+            var emoteSpy = new RefCountSpy();
+            var emoteStorage = new MemoryEmotesStorage();
+            emoteStorage.GetOrAddByDTO(EmoteDto(EMOTE_URN)).ThumbnailAssetResult = SucceededThumbnail(emoteSpy);
+
+            var trimmedEmoteSpy = new RefCountSpy();
+            var trimmedEmoteStorage = new TrimmedEmoteStorage();
+            trimmedEmoteStorage.GetOrAddByDTO(TrimmedEmoteDto(EMOTE_URN)).ThumbnailAssetResult = SucceededThumbnail(trimmedEmoteSpy);
+
+            trimmedWearableStorage.Unload(budget);
+            wearableStorage.Unload(budget);
+            emoteStorage.Unload(budget);
+            trimmedEmoteStorage.Unload(budget);
+
+            Assert.That(trimmedWearableSpy.Dereferences, Is.EqualTo(1), nameof(TrimmedWearableStorage));
+            Assert.That(wearableSpy.Dereferences, Is.EqualTo(1), nameof(WearableStorage));
+            Assert.That(emoteSpy.Dereferences, Is.EqualTo(1), nameof(MemoryEmotesStorage));
+            Assert.That(trimmedEmoteSpy.Dereferences, Is.EqualTo(1), nameof(TrimmedEmoteStorage));
+        }
+
+        private static StreamableLoadingResult<SpriteData>.WithFallback UnacquiredThumbnail(bool cancelled) =>
+            cancelled
+                ? StreamableLoadingResult<SpriteData>.WithFallback.CancelledResult()
+                : StreamableLoadingResult<SpriteData>.WithFallback.Failed();
+
+        private static StreamableLoadingResult<SpriteData>.WithFallback SucceededThumbnail(RefCountSpy spy) =>
+            new (new SpriteData(spy, null!));
+
+        private static TrimmedWearableDTO TrimmedWearableDto(string urn) =>
+            new () { metadata = new TrimmedWearableDTO.WearableMetadataDto { id = urn } };
+
+        private static TrimmedEmoteDTO TrimmedEmoteDto(string urn) =>
+            new () { metadata = new TrimmedEmoteDTO.EmoteMetadataDto { id = urn } };
+
+        private static EmoteDTO EmoteDto(string urn) =>
+            new () { metadata = new EmoteDTO.EmoteMetadataDto { id = urn } };
+
+        private class RefCountSpy : IStreamableRefCountData
+        {
+            public int Dereferences { get; private set; }
+
+            public void Dereference()
+            {
+                Dereferences++;
+            }
+
+            public void Dispose() { }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs
+++ b/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs
@@ -11,9 +11,8 @@ using NUnit.Framework;
 namespace DCL.ResourcesUnloading.Tests
 {
     /// <summary>
-    ///     Storage Unload must evict entries whose terminal thumbnail result never acquired a
-    ///     refcounted reference (failed/cancelled carry a default <see cref="SpriteData" />),
-    ///     and must release exactly one reference for succeeded thumbnails.
+    ///     Unload must evict entries whose thumbnail never acquired a reference (failed/cancelled carry
+    ///     a default <see cref="SpriteData" />) and release exactly one reference for succeeded thumbnails.
     /// </summary>
     public class StorageThumbnailDisposalShould
     {

--- a/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs.meta
+++ b/Explorer/Assets/DCL/ResourcesUnloading/Tests/StorageThumbnailDisposalShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64652d83fc4d4df893626a58dd5ccc49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UICanvasInformation/UICanvasInformationSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Systems/UICanvasInformation/UICanvasInformationSystem.cs
@@ -10,6 +10,7 @@ using Decentraland.Common;
 using ECS.Abstract;
 using ECS.Groups;
 using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
 {
@@ -18,22 +19,26 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
     public partial class UICanvasInformationSystem : BaseUnityLoopSystem
     {
         private readonly IECSToCRDTWriter ecsToCRDTWriter;
+        private readonly UIDocument canvas;
         private BorderRect interactableArea;
         private int lastViewportResolutionWidth = -1;
-        private int lastScreenRealResolutionWidth = -1;
+        private int lastViewportResolutionHeight = -1;
+        private float lastDevicePixelRatio = -1;
 
         public override void Initialize()
         {
             base.Initialize();
 
             interactableArea = new BorderRect { Bottom = 0, Left = Screen.width * 0.25f, Right = 0, Top = 0 };
+            lastDevicePixelRatio = GetDevicePixelRatio();
 
             WriteToCRDT();
         }
 
-        private UICanvasInformationSystem(World world, IECSToCRDTWriter ecsToCRDTWriter) : base(world)
+        private UICanvasInformationSystem(World world, IECSToCRDTWriter ecsToCRDTWriter, UIDocument canvas) : base(world)
         {
             this.ecsToCRDTWriter = ecsToCRDTWriter;
+            this.canvas = canvas;
         }
 
         protected override void Update(float t)
@@ -50,15 +55,24 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
 
         private void UpdateUICanvasInformationComponent()
         {
-            if (lastViewportResolutionWidth == Screen.width && lastScreenRealResolutionWidth == Screen.mainWindowDisplayInfo.width)
+            float devicePixelRatio = GetDevicePixelRatio();
+
+            if (lastViewportResolutionWidth == Screen.width && lastViewportResolutionHeight == Screen.height && Mathf.Approximately(lastDevicePixelRatio, devicePixelRatio))
                 return;
 
-            lastScreenRealResolutionWidth = Screen.mainWindowDisplayInfo.width;
             lastViewportResolutionWidth = Screen.width;
+            lastViewportResolutionHeight = Screen.height;
+            lastDevicePixelRatio = devicePixelRatio;
 
             interactableArea.Left = Screen.width * 0.25f;
 
             WriteToCRDT();
+        }
+
+        private float GetDevicePixelRatio()
+        {
+            VisualElement root = canvas.rootVisualElement;
+            return root?.panel != null ? root.scaledPixelsPerPoint : 1f;
         }
 
         private void WriteToCRDT()
@@ -68,7 +82,7 @@ namespace DCL.SDKComponents.SceneUI.Systems.UICanvasInformation
                 component.InteractableArea = system.interactableArea;
                 component.Width = Screen.width;
                 component.Height = Screen.height;
-                component.DevicePixelRatio = Screen.mainWindowDisplayInfo.width / (float)Screen.width;
+                component.DevicePixelRatio = system.lastDevicePixelRatio;
             }, SpecialEntitiesID.SCENE_ROOT_ENTITY, this);
         }
     }

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
@@ -1,0 +1,130 @@
+using Arch.Core;
+using Arch.SystemGroups;
+using CRDT;
+using CrdtEcsBridge.Components.Special;
+using CrdtEcsBridge.ECSToCRDTWriter;
+using DCL.ECSComponents;
+using DCL.SDKComponents.SceneUI.Systems.UICanvasInformation;
+using ECS.Groups;
+using ECS.TestSuite;
+using NSubstitute;
+using NUnit.Framework;
+using SceneRunner.Scene;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace DCL.SDKComponents.SceneUI.Tests
+{
+    /// <summary>
+    ///     Pins the contract of PBUiCanvasInformation.DevicePixelRatio: it reports the scene panel's own
+    ///     physical-pixels-per-UI-point density, republished whenever that density or the viewport moves.
+    /// </summary>
+    public class UICanvasInformationSystemShould : UnitySystemTestBase<UICanvasInformationSystem>
+    {
+        /// <summary>Panel scale the system is expected to report verbatim; deliberately not the unattached-panel fallback of 1.</summary>
+        private const float SCENE_PANEL_SCALE = 2.75f;
+
+        /// <summary>Panel scale applied mid-test to move the ratio and trip the dirty check.</summary>
+        private const float RESCALED_SCENE_PANEL_SCALE = 1.5f;
+
+        /// <summary>Tolerance for comparing a reported ratio against the panel scale that produced it.</summary>
+        private const float RATIO_TOLERANCE = 0.001f;
+
+        private readonly List<PBUiCanvasInformation> publishedComponents = new ();
+
+        private IECSToCRDTWriter ecsToCRDTWriter;
+        private GameObject canvasGameObject;
+        private PanelSettings panelSettings;
+        private UIDocument canvas;
+
+        [SetUp]
+        public void SetUp()
+        {
+            publishedComponents.Clear();
+            ecsToCRDTWriter = Substitute.For<IECSToCRDTWriter>();
+
+            // The system never touches the message itself: it hands the writer a static delegate that
+            // fills a rented instance, so the delegate has to be run to observe what would be written.
+            ecsToCRDTWriter
+               .When(x => x.PutMessage(
+                    Arg.Any<Action<PBUiCanvasInformation, UICanvasInformationSystem>>(),
+                    Arg.Any<CRDTEntity>(),
+                    Arg.Any<UICanvasInformationSystem>()))
+               .Do(callInfo =>
+                {
+                    var prepareMessage = callInfo.Arg<Action<PBUiCanvasInformation, UICanvasInformationSystem>>();
+                    var data = callInfo.Arg<UICanvasInformationSystem>();
+                    var component = new PBUiCanvasInformation();
+                    prepareMessage(component, data);
+                    publishedComponents.Add(component);
+                });
+
+            // ConstantPixelSize mirrors the shipped DCLScenePanelSettings.asset (m_ScaleMode: 0).
+            panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
+            panelSettings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            panelSettings.scale = SCENE_PANEL_SCALE;
+
+            canvasGameObject = new GameObject(nameof(UICanvasInformationSystemShould) + "_Canvas");
+            canvas = canvasGameObject.AddComponent<UIDocument>();
+            canvas.panelSettings = panelSettings;
+
+            Assert.That(canvas.rootVisualElement?.panel, Is.Not.Null,
+                "The scene UIDocument must be attached to a live panel, otherwise the system reports its unattached fallback instead of the panel ratio.");
+
+            var builder = new ArchSystemsWorldBuilder<World>(world);
+
+            // SyncedInitializationSystemGroup is a custom group: InjectToWorld throws GroupNotFoundException
+            // unless it is injected first, as production does in ECSWorldFactory.
+            builder.InjectCustomGroup(new SyncedInitializationSystemGroup(Substitute.For<ISceneStateProvider>()));
+            system = UICanvasInformationSystem.InjectToWorld(ref builder, ecsToCRDTWriter, canvas);
+
+            world.Create(new SceneRootComponent());
+        }
+
+        protected override void OnTearDown()
+        {
+            if (canvasGameObject != null)
+                UnityEngine.Object.DestroyImmediate(canvasGameObject);
+
+            if (panelSettings != null)
+                UnityEngine.Object.DestroyImmediate(panelSettings);
+        }
+
+        [Test]
+        public void ReportScenePanelPixelsPerPointAsDevicePixelRatio()
+        {
+            system.Initialize();
+
+            Assert.That(publishedComponents, Is.Not.Empty, "Initialize() must publish a PBUiCanvasInformation via PutMessage.");
+            Assert.That(publishedComponents[0].DevicePixelRatio, Is.EqualTo(SCENE_PANEL_SCALE).Within(RATIO_TOLERANCE));
+        }
+
+        [Test]
+        public void NotRepublishWhenViewportAndPixelsPerPointAreUnchanged()
+        {
+            system.Initialize();
+            system.Update(0);
+
+            int publishedAfterFirstUpdate = publishedComponents.Count;
+            system.Update(0);
+
+            Assert.That(publishedComponents.Count, Is.EqualTo(publishedAfterFirstUpdate), "A tick that changes neither the viewport nor the panel ratio must not republish.");
+        }
+
+        [Test]
+        public void RepublishWhenScenePanelPixelsPerPointChanges()
+        {
+            system.Initialize();
+            system.Update(0);
+
+            int publishedAfterFirstUpdate = publishedComponents.Count;
+            panelSettings.scale = RESCALED_SCENE_PANEL_SCALE;
+            system.Update(0);
+
+            Assert.That(publishedComponents.Count, Is.EqualTo(publishedAfterFirstUpdate + 1));
+            Assert.That(publishedComponents[^1].DevicePixelRatio, Is.EqualTo(RESCALED_SCENE_PANEL_SCALE).Within(RATIO_TOLERANCE));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
@@ -59,14 +59,9 @@ namespace DCL.SDKComponents.SceneUI.Tests
                     publishedComponents.Add(component);
                 });
 
-            // ConstantPixelSize mirrors the shipped DCLScenePanelSettings.asset (m_ScaleMode: 0).
-            panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
-            panelSettings.scaleMode = PanelScaleMode.ConstantPixelSize;
-            panelSettings.scale = SCENE_PANEL_SCALE;
-
             canvasGameObject = new GameObject(nameof(UICanvasInformationSystemShould) + "_Canvas");
             canvas = canvasGameObject.AddComponent<UIDocument>();
-            canvas.panelSettings = panelSettings;
+            AttachNewPanelSettings(SCENE_PANEL_SCALE);
 
             Assert.That(canvas.rootVisualElement?.panel, Is.Not.Null,
                 "The scene UIDocument must be attached to a live panel, otherwise the system reports its unattached fallback instead of the panel ratio.");
@@ -78,6 +73,20 @@ namespace DCL.SDKComponents.SceneUI.Tests
             system = UICanvasInformationSystem.InjectToWorld(ref builder, ecsToCRDTWriter, canvas);
 
             world.Create(new SceneRootComponent());
+        }
+
+        /// <summary>Attaching a fresh PanelSettings applies the scale immediately; mutating scale on a live panel only applies during the player loop, which never runs in these synchronous tests.</summary>
+        private void AttachNewPanelSettings(float scale)
+        {
+            PanelSettings previous = panelSettings;
+
+            panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
+            panelSettings.scaleMode = PanelScaleMode.ConstantPixelSize; // mirrors the shipped DCLScenePanelSettings.asset (m_ScaleMode: 0)
+            panelSettings.scale = scale;
+            canvas.panelSettings = panelSettings;
+
+            if (previous != null)
+                UnityEngine.Object.DestroyImmediate(previous);
         }
 
         protected override void OnTearDown()
@@ -117,7 +126,7 @@ namespace DCL.SDKComponents.SceneUI.Tests
             system.Update(0);
 
             int publishedAfterFirstUpdate = publishedComponents.Count;
-            panelSettings.scale = RESCALED_SCENE_PANEL_SCALE;
+            AttachNewPanelSettings(RESCALED_SCENE_PANEL_SCALE);
             system.Update(0);
 
             Assert.That(publishedComponents.Count, Is.EqualTo(publishedAfterFirstUpdate + 1));

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
@@ -29,7 +29,6 @@ namespace DCL.SDKComponents.SceneUI.Tests
         /// <summary>Panel scale applied mid-test to move the ratio and trip the dirty check.</summary>
         private const float RESCALED_SCENE_PANEL_SCALE = 1.5f;
 
-        /// <summary>Tolerance for comparing a reported ratio against the panel scale that produced it.</summary>
         private const float RATIO_TOLERANCE = 0.001f;
 
         private readonly List<PBUiCanvasInformation> publishedComponents = new ();
@@ -45,8 +44,7 @@ namespace DCL.SDKComponents.SceneUI.Tests
             publishedComponents.Clear();
             ecsToCRDTWriter = Substitute.For<IECSToCRDTWriter>();
 
-            // The system never touches the message itself: it hands the writer a static delegate that
-            // fills a rented instance, so the delegate has to be run to observe what would be written.
+            // PutMessage receives a delegate that fills a rented message; run it to observe what would be written
             ecsToCRDTWriter
                .When(x => x.PutMessage(
                     Arg.Any<Action<PBUiCanvasInformation, UICanvasInformationSystem>>(),
@@ -75,8 +73,7 @@ namespace DCL.SDKComponents.SceneUI.Tests
 
             var builder = new ArchSystemsWorldBuilder<World>(world);
 
-            // SyncedInitializationSystemGroup is a custom group: InjectToWorld throws GroupNotFoundException
-            // unless it is injected first, as production does in ECSWorldFactory.
+            // The custom group must be injected first or InjectToWorld throws GroupNotFoundException
             builder.InjectCustomGroup(new SyncedInitializationSystemGroup(Substitute.For<ISceneStateProvider>()));
             system = UICanvasInformationSystem.InjectToWorld(ref builder, ecsToCRDTWriter, canvas);
 

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs.meta
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 562b128f9cab4ef49d6c7b23fd7a7abf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/SceneLoadingScreens/ISceneTipsProvider.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/ISceneTipsProvider.cs
@@ -1,13 +1,9 @@
-using Cysharp.Threading.Tasks;
-using System.Threading;
-using UnityEngine;
-
 namespace DCL.SceneLoadingScreens
 {
     public interface ISceneTipsProvider
     {
-        // TODO: in the future we may require the parcel coordinate to provide specific scene tips
-        // UniTask<SceneTips> Get(Vector2Int parcelCoord, CancellationToken ct);
-        UniTask<SceneTips> GetAsync(CancellationToken ct);
+        // TODO: in the future we may require the parcel coordinate to provide specific scene tips,
+        // which would make this async again: UniTask<SceneTips> GetAsync(Vector2Int parcelCoord, CancellationToken ct)
+        SceneTips Get();
     }
 }

--- a/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
@@ -34,6 +34,7 @@ namespace DCL.SceneLoadingScreens
         private SceneTips tips;
         private CancellationTokenSource? tipsRotationCancellationToken;
         private CancellationTokenSource? tipsFadeCancellationToken;
+        private bool inputsBlocked;
 
         // IntVariable causes deadlock occasionally.
         // There is a similar issue reported on the forum:https://discussions.unity.com/t/deadlock-freezing-issue-with-localizationsettings-stringdatabase-getlocalizedstring-under-multiple-concurrent-calls-on-mobile/1566794
@@ -127,6 +128,13 @@ namespace DCL.SceneLoadingScreens
             BlockUnwantedInputs();
             SetLoadProgress(0);
             viewInstance!.ClearTips();
+
+            // Fetched synchronously before the view shows, so `tips` is populated on every path
+            // that can reach OnViewClose and the release there needs no emptiness guard.
+            tips = sceneTipsProvider.Get();
+
+            if (tips.Random)
+                tips.Tips.Shuffle();
         }
 
         protected override void OnViewShow()
@@ -146,6 +154,12 @@ namespace DCL.SceneLoadingScreens
         protected override void OnViewClose()
         {
             base.OnViewClose();
+
+            // The blocked inputs must be restored on every close path, so the release runs first,
+            // before any statement that can throw: the fade-out is skipped when the close intent
+            // is cancelled or fails, while OnViewClose is guaranteed by the MVC teardown.
+            UnblockUnwantedInputs();
+
             tipsRotationCancellationToken?.SafeCancelAndDispose();
             tipsFadeCancellationToken?.SafeCancelAndDispose();
 
@@ -159,7 +173,7 @@ namespace DCL.SceneLoadingScreens
 
         protected override async UniTask WaitForCloseIntentAsync(CancellationToken ct)
         {
-            await LoadTipsAsync(ct);
+            await LoadTipsAsync();
 
             ShowTip(currentTip.Value);
 
@@ -203,13 +217,8 @@ namespace DCL.SceneLoadingScreens
             }
         }
 
-        private async UniTask LoadTipsAsync(CancellationToken ct)
+        private async UniTask LoadTipsAsync()
         {
-            tips = await sceneTipsProvider.GetAsync(ct);
-
-            if (tips.Random)
-                tips.Tips.Shuffle();
-
             using var scope = ListPool<UniTask<SceneTips.LoadedTip>>.Get(out var tasks);
             foreach (SceneTips.Tip tip in tips.Tips) tasks.Add(tip.LoadAsync());
             var loaded = await UniTask.WhenAll(tasks!);
@@ -311,11 +320,17 @@ namespace DCL.SceneLoadingScreens
 
         private void BlockUnwantedInputs()
         {
+            if (inputsBlocked) return;
+
+            inputsBlocked = true;
             inputBlock.Disable(InputMapComponent.BLOCK_USER_INPUT);
         }
 
         private void UnblockUnwantedInputs()
         {
+            if (!inputsBlocked) return;
+
+            inputsBlocked = false;
             inputBlock.Enable(InputMapComponent.BLOCK_USER_INPUT);
         }
     }

--- a/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/SceneLoadingScreenController.cs
@@ -129,8 +129,7 @@ namespace DCL.SceneLoadingScreens
             SetLoadProgress(0);
             viewInstance!.ClearTips();
 
-            // Fetched synchronously before the view shows, so `tips` is populated on every path
-            // that can reach OnViewClose and the release there needs no emptiness guard.
+            // Fetched synchronously, so `tips` is populated before the view can show
             tips = sceneTipsProvider.Get();
 
             if (tips.Random)
@@ -155,9 +154,7 @@ namespace DCL.SceneLoadingScreens
         {
             base.OnViewClose();
 
-            // The blocked inputs must be restored on every close path, so the release runs first,
-            // before any statement that can throw: the fade-out is skipped when the close intent
-            // is cancelled or fails, while OnViewClose is guaranteed by the MVC teardown.
+            // Runs first, before any statement that can throw: input must be unblocked on every close path
             UnblockUnwantedInputs();
 
             tipsRotationCancellationToken?.SafeCancelAndDispose();

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Tests/SceneLoadingScreenControllerInputBlockShould.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Tests/SceneLoadingScreenControllerInputBlockShould.cs
@@ -1,0 +1,237 @@
+using Arch.Core;
+using Cysharp.Threading.Tasks;
+using DCL.Audio;
+using DCL.Input;
+using DCL.Input.Component;
+using DCL.Prefs;
+using DCL.Utilities;
+using ECS.Abstract;
+using MVC;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine.Audio;
+using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
+
+namespace DCL.SceneLoadingScreens.Tests
+{
+    /// <summary>
+    ///     Regression coverage for #9502: camera and avatar input stayed permanently blocked after the
+    ///     scene loading screen closed on a cancelled outer token (teleport superseded/aborted mid-load,
+    ///     e.g. spawning into a World via a coordinate link, or a long Alt-Tab stalling the fade).
+    ///     <see cref="InputMapComponent.BlockInput" />/<see cref="InputMapComponent.UnblockInput" /> are
+    ///     refcounted with no external audit or reset, so an acquire in <c>OnBeforeViewShow</c> that is
+    ///     never matched by a release on an abnormal close leaks the block forever - every subsequent
+    ///     "unblock" (e.g. a chat blur) only brings the counter from 2 back to 1, not to 0.
+    ///     See bugreports-early-aug/camera-avatar-locked-after-paste-alttab/{report.md,review.md}.
+    /// </summary>
+    public class SceneLoadingScreenControllerInputBlockShould
+    {
+        private const string VIEW_PREFAB_PATH = "Assets/DCL/SceneLoadingScreens/Assets/SceneLoadingScreen.prefab";
+        private const string AUDIO_MIXER_PATH = "Assets/DCL/Audio/Prefabs/GeneralAudioMixer.mixer";
+
+        private static readonly InputMapComponent.Kind ALL_KINDS = AllKinds();
+        private static readonly InputMapComponent.Kind BLOCKED_BY_LOADING_SCREEN = BlockUserInputMask();
+
+        // SceneLoadingScreenController.UpdateLocalizedTextAsync() is fired via .Forget() from both
+        // OnViewInstantiated and OnViewShow - a detached UniTaskVoid this test never has a handle to
+        // await. In a bare EditMode harness (no active localization catalog) its AsyncOperationHandle
+        // resolves to Failed a few Editor ticks later and logs "cannot load localized text" - unrelated
+        // to the input-block bug under test. Nothing else in the process pumps the Editor loop once a
+        // test's own awaits are done, so without an explicit flush that continuation can resolve
+        // arbitrarily far in the future (another fixture entirely) - past any ignoreFailingMessages
+        // window scoped only to [SetUp]/[TearDown] or even [OneTimeSetUp]/[OneTimeTearDown]. The fix is
+        // two-part: suppress for the whole fixture AND explicitly pump bounded frames at the tail of
+        // each test (FlushDeferredViewLogsAsync) so the log - if it fires at all - fires HERE, while
+        // suppression is still active, instead of leaking into an unrelated later test.
+        private const int FLUSH_FRAME_COUNT = 30;
+
+        private World? world;
+        private SingleInstanceEntity inputMapEntity;
+        private IInputBlock? inputBlock;
+        private SceneLoadingScreenView? viewInstance;
+        private AudioMixerVolumesController? audioMixerVolumesController;
+        private bool originalIgnoreFailingMessages;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // The view's fire-and-forget localized-text refresh is unrelated to the input-block bug
+            // under test and can log in a bare Editor test context (no active localization init) -
+            // including from late async continuations that land between tests, so the suppression
+            // must span the whole fixture, not a single test.
+            originalIgnoreFailingMessages = LogAssert.ignoreFailingMessages;
+            LogAssert.ignoreFailingMessages = true;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            LogAssert.ignoreFailingMessages = originalIgnoreFailingMessages;
+        }
+
+        // Pumps bounded Editor frames so any pending fire-and-forget continuation (see the comment
+        // above FLUSH_FRAME_COUNT) gets a chance to actually resolve and log before this test returns,
+        // rather than resolving later while some unrelated test/fixture is running. Tolerant by design:
+        // the message may fire 0..N times here (or not at all) - LogAssert.ignoreFailingMessages is what
+        // makes that acceptable, not an expectation that it must occur.
+        private static async UniTask FlushDeferredViewLogsAsync()
+        {
+            for (var i = 0; i < FLUSH_FRAME_COUNT; i++)
+                await UniTask.Yield();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            // SceneLoadingScreenController's ctor eagerly constructs a PersistentSetting<int>, which reads
+            // DCLPlayerPrefs.GetInt off the static dclPrefs backing field - never populated in a bare EditMode
+            // test process (RuntimeInitializeOnLoadMethod only fires in Play/Runtime). Inject an in-memory
+            // implementation via reflection, the established pattern for this exact gap (see
+            // ChatReactionRecentsServiceShould/HomeMarkerControllerShould).
+            var dclPrefsField = typeof(DCLPlayerPrefs).GetField("dclPrefs", BindingFlags.NonPublic | BindingFlags.Static);
+            dclPrefsField!.SetValue(null, new InMemoryDCLPlayerPrefs());
+
+            world = World.Create();
+            world.Create(new InputMapComponent(ALL_KINDS));
+            inputMapEntity = world.CacheInputMap();
+            inputBlock = new ECSInputBlock(world);
+
+            var viewPrefab = AssetDatabase.LoadAssetAtPath<SceneLoadingScreenView>(VIEW_PREFAB_PATH);
+            Assert.IsNotNull(viewPrefab, $"Could not load the real loading-screen prefab from {VIEW_PREFAB_PATH}");
+            viewInstance = Object.Instantiate(viewPrefab);
+
+            var audioMixer = AssetDatabase.LoadAssetAtPath<AudioMixer>(AUDIO_MIXER_PATH);
+            Assert.IsNotNull(audioMixer, $"Could not load the real audio mixer from {AUDIO_MIXER_PATH}");
+            audioMixerVolumesController = new AudioMixerVolumesController(audioMixer);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (viewInstance != null)
+                Object.DestroyImmediate(viewInstance.gameObject);
+
+            world!.Dispose();
+
+            // Reset the static field so later tests in the same run aren't left with a stale in-memory
+            // prefs instance (mirrors the reset half of the same established pattern).
+            var dclPrefsField = typeof(DCLPlayerPrefs).GetField("dclPrefs", BindingFlags.NonPublic | BindingFlags.Static);
+            dclPrefsField!.SetValue(null, null);
+        }
+
+        [Test]
+        public async Task ReleaseInputBlockWhenCloseIntentIsCancelledAsync()
+        {
+            // The framework resets LogAssert state at test start, wiping any fixture/SetUp-scoped
+            // suppression - the flag must be raised inside the test body itself.
+            LogAssert.ignoreFailingMessages = true;
+
+            SceneLoadingScreenController controller = CreateController(EmptyTipsProvider());
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // OnBeforeViewShow blocks input unconditionally on every show. The outer token is already
+            // cancelled, so WaitForCloseIntentAsync's "if (!ct.IsCancellationRequested) await FadeOutAsync(ct)"
+            // guard is never entered and the only release the unpatched code has (the last statement of
+            // FadeOutAsync) never runs - this is leak path 1 from report.md ("outer token cancelled").
+            await controller.LaunchViewLifeCycleAsync(new CanvasOrdering(CanvasOrdering.SortingLayer.Overlay, 0), CompletedParams(), cts.Token);
+
+            Assert.That(ActiveKinds(), Is.EqualTo(ALL_KINDS & ~BLOCKED_BY_LOADING_SCREEN),
+                "input should be blocked right after showing the loading screen");
+
+            // The MVC teardown (MVCManager.ShowOverlayAsync's finally) always calls HideViewAsync once the
+            // view has started showing, regardless of whether WaitForCloseIntentAsync threw, was cancelled,
+            // or returned normally - so OnViewClose is guaranteed to run here exactly as it does in production.
+            await ((IController)controller).HideViewAsync(CancellationToken.None);
+
+            Assert.That(ActiveKinds(), Is.EqualTo(ALL_KINDS),
+                "BLOCK_USER_INPUT must be released when the loading screen closes on a cancelled token - " +
+                "unpatched, this leaks +1 on the refcount forever (#9502)");
+
+            // Let the OnViewInstantiated/OnViewShow localized-text refreshes settle before TearDown
+            // destroys viewInstance, so any log they produce fires inside this test, not later.
+            await FlushDeferredViewLogsAsync();
+        }
+
+        [Test]
+        public async Task ReleaseInputBlockWhenClosedWhileSceneIsStillLoadingAsync()
+        {
+            // The framework resets LogAssert state at test start, wiping any fixture/SetUp-scoped
+            // suppression - the flag must be raised inside the test body itself.
+            LogAssert.ignoreFailingMessages = true;
+
+            SceneLoadingScreenController controller = CreateController(EmptyTipsProvider());
+
+            // A load report that never completes keeps WaitForCloseIntentAsync suspended waiting on it,
+            // so the fade-out (the unpatched code's only release) never runs. Deliberately not awaited:
+            // this matches the real MVCManager.ShowOverlayAsync race where the teardown's finally calls
+            // HideViewAsync while the orphaned lifecycle task is still suspended (teleport superseded
+            // mid-load - leak path 2 from report.md).
+            AsyncLoadProcessReport pendingReport = AsyncLoadProcessReport.Create(CancellationToken.None);
+            UniTask launch = controller.LaunchViewLifeCycleAsync(new CanvasOrdering(CanvasOrdering.SortingLayer.Overlay, 0), new SceneLoadingScreenController.Params(pendingReport), CancellationToken.None);
+
+            Assert.That(ActiveKinds(), Is.EqualTo(ALL_KINDS & ~BLOCKED_BY_LOADING_SCREEN),
+                "input should be blocked right after showing the loading screen");
+
+            await ((IController)controller).HideViewAsync(CancellationToken.None);
+
+            Assert.That(ActiveKinds(), Is.EqualTo(ALL_KINDS),
+                "BLOCK_USER_INPUT must be released even when the loading screen closes while the scene " +
+                "is still loading - unpatched, this leaks +1 on the refcount forever (#9502)");
+
+            launch.Forget();
+
+            // Let the OnViewInstantiated/OnViewShow localized-text refreshes settle before TearDown
+            // destroys viewInstance, so any log they produce fires inside this test, not later.
+            await FlushDeferredViewLogsAsync();
+        }
+
+        private static ISceneTipsProvider EmptyTipsProvider()
+        {
+            ISceneTipsProvider tipsProvider = Substitute.For<ISceneTipsProvider>();
+            tipsProvider.Get().Returns(new SceneTips(TimeSpan.Zero, false, new List<SceneTips.Tip>()));
+            return tipsProvider;
+        }
+
+        private SceneLoadingScreenController CreateController(ISceneTipsProvider tipsProvider) =>
+            new (() => viewInstance!, tipsProvider, TimeSpan.Zero, audioMixerVolumesController!, inputBlock!, Substitute.For<IMVCManager>());
+
+        private static SceneLoadingScreenController.Params CompletedParams()
+        {
+            AsyncLoadProcessReport report = AsyncLoadProcessReport.Create(CancellationToken.None);
+            report.SetProgress(1f);
+            return new SceneLoadingScreenController.Params(report);
+        }
+
+        private InputMapComponent.Kind ActiveKinds() =>
+            inputMapEntity.GetInputMapComponent(world!).Active;
+
+        private static InputMapComponent.Kind AllKinds()
+        {
+            InputMapComponent.Kind all = InputMapComponent.Kind.None;
+
+            foreach (InputMapComponent.Kind kind in InputMapComponent.VALUES)
+                all |= kind;
+
+            return all;
+        }
+
+        private static InputMapComponent.Kind BlockUserInputMask()
+        {
+            InputMapComponent.Kind mask = InputMapComponent.Kind.None;
+
+            foreach (InputMapComponent.Kind kind in InputMapComponent.BLOCK_USER_INPUT)
+                mask |= kind;
+
+            return mask;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Tests/SceneLoadingScreenControllerInputBlockShould.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Tests/SceneLoadingScreenControllerInputBlockShould.cs
@@ -22,14 +22,8 @@ using Object = UnityEngine.Object;
 namespace DCL.SceneLoadingScreens.Tests
 {
     /// <summary>
-    ///     Regression coverage for #9502: camera and avatar input stayed permanently blocked after the
-    ///     scene loading screen closed on a cancelled outer token (teleport superseded/aborted mid-load,
-    ///     e.g. spawning into a World via a coordinate link, or a long Alt-Tab stalling the fade).
-    ///     <see cref="InputMapComponent.BlockInput" />/<see cref="InputMapComponent.UnblockInput" /> are
-    ///     refcounted with no external audit or reset, so an acquire in <c>OnBeforeViewShow</c> that is
-    ///     never matched by a release on an abnormal close leaks the block forever - every subsequent
-    ///     "unblock" (e.g. a chat blur) only brings the counter from 2 back to 1, not to 0.
-    ///     See bugreports-early-aug/camera-avatar-locked-after-paste-alttab/{report.md,review.md}.
+    ///     Regression coverage for #9502: the refcounted input block acquired in <c>OnBeforeViewShow</c>
+    ///     leaked forever when the loading screen closed on a cancelled token or mid-load.
     /// </summary>
     public class SceneLoadingScreenControllerInputBlockShould
     {
@@ -39,17 +33,8 @@ namespace DCL.SceneLoadingScreens.Tests
         private static readonly InputMapComponent.Kind ALL_KINDS = AllKinds();
         private static readonly InputMapComponent.Kind BLOCKED_BY_LOADING_SCREEN = BlockUserInputMask();
 
-        // SceneLoadingScreenController.UpdateLocalizedTextAsync() is fired via .Forget() from both
-        // OnViewInstantiated and OnViewShow - a detached UniTaskVoid this test never has a handle to
-        // await. In a bare EditMode harness (no active localization catalog) its AsyncOperationHandle
-        // resolves to Failed a few Editor ticks later and logs "cannot load localized text" - unrelated
-        // to the input-block bug under test. Nothing else in the process pumps the Editor loop once a
-        // test's own awaits are done, so without an explicit flush that continuation can resolve
-        // arbitrarily far in the future (another fixture entirely) - past any ignoreFailingMessages
-        // window scoped only to [SetUp]/[TearDown] or even [OneTimeSetUp]/[OneTimeTearDown]. The fix is
-        // two-part: suppress for the whole fixture AND explicitly pump bounded frames at the tail of
-        // each test (FlushDeferredViewLogsAsync) so the log - if it fires at all - fires HERE, while
-        // suppression is still active, instead of leaking into an unrelated later test.
+        // The view's detached UpdateLocalizedTextAsync().Forget() can log a localization failure several
+        // Editor ticks later; each test pumps this many frames so the log fires while suppression is active.
         private const int FLUSH_FRAME_COUNT = 30;
 
         private World? world;
@@ -62,10 +47,7 @@ namespace DCL.SceneLoadingScreens.Tests
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            // The view's fire-and-forget localized-text refresh is unrelated to the input-block bug
-            // under test and can log in a bare Editor test context (no active localization init) -
-            // including from late async continuations that land between tests, so the suppression
-            // must span the whole fixture, not a single test.
+            // Late fire-and-forget localization logs can land between tests, so suppression spans the whole fixture
             originalIgnoreFailingMessages = LogAssert.ignoreFailingMessages;
             LogAssert.ignoreFailingMessages = true;
         }
@@ -76,11 +58,8 @@ namespace DCL.SceneLoadingScreens.Tests
             LogAssert.ignoreFailingMessages = originalIgnoreFailingMessages;
         }
 
-        // Pumps bounded Editor frames so any pending fire-and-forget continuation (see the comment
-        // above FLUSH_FRAME_COUNT) gets a chance to actually resolve and log before this test returns,
-        // rather than resolving later while some unrelated test/fixture is running. Tolerant by design:
-        // the message may fire 0..N times here (or not at all) - LogAssert.ignoreFailingMessages is what
-        // makes that acceptable, not an expectation that it must occur.
+        // Pumps bounded Editor frames so pending fire-and-forget continuations resolve, and may log,
+        // before the test returns; the log may fire 0..N times here.
         private static async UniTask FlushDeferredViewLogsAsync()
         {
             for (var i = 0; i < FLUSH_FRAME_COUNT; i++)
@@ -90,11 +69,8 @@ namespace DCL.SceneLoadingScreens.Tests
         [SetUp]
         public void SetUp()
         {
-            // SceneLoadingScreenController's ctor eagerly constructs a PersistentSetting<int>, which reads
-            // DCLPlayerPrefs.GetInt off the static dclPrefs backing field - never populated in a bare EditMode
-            // test process (RuntimeInitializeOnLoadMethod only fires in Play/Runtime). Inject an in-memory
-            // implementation via reflection, the established pattern for this exact gap (see
-            // ChatReactionRecentsServiceShould/HomeMarkerControllerShould).
+            // The controller's ctor reads DCLPlayerPrefs, whose static backing field is never populated in
+            // EditMode; inject an in-memory implementation via reflection (same pattern as ChatReactionRecentsServiceShould)
             var dclPrefsField = typeof(DCLPlayerPrefs).GetField("dclPrefs", BindingFlags.NonPublic | BindingFlags.Static);
             dclPrefsField!.SetValue(null, new InMemoryDCLPlayerPrefs());
 
@@ -120,8 +96,7 @@ namespace DCL.SceneLoadingScreens.Tests
 
             world!.Dispose();
 
-            // Reset the static field so later tests in the same run aren't left with a stale in-memory
-            // prefs instance (mirrors the reset half of the same established pattern).
+            // Reset the static field so later tests don't see a stale in-memory prefs instance
             var dclPrefsField = typeof(DCLPlayerPrefs).GetField("dclPrefs", BindingFlags.NonPublic | BindingFlags.Static);
             dclPrefsField!.SetValue(null, null);
         }
@@ -129,8 +104,7 @@ namespace DCL.SceneLoadingScreens.Tests
         [Test]
         public async Task ReleaseInputBlockWhenCloseIntentIsCancelledAsync()
         {
-            // The framework resets LogAssert state at test start, wiping any fixture/SetUp-scoped
-            // suppression - the flag must be raised inside the test body itself.
+            // The framework resets LogAssert state at test start, so the flag must be raised inside the test body
             LogAssert.ignoreFailingMessages = true;
 
             SceneLoadingScreenController controller = CreateController(EmptyTipsProvider());
@@ -138,43 +112,33 @@ namespace DCL.SceneLoadingScreens.Tests
             using var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            // OnBeforeViewShow blocks input unconditionally on every show. The outer token is already
-            // cancelled, so WaitForCloseIntentAsync's "if (!ct.IsCancellationRequested) await FadeOutAsync(ct)"
-            // guard is never entered and the only release the unpatched code has (the last statement of
-            // FadeOutAsync) never runs - this is leak path 1 from report.md ("outer token cancelled").
+            // With the outer token already cancelled, the fade-out (the unpatched code's only release) never runs
             await controller.LaunchViewLifeCycleAsync(new CanvasOrdering(CanvasOrdering.SortingLayer.Overlay, 0), CompletedParams(), cts.Token);
 
             Assert.That(ActiveKinds(), Is.EqualTo(ALL_KINDS & ~BLOCKED_BY_LOADING_SCREEN),
                 "input should be blocked right after showing the loading screen");
 
-            // The MVC teardown (MVCManager.ShowOverlayAsync's finally) always calls HideViewAsync once the
-            // view has started showing, regardless of whether WaitForCloseIntentAsync threw, was cancelled,
-            // or returned normally - so OnViewClose is guaranteed to run here exactly as it does in production.
+            // Mirrors MVCManager.ShowOverlayAsync's finally, which always calls HideViewAsync once the view has shown
             await ((IController)controller).HideViewAsync(CancellationToken.None);
 
             Assert.That(ActiveKinds(), Is.EqualTo(ALL_KINDS),
                 "BLOCK_USER_INPUT must be released when the loading screen closes on a cancelled token - " +
                 "unpatched, this leaks +1 on the refcount forever (#9502)");
 
-            // Let the OnViewInstantiated/OnViewShow localized-text refreshes settle before TearDown
-            // destroys viewInstance, so any log they produce fires inside this test, not later.
+            // Let the fire-and-forget localized-text refreshes settle before TearDown destroys viewInstance
             await FlushDeferredViewLogsAsync();
         }
 
         [Test]
         public async Task ReleaseInputBlockWhenClosedWhileSceneIsStillLoadingAsync()
         {
-            // The framework resets LogAssert state at test start, wiping any fixture/SetUp-scoped
-            // suppression - the flag must be raised inside the test body itself.
+            // The framework resets LogAssert state at test start, so the flag must be raised inside the test body
             LogAssert.ignoreFailingMessages = true;
 
             SceneLoadingScreenController controller = CreateController(EmptyTipsProvider());
 
-            // A load report that never completes keeps WaitForCloseIntentAsync suspended waiting on it,
-            // so the fade-out (the unpatched code's only release) never runs. Deliberately not awaited:
-            // this matches the real MVCManager.ShowOverlayAsync race where the teardown's finally calls
-            // HideViewAsync while the orphaned lifecycle task is still suspended (teleport superseded
-            // mid-load - leak path 2 from report.md).
+            // A never-completing load report keeps WaitForCloseIntentAsync suspended, so the fade-out never runs.
+            // Deliberately not awaited: HideViewAsync races the still-suspended lifecycle task, as in production.
             AsyncLoadProcessReport pendingReport = AsyncLoadProcessReport.Create(CancellationToken.None);
             UniTask launch = controller.LaunchViewLifeCycleAsync(new CanvasOrdering(CanvasOrdering.SortingLayer.Overlay, 0), new SceneLoadingScreenController.Params(pendingReport), CancellationToken.None);
 
@@ -189,8 +153,7 @@ namespace DCL.SceneLoadingScreens.Tests
 
             launch.Forget();
 
-            // Let the OnViewInstantiated/OnViewShow localized-text refreshes settle before TearDown
-            // destroys viewInstance, so any log they produce fires inside this test, not later.
+            // Let the fire-and-forget localized-text refreshes settle before TearDown destroys viewInstance
             await FlushDeferredViewLogsAsync();
         }
 

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Tests/SceneLoadingScreenControllerInputBlockShould.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Tests/SceneLoadingScreenControllerInputBlockShould.cs
@@ -6,6 +6,7 @@ using DCL.Input.Component;
 using DCL.Prefs;
 using DCL.Utilities;
 using ECS.Abstract;
+using ECS.TestSuite;
 using MVC;
 using NSubstitute;
 using NUnit.Framework;
@@ -50,11 +51,17 @@ namespace DCL.SceneLoadingScreens.Tests
             // Late fire-and-forget localization logs can land between tests, so suppression spans the whole fixture
             originalIgnoreFailingMessages = LogAssert.ignoreFailingMessages;
             LogAssert.ignoreFailingMessages = true;
+
+            // OnViewInstantiated reads FeaturesRegistry.Instance (BugReport button gating); the editor
+            // domain may still hold an initialized registry from a play-mode session
+            EcsTestsUtils.TearDownFeaturesRegistry();
+            EcsTestsUtils.SetUpFeaturesRegistry();
         }
 
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
+            EcsTestsUtils.TearDownFeaturesRegistry();
             LogAssert.ignoreFailingMessages = originalIgnoreFailingMessages;
         }
 

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Tests/SceneLoadingScreenControllerInputBlockShould.cs.meta
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Tests/SceneLoadingScreenControllerInputBlockShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab54ba7f2e1542e599339e58c6521c04
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/SceneLoadingScreens/TipsFromFeatureFlagDecorator.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/TipsFromFeatureFlagDecorator.cs
@@ -1,11 +1,9 @@
-using Cysharp.Threading.Tasks;
 using DCL.FeatureFlags;
 using DCL.PerformanceAndDiagnostics.Analytics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Threading;
 
 namespace DCL.SceneLoadingScreens
 {
@@ -30,7 +28,7 @@ namespace DCL.SceneLoadingScreens
             this.legacyTips = legacyTips;
         }
 
-        public async UniTask<SceneTips> GetAsync(CancellationToken ct)
+        public SceneTips Get()
         {
             if (!featureFlagChecked)
             {
@@ -42,7 +40,7 @@ namespace DCL.SceneLoadingScreens
                 featureFlagChecked = true;
             }
 
-            SceneTips originTips = await legacyTips.GetAsync(ct);
+            SceneTips originTips = legacyTips.Get();
 
             if (audienceTipsParseSuccess)
             {

--- a/Explorer/Assets/DCL/SceneLoadingScreens/UnityLocalizationSceneTipsProvider.cs
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/UnityLocalizationSceneTipsProvider.cs
@@ -46,7 +46,7 @@ namespace DCL.SceneLoadingScreens
             fallbackTips = Get(tipsTable, imagesTable, ct);
         }
 
-        public async UniTask<SceneTips> GetAsync(CancellationToken ct) =>
+        public SceneTips Get() =>
 
             // TODO: we will need specific scene tips in the future, but its disabled at the moment
             /*StringTable tipsTable = await tipsDatabase.GetTableAsync($"LoadingSceneTips-{parcelCoord.x},{parcelCoord.y}").Task

--- a/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/CodeConventionTests.cs
@@ -39,6 +39,7 @@ namespace DCL.Tests
         private static readonly string[] WEBGL_THREAD_SAFETY_EXCLUDED_PATHS = {
             "Assets/DCL/Input/UnityInputSystem/DCLInput.cs", // cause it's autogen
             "Assets/Plugins/UUAV/Packages/UUAV/Runtime/UUAVPlayer.cs", // desktop-only native plugin; Interlocked guards FFI callback state and the assembly never targets WebGL
+            "Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs", // desktop-only; SynchronizationContext.Current gates the connect continuation's thread affinity
         };
 
         private static readonly string[] WEB_SOCKETS_EXCLUDED_PATHS = {
@@ -200,6 +201,7 @@ namespace DCL.Tests
                 "Assets/DCL/Infrastructure/Utility/Multithreading/DCLConcurrentDictionary.cs",
                 "Assets/DCL/Infrastructure/Utility/Multithreading/DCLConcurrentBag.cs",
                 "Assets/DCL/Infrastructure/Utility/Multithreading/DCLConcurrentQueue.cs",
+                "Assets/DCL/Infrastructure/Utility/Tests/DCLWebSocketCloseAsyncShould.cs", // test-only SynchronizationContext pump uses BlockingCollection
             };
             ValidateNoForbiddenApiUsed(PATTERN, "Use DCLConcurrent insteat version instead.", ignorePaths);
         }

--- a/Explorer/Assets/DCL/Tests/Editor/DCL.EditMode.Tests.asmdef
+++ b/Explorer/Assets/DCL/Tests/Editor/DCL.EditMode.Tests.asmdef
@@ -88,7 +88,8 @@
         "Collections.Pooled.dll",
         "Thirdweb.dll",
         "Nethereum.Signer.dll",
-        "Arch.SystemGroups.dll"
+        "Arch.SystemGroups.dll",
+        "Sentry.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Explorer/Assets/DCL/Tests/Editor/DCL.EditMode.Tests.asmdef
+++ b/Explorer/Assets/DCL/Tests/Editor/DCL.EditMode.Tests.asmdef
@@ -65,7 +65,8 @@
         "GUID:f254b2009e854709a0ef0022a7ca697c",
         "GUID:4d072b9bce344c9bbcff885117cf1e6f",
         "GUID:d9709898aa920584a8d1613950e6a7f5",
-        "GUID:63cde67b4a5d47449392dfc49fc0c3ed"
+        "GUID:63cde67b4a5d47449392dfc49fc0c3ed",
+        "GUID:1d75b3d8691c845b1a51082e81433dfc"
     ],
     "includePlatforms": [
         "Editor"

--- a/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
+++ b/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
@@ -40,6 +40,12 @@ namespace DCL.Tests.PlayMode.PerformanceTests
             iterationTotalTime = new SampleGroup("Iteration Total Time", SampleUnit.Microsecond);
             iterationDownloadedData = new SampleGroup("Iteration Downloaded Data", SampleUnit.Megabyte);
             reportScope = new MockedReportScope();
+
+            // Benchmarks measure request routing, not machine capability: pinning the probe keeps
+            // SetKTXEnabled(true) deterministic on every machine and keeps the real probe (and any
+            // native-lib console logging) out of the test runner.
+            KtxNativeSupport.Reset();
+            KtxNativeSupport.probeOverride = static () => true;
         }
 
         [OneTimeSetUp]
@@ -59,8 +65,11 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         }
 
         [TearDown]
-        public void TearDown() =>
+        public void TearDown()
+        {
             reportScope?.Dispose();
+            KtxNativeSupport.Reset();
+        }
 
         protected void EnableErrors()
         {

--- a/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
+++ b/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
@@ -41,9 +41,8 @@ namespace DCL.Tests.PlayMode.PerformanceTests
             iterationDownloadedData = new SampleGroup("Iteration Downloaded Data", SampleUnit.Megabyte);
             reportScope = new MockedReportScope();
 
-            // Benchmarks measure request routing, not machine capability: pinning the probe keeps
-            // SetKTXEnabled(true) deterministic on every machine and keeps the real probe (and any
-            // native-lib console logging) out of the test runner.
+            // Pin the probe so SetKTXEnabled(true) is deterministic on every machine and the real
+            // native probe never runs in the test runner
             KtxNativeSupport.Reset();
             KtxNativeSupport.probeOverride = static () => true;
         }

--- a/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
@@ -150,6 +150,10 @@ namespace DCL.UI.DebugMenu
                 HideDebugPanelOwnToggle();
             }
 
+            // Logs pushed from other threads since last frame become visible here; a resulting
+            // LogsUpdated sets shouldRefreshConsole synchronously, so they render this same frame.
+            logsHistory.DrainPendingLogs();
+
             if (shouldRefreshConsole)
             {
                 shouldRefreshConsole = false;

--- a/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
@@ -150,8 +150,7 @@ namespace DCL.UI.DebugMenu
                 HideDebugPanelOwnToggle();
             }
 
-            // Logs pushed from other threads since last frame become visible here; a resulting
-            // LogsUpdated sets shouldRefreshConsole synchronously, so they render this same frame.
+            // Drain before the shouldRefreshConsole check so logs pushed from other threads render this same frame
             logsHistory.DrainPendingLogs();
 
             if (shouldRefreshConsole)

--- a/Explorer/Assets/DCL/UI/DebugMenu/LogHistory/DebugMenuConsoleLogHistory.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/LogHistory/DebugMenuConsoleLogHistory.cs
@@ -4,16 +4,33 @@ using System.Linq;
 
 namespace DCL.UI.DebugMenu.LogHistory
 {
+    /// <summary>
+    ///     <see cref="AddLogMessage" /> is fed from the global log callback and may be invoked from any
+    ///     thread; it only enqueues into a capped pending queue. <see cref="Paused" /> is written on the
+    ///     main thread and read on the logging threads through a volatile field: a toggle racing an
+    ///     enqueue may admit or drop a borderline entry, which is acceptable for a pause toggle. Every
+    ///     other member — the lists, the counters
+    ///     and <see cref="LogsUpdated" /> — is main-thread-only: entries become visible when
+    ///     <see cref="DrainPendingLogs" /> runs on the main thread.
+    /// </summary>
     public class DebugMenuConsoleLogHistory
     {
-        public readonly List<DebugMenuConsoleLogEntry> FilteredLogMessages = new ();
-        public event Action LogsUpdated;
-        public bool Paused { get; set; }
-        public int LogEntryCount => allLogMessages.Count(logEntry => logEntry.Type == LogMessageType.Log);
-        public int ErrorEntryCount => allLogMessages.Count(logEntry => logEntry.Type == LogMessageType.Error);
+        private const int MAX_PENDING_LOGS = 10000;
 
+        public readonly List<DebugMenuConsoleLogEntry> FilteredLogMessages = new ();
+        public event Action? LogsUpdated;
+        public bool Paused { get => paused; set => paused = value; }
+        public int LogEntryCount { get; private set; }
+        public int ErrorEntryCount { get; private set; }
+
+        // volatile so a main-thread toggle becomes visible promptly on the logging threads
+        private volatile bool paused;
+
+        private readonly object pendingLock = new ();
+        private readonly Queue<DebugMenuConsoleLogEntry> pendingLogMessages = new ();
+        private readonly List<DebugMenuConsoleLogEntry> drainBuffer = new ();
         private readonly List<DebugMenuConsoleLogEntry> allLogMessages = new ();
-        private string textFilter;
+        private string? textFilter;
         private bool showErrorEntries = true;
         private bool showLogEntries = true;
 
@@ -21,18 +38,52 @@ namespace DCL.UI.DebugMenu.LogHistory
         {
             if (Paused) return;
 
-            allLogMessages.Add(logEntry);
+            lock (pendingLock)
+            {
+                if (pendingLogMessages.Count == MAX_PENDING_LOGS)
+                    pendingLogMessages.Dequeue();
 
-            if (!KeepAfterFilter(logEntry)) return;
+                pendingLogMessages.Enqueue(logEntry);
+            }
+        }
 
-            FilteredLogMessages.Add(logEntry);
+        public void DrainPendingLogs()
+        {
+            lock (pendingLock)
+            {
+                while (pendingLogMessages.Count > 0)
+                    drainBuffer.Add(pendingLogMessages.Dequeue());
+            }
+
+            if (drainBuffer.Count == 0) return;
+
+            for (var i = 0; i < drainBuffer.Count; i++)
+            {
+                DebugMenuConsoleLogEntry logEntry = drainBuffer[i];
+
+                allLogMessages.Add(logEntry);
+
+                if (logEntry.Type == LogMessageType.Log)
+                    LogEntryCount++;
+                else if (logEntry.Type == LogMessageType.Error)
+                    ErrorEntryCount++;
+
+                if (KeepAfterFilter(logEntry))
+                    FilteredLogMessages.Add(logEntry);
+            }
+
+            drainBuffer.Clear();
             LogsUpdated?.Invoke();
         }
 
         public void ClearLogMessages()
         {
+            lock (pendingLock) { pendingLogMessages.Clear(); }
+
             allLogMessages.Clear();
             FilteredLogMessages.Clear();
+            LogEntryCount = 0;
+            ErrorEntryCount = 0;
             LogsUpdated?.Invoke();
         }
 

--- a/Explorer/Assets/DCL/UI/DebugMenu/LogHistory/DebugMenuConsoleLogHistory.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/LogHistory/DebugMenuConsoleLogHistory.cs
@@ -5,13 +5,8 @@ using System.Linq;
 namespace DCL.UI.DebugMenu.LogHistory
 {
     /// <summary>
-    ///     <see cref="AddLogMessage" /> is fed from the global log callback and may be invoked from any
-    ///     thread; it only enqueues into a capped pending queue. <see cref="Paused" /> is written on the
-    ///     main thread and read on the logging threads through a volatile field: a toggle racing an
-    ///     enqueue may admit or drop a borderline entry, which is acceptable for a pause toggle. Every
-    ///     other member — the lists, the counters
-    ///     and <see cref="LogsUpdated" /> — is main-thread-only: entries become visible when
-    ///     <see cref="DrainPendingLogs" /> runs on the main thread.
+    ///     <see cref="AddLogMessage" /> may run on any thread and only enqueues into a capped pending queue;
+    ///     every other member is main-thread-only, with entries surfacing via <see cref="DrainPendingLogs" />.
     /// </summary>
     public class DebugMenuConsoleLogHistory
     {

--- a/Explorer/Assets/DCL/UI/DebugMenu/Tests/DebugMenuConsoleLogHistoryShould.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/Tests/DebugMenuConsoleLogHistoryShould.cs
@@ -2,13 +2,14 @@ using DCL.UI.DebugMenu.LogHistory;
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Threading;
 
 namespace DCL.UI.DebugMenu.Tests
 {
     [TestFixture]
     public class DebugMenuConsoleLogHistoryShould
     {
-        private DebugMenuConsoleLogHistory logHistory;
+        private DebugMenuConsoleLogHistory logHistory = null!;
 
         [SetUp]
         public void SetUp()
@@ -19,7 +20,109 @@ namespace DCL.UI.DebugMenu.Tests
         [TearDown]
         public void TearDown()
         {
-            logHistory = null;
+            logHistory = null!;
+        }
+
+        [Test]
+        public void AddLogMessage_FromWorkerThread_DoesNotBreakMainThreadEnumeration()
+        {
+            // AddLogMessage is fed by the global Unity log callback, which fires on arbitrary
+            // threads while the main thread reads the counters and enumerates FilteredLogMessages
+            // (ConsolePanelView.Refresh / ListView binding / copy-all).
+            const int ENTRY_COUNT = 50000;
+
+            Exception? mainThreadException = null;
+            Exception? workerException = null;
+
+            var worker = new Thread(() =>
+            {
+                try
+                {
+                    for (var i = 0; i < ENTRY_COUNT; i++)
+                        logHistory.AddLogMessage(new DebugMenuConsoleLogEntry(i % 2 == 0 ? LogMessageType.Log : LogMessageType.Error, "worker entry"));
+                }
+                catch (Exception e) { workerException = e; }
+            });
+
+            worker.Start();
+
+            try
+            {
+                while (worker.IsAlive)
+                {
+                    _ = logHistory.LogEntryCount + logHistory.ErrorEntryCount;
+
+                    foreach (DebugMenuConsoleLogEntry entry in logHistory.FilteredLogMessages)
+                        _ = entry.Type == LogMessageType.Error;
+                }
+            }
+            catch (Exception e) { mainThreadException = e; }
+
+            worker.Join();
+
+            Assert.That(mainThreadException, Is.Null, $"Main-thread read raced a logging-thread AddLogMessage: {mainThreadException}");
+            Assert.That(workerException, Is.Null, $"Logging-thread AddLogMessage threw: {workerException}");
+        }
+
+        [Test]
+        public void AddLogMessage_FromWorkerThread_IsInvisibleUntilDrained()
+        {
+            // Arrange
+            int eventCallCount = 0;
+            logHistory.LogsUpdated += () => eventCallCount++;
+
+            // Act
+            var worker = new Thread(() => logHistory.AddLogMessage(new DebugMenuConsoleLogEntry(LogMessageType.Log, "Worker message")));
+            worker.Start();
+            worker.Join();
+
+            // Assert: nothing surfaces on the ingestion thread
+            Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(0));
+            Assert.That(logHistory.LogEntryCount, Is.EqualTo(0));
+            Assert.That(eventCallCount, Is.EqualTo(0));
+
+            // Act: main thread drains
+            logHistory.DrainPendingLogs();
+
+            // Assert
+            Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(1));
+            Assert.That(logHistory.FilteredLogMessages[0].Message, Does.Contain("Worker message"));
+            Assert.That(logHistory.LogEntryCount, Is.EqualTo(1));
+            Assert.That(eventCallCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void DrainPendingLogs_WithNothingPending_ShouldNotFireEvent()
+        {
+            // Arrange
+            bool eventFired = false;
+            logHistory.LogsUpdated += () => eventFired = true;
+
+            // Act
+            logHistory.DrainPendingLogs();
+
+            // Assert
+            Assert.That(eventFired, Is.False);
+        }
+
+        [Test]
+        public void AddLogMessage_BeyondPendingCap_ShouldDropOldestPendingEntries()
+        {
+            // Arrange: 5 entries beyond the pending cap (10000)
+            const int PENDING_CAP = 10000;
+            const int OVERFLOW = 5;
+
+            for (var i = 0; i < PENDING_CAP + OVERFLOW; i++)
+                logHistory.AddLogMessage(new DebugMenuConsoleLogEntry(LogMessageType.Log, $"entry #{i:D5}"));
+
+            // Act
+            logHistory.DrainPendingLogs();
+
+            // Assert: oldest OVERFLOW entries were dropped, newest survive in order
+            Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(PENDING_CAP));
+            Assert.That(logHistory.LogEntryCount, Is.EqualTo(PENDING_CAP));
+            Assert.That(logHistory.FilteredLogMessages[0].Message, Does.Contain($"entry #{OVERFLOW:D5}"));
+            Assert.That(logHistory.FilteredLogMessages[PENDING_CAP - 1].Message, Does.Contain($"entry #{PENDING_CAP + OVERFLOW - 1:D5}"));
         }
 
         [Test]
@@ -32,6 +135,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             // Act
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(1));
@@ -50,6 +154,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             // Act
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(0));
@@ -68,6 +173,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry1);
             logHistory.AddLogMessage(logEntry2);
             logHistory.AddLogMessage(errorEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.LogEntryCount, Is.EqualTo(2));
@@ -84,6 +190,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             logHistory.AddLogMessage(logEntry);
             logHistory.AddLogMessage(errorEntry);
+            logHistory.DrainPendingLogs();
             logHistory.LogsUpdated += () => eventFired = true;
 
             // Act
@@ -108,6 +215,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry1);
             logHistory.AddLogMessage(logEntry2);
             logHistory.AddLogMessage(logEntry3);
+            logHistory.DrainPendingLogs();
             logHistory.LogsUpdated += () => eventFired = true;
 
             // Act
@@ -128,6 +236,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             logHistory.AddLogMessage(logEntry1);
             logHistory.AddLogMessage(logEntry2);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("TEST", true, true);
@@ -148,6 +257,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry);
             logHistory.AddLogMessage(errorEntry);
             logHistory.AddLogMessage(warningEntry);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("", false, true);
@@ -170,6 +280,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry);
             logHistory.AddLogMessage(errorEntry);
             logHistory.AddLogMessage(warningEntry);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("", true, false);
@@ -192,6 +303,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry1);
             logHistory.AddLogMessage(logEntry2);
             logHistory.AddLogMessage(errorEntry);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("Important", false, true);
@@ -211,6 +323,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             logHistory.AddLogMessage(logEntry);
             logHistory.AddLogMessage(errorEntry);
+            logHistory.DrainPendingLogs();
 
             // Act
             logHistory.ApplyFilter("", true, true);
@@ -220,17 +333,20 @@ namespace DCL.UI.DebugMenu.Tests
         }
 
         [Test]
-        public void LogsUpdated_Event_ShouldFireOnAddLogMessage()
+        public void LogsUpdated_Event_ShouldFireOncePerDrainWithPendingLogs()
         {
             // Arrange
-            var logEntry = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message");
+            var logEntry1 = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message 1");
+            var logEntry2 = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message 2");
             int eventCallCount = 0;
             logHistory.LogsUpdated += () => eventCallCount++;
 
             // Act
-            logHistory.AddLogMessage(logEntry);
+            logHistory.AddLogMessage(logEntry1);
+            logHistory.AddLogMessage(logEntry2);
+            logHistory.DrainPendingLogs();
 
-            // Assert
+            // Assert: a drained batch fires a single update
             Assert.That(eventCallCount, Is.EqualTo(1));
         }
 
@@ -240,6 +356,7 @@ namespace DCL.UI.DebugMenu.Tests
             // Arrange
             var logEntry = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message");
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             int eventCallCount = 0;
             logHistory.LogsUpdated += () => eventCallCount++;
@@ -257,6 +374,7 @@ namespace DCL.UI.DebugMenu.Tests
             // Arrange
             var logEntry = new DebugMenuConsoleLogEntry(LogMessageType.Log, "Test message");
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             int eventCallCount = 0;
             logHistory.LogsUpdated += () => eventCallCount++;
@@ -277,6 +395,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             // Act
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(0));
@@ -292,6 +411,7 @@ namespace DCL.UI.DebugMenu.Tests
 
             // Act
             logHistory.AddLogMessage(logEntry);
+            logHistory.DrainPendingLogs();
 
             // Assert
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(0));

--- a/Explorer/Assets/DCL/UI/DebugMenu/Tests/DebugMenuConsoleLogHistoryShould.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/Tests/DebugMenuConsoleLogHistoryShould.cs
@@ -26,9 +26,8 @@ namespace DCL.UI.DebugMenu.Tests
         [Test]
         public void AddLogMessage_FromWorkerThread_DoesNotBreakMainThreadEnumeration()
         {
-            // AddLogMessage is fed by the global Unity log callback, which fires on arbitrary
-            // threads while the main thread reads the counters and enumerates FilteredLogMessages
-            // (ConsolePanelView.Refresh / ListView binding / copy-all).
+            // The global Unity log callback fires AddLogMessage on arbitrary threads while the main
+            // thread reads the counters and enumerates FilteredLogMessages
             const int ENTRY_COUNT = 50000;
 
             Exception? mainThreadException = null;
@@ -67,24 +66,19 @@ namespace DCL.UI.DebugMenu.Tests
         [Test]
         public void AddLogMessage_FromWorkerThread_IsInvisibleUntilDrained()
         {
-            // Arrange
             int eventCallCount = 0;
             logHistory.LogsUpdated += () => eventCallCount++;
 
-            // Act
             var worker = new Thread(() => logHistory.AddLogMessage(new DebugMenuConsoleLogEntry(LogMessageType.Log, "Worker message")));
             worker.Start();
             worker.Join();
 
-            // Assert: nothing surfaces on the ingestion thread
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(0));
             Assert.That(logHistory.LogEntryCount, Is.EqualTo(0));
             Assert.That(eventCallCount, Is.EqualTo(0));
 
-            // Act: main thread drains
             logHistory.DrainPendingLogs();
 
-            // Assert
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(1));
             Assert.That(logHistory.FilteredLogMessages[0].Message, Does.Contain("Worker message"));
             Assert.That(logHistory.LogEntryCount, Is.EqualTo(1));
@@ -94,31 +88,25 @@ namespace DCL.UI.DebugMenu.Tests
         [Test]
         public void DrainPendingLogs_WithNothingPending_ShouldNotFireEvent()
         {
-            // Arrange
             bool eventFired = false;
             logHistory.LogsUpdated += () => eventFired = true;
 
-            // Act
             logHistory.DrainPendingLogs();
 
-            // Assert
             Assert.That(eventFired, Is.False);
         }
 
         [Test]
         public void AddLogMessage_BeyondPendingCap_ShouldDropOldestPendingEntries()
         {
-            // Arrange: 5 entries beyond the pending cap (10000)
             const int PENDING_CAP = 10000;
             const int OVERFLOW = 5;
 
             for (var i = 0; i < PENDING_CAP + OVERFLOW; i++)
                 logHistory.AddLogMessage(new DebugMenuConsoleLogEntry(LogMessageType.Log, $"entry #{i:D5}"));
 
-            // Act
             logHistory.DrainPendingLogs();
 
-            // Assert: oldest OVERFLOW entries were dropped, newest survive in order
             Assert.That(logHistory.FilteredLogMessages.Count, Is.EqualTo(PENDING_CAP));
             Assert.That(logHistory.LogEntryCount, Is.EqualTo(PENDING_CAP));
             Assert.That(logHistory.FilteredLogMessages[0].Message, Does.Contain($"entry #{OVERFLOW:D5}"));
@@ -346,7 +334,7 @@ namespace DCL.UI.DebugMenu.Tests
             logHistory.AddLogMessage(logEntry2);
             logHistory.DrainPendingLogs();
 
-            // Assert: a drained batch fires a single update
+            // Assert
             Assert.That(eventCallCount, Is.EqualTo(1));
         }
 

--- a/Explorer/Assets/DCL/Web3/Accounts/RustEthereumAccount.cs
+++ b/Explorer/Assets/DCL/Web3/Accounts/RustEthereumAccount.cs
@@ -8,6 +8,8 @@ namespace DCL.Web3.Accounts
 {
     public class RustEthereumAccount : IWeb3Account
     {
+        private const int PRIVATE_KEY_SIZE = 32;
+
         private readonly IWeb3Account verifierAccount;
 
         public Web3Address Address { get; }
@@ -18,12 +20,27 @@ namespace DCL.Web3.Accounts
         {
             verifierAccount = NethereumAccount.CreateForVerifyOnly(key);
 
-            PrivateKey = key.GetPrivateKey().EnsureNotNull();
             Address = new Web3Address(key.GetPublicAddress()!);
-            byte[] bytes = key.GetPrivateKeyAsBytes().EnsureNotNull();
+
+            // secp256k1 private keys are 32-byte big-endian scalars; Nethereum's
+            // GetPrivateKeyAsBytes() returns the scalar unsigned-trimmed, without leading
+            // zero bytes, while RustEthSignServer.Initialize demands exactly 32 bytes.
+            byte[] bytes = LeftPad(key.GetPrivateKeyAsBytes().EnsureNotNull(), PRIVATE_KEY_SIZE);
+            PrivateKey = ToHex(bytes, true);
 
             if (!RustEthSignServer.Initialize(bytes))
                 throw new Exception("Failed to initialize sign server");
+        }
+
+        private static byte[] LeftPad(byte[] value, int size)
+        {
+            if (value.Length == size)
+                return value;
+
+            // Fresh array: the input is cached inside EthECKey and must not be mutated.
+            var padded = new byte[size];
+            Buffer.BlockCopy(value, 0, padded, size - value.Length, value.Length);
+            return padded;
         }
 
         public string Sign(string message) =>

--- a/Explorer/Assets/DCL/Web3/Accounts/RustEthereumAccount.cs
+++ b/Explorer/Assets/DCL/Web3/Accounts/RustEthereumAccount.cs
@@ -22,9 +22,7 @@ namespace DCL.Web3.Accounts
 
             Address = new Web3Address(key.GetPublicAddress()!);
 
-            // secp256k1 private keys are 32-byte big-endian scalars; Nethereum's
-            // GetPrivateKeyAsBytes() returns the scalar unsigned-trimmed, without leading
-            // zero bytes, while RustEthSignServer.Initialize demands exactly 32 bytes.
+            // Nethereum's GetPrivateKeyAsBytes() trims leading zero bytes; RustEthSignServer.Initialize demands exactly 32.
             byte[] bytes = LeftPad(key.GetPrivateKeyAsBytes().EnsureNotNull(), PRIVATE_KEY_SIZE);
             PrivateKey = ToHex(bytes, true);
 
@@ -34,7 +32,7 @@ namespace DCL.Web3.Accounts
 
         private static byte[] LeftPad(byte[] value, int size)
         {
-            if (value.Length == size)
+            if (value.Length >= size)
                 return value;
 
             // Fresh array: the input is cached inside EthECKey and must not be mutated.

--- a/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs
+++ b/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs
@@ -1,0 +1,39 @@
+using DCL.Web3.Abstract;
+using DCL.Web3.Accounts.Factory;
+using Nethereum.Signer;
+using NUnit.Framework;
+
+namespace DCL.Web3.Tests
+{
+    [TestFixture]
+    public class RustEthereumAccountShould
+    {
+        // Scalar with a 0x00 top byte: Nethereum's GetPrivateKeyAsBytes() returns the
+        // scalar unsigned-trimmed, so this key materializes as 31 bytes (~1/256 of keys).
+        private const string LEADING_ZERO_PRIVATE_KEY = "0x0011223344556677889900112233445566778899001122334455667788990011";
+
+        [Test]
+        public void CreateAccountWhenPrivateKeyHasLeadingZeroByte()
+        {
+            var key = new EthECKey(LEADING_ZERO_PRIVATE_KEY);
+            Assume.That(key.GetPrivateKeyAsBytes()!.Length, Is.LessThan(32));
+
+            IWeb3Account account = new Web3AccountFactory().CreateAccount(key);
+
+            Assert.That(account.Address.ToString(), Is.EqualTo(key.GetPublicAddress()).IgnoreCase);
+
+            string signature = account.Sign("hello");
+            Assert.That(account.Verify("hello", signature), Is.True);
+        }
+
+        [Test]
+        public void ExposeCanonicalPaddedPrivateKeyHex()
+        {
+            var key = new EthECKey(LEADING_ZERO_PRIVATE_KEY);
+
+            IWeb3Account account = new Web3AccountFactory().CreateAccount(key);
+
+            Assert.That(account.PrivateKey, Is.EqualTo(LEADING_ZERO_PRIVATE_KEY));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs
+++ b/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs
@@ -8,8 +8,7 @@ namespace DCL.Web3.Tests
     [TestFixture]
     public class RustEthereumAccountShould
     {
-        // Scalar with a 0x00 top byte: Nethereum's GetPrivateKeyAsBytes() returns the
-        // scalar unsigned-trimmed, so this key materializes as 31 bytes (~1/256 of keys).
+        // 0x00 top byte: GetPrivateKeyAsBytes() trims it, so this key materializes as 31 bytes.
         private const string LEADING_ZERO_PRIVATE_KEY = "0x0011223344556677889900112233445566778899001122334455667788990011";
 
         [Test]

--- a/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs.meta
+++ b/Explorer/Assets/DCL/Web3/Tests/RustEthereumAccountShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 500d4d1ce171409e9a0f5cdf21d8319f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
@@ -212,7 +212,9 @@ namespace DCL.WebRequests
             public async UniTask<T?> ExecuteAsync(TRequest request, CancellationToken ct)
             {
                 DownloadHandler downloadHandler = request.UnityWebRequest.downloadHandler;
-                string text = null;
+
+                // Non-null only on the text-based branch; streaming failures rethrow raw
+                string? text = null;
 
                 try
                 {
@@ -266,6 +268,40 @@ namespace DCL.WebRequests
             }
         }
 
+        /// <summary>
+        ///     <see cref="JsonSerializer.Populate(JsonReader, object)" /> resolves the target's contract directly and never
+        ///     consults converters registered for the root type, so a matching root-level converter must be routed manually,
+        ///     receiving <paramref name="target" /> as its existing value to populate in place.
+        /// </summary>
+        /// <remarks>
+        ///     Only <see cref="JsonSerializer.Converters" /> are consulted, matched against the static <typeparamref name="T" />;
+        ///     a matching converter that returns a fresh result instead of filling <paramref name="target" /> throws.
+        /// </remarks>
+        public static void PopulateInto<T>(JsonReader reader, T target, JsonSerializer serializer)
+        {
+            IList<JsonConverter> converters = serializer.Converters;
+
+            for (var i = 0; i < converters.Count; i++)
+            {
+                JsonConverter converter = converters[i];
+
+                if (converter.CanRead && converter.CanConvert(typeof(T)))
+                {
+                    // Converters expect the reader at the value's first token; an empty body has none and is a no-op
+                    if (reader.TokenType == JsonToken.None && !reader.Read())
+                        return;
+
+                    // A null result (e.g. a null token) legitimately leaves the target untouched; anything else must be the target itself or data is silently lost
+                    if (converter.ReadJson(reader, typeof(T), target, serializer) is { } result && !ReferenceEquals(result, target))
+                        throw new JsonSerializationException($"{converter.GetType().Name} did not populate the existing value in place; its result would be discarded.");
+
+                    return;
+                }
+            }
+
+            serializer.Populate(reader, target);
+        }
+
         public struct OverwriteFromJsonAsyncOp<T, TRequest> : IWebRequestOp<TRequest, T> where TRequest: struct, ITypedWebRequest, IGenericDownloadHandlerRequest
         {
             private readonly CreateExceptionOnParseFail? createCustomExceptionOnFailure;
@@ -287,7 +323,9 @@ namespace DCL.WebRequests
             public async UniTask<T?> ExecuteAsync(TRequest request, CancellationToken ct)
             {
                 DownloadHandler downloadHandler = request.UnityWebRequest.downloadHandler;
-                string text = null;
+
+                // Non-null only on the text-based branch; streaming failures rethrow raw
+                string? text = null;
 
                 try
                 {
@@ -322,7 +360,7 @@ namespace DCL.WebRequests
 
                             using var textReader = new StreamReader(stream, Encoding.UTF8);
                             using var jsonReader = new JsonTextReader(textReader);
-                            serializer.Populate(jsonReader, Target);
+                            PopulateInto(jsonReader, Target, serializer);
                         }
                     }
                 }

--- a/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/GenericDownloadHandlerUtils.cs
@@ -269,14 +269,9 @@ namespace DCL.WebRequests
         }
 
         /// <summary>
-        ///     <see cref="JsonSerializer.Populate(JsonReader, object)" /> resolves the target's contract directly and never
-        ///     consults converters registered for the root type, so a matching root-level converter must be routed manually,
-        ///     receiving <paramref name="target" /> as its existing value to populate in place.
+        ///     <see cref="JsonSerializer.Populate(JsonReader, object)" /> never consults root-level converters, so a converter
+        ///     matching <typeparamref name="T" /> is routed manually, receiving <paramref name="target" /> to populate in place.
         /// </summary>
-        /// <remarks>
-        ///     Only <see cref="JsonSerializer.Converters" /> are consulted, matched against the static <typeparamref name="T" />;
-        ///     a matching converter that returns a fresh result instead of filling <paramref name="target" /> throws.
-        /// </remarks>
         public static void PopulateInto<T>(JsonReader reader, T target, JsonSerializer serializer)
         {
             IList<JsonConverter> converters = serializer.Converters;

--- a/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
+++ b/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
@@ -77,7 +77,9 @@ namespace DCL.WebRequests.RequestsHub
 
         public void SetKTXEnabled(bool enabled)
         {
-            ktxEnabled = enabled;
+            // The flag comes from a remote source that cannot know whether this machine can load the
+            // ktx_unity native plugin; short-circuiting keeps the probe lazy while the feature is off.
+            ktxEnabled = enabled && KtxNativeSupport.IsSupported;
         }
     }
 }

--- a/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
+++ b/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
@@ -77,8 +77,7 @@ namespace DCL.WebRequests.RequestsHub
 
         public void SetKTXEnabled(bool enabled)
         {
-            // The flag comes from a remote source that cannot know whether this machine can load the
-            // ktx_unity native plugin; short-circuiting keeps the probe lazy while the feature is off.
+            // The remote flag cannot know whether this machine can load the ktx_unity native plugin; && keeps the probe lazy while off.
             ktxEnabled = enabled && KtxNativeSupport.IsSupported;
         }
     }

--- a/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs
+++ b/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs
@@ -1,0 +1,139 @@
+using DCL.Notifications.Serialization;
+using DCL.NotificationsBus.NotificationTypes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace DCL.WebRequests.Tests
+{
+    public class GenericDownloadHandlerPopulateIntoShould
+    {
+        private const string NOTIFICATIONS_PAYLOAD =
+            "{\"notifications\":[{\"id\":\"n-1\",\"type\":\"events_started\"},{\"id\":\"n-2\",\"type\":\"badge_granted\"}]}";
+
+        private static JsonSerializer NewNotificationsSerializer() =>
+            JsonSerializer.CreateDefault(new JsonSerializerSettings
+            {
+                Converters = new JsonConverter[] { new NotificationJsonDtoConverter(true) },
+            });
+
+        private static void PopulateIntoBuffer(List<INotification> buffer, JsonSerializer serializer)
+        {
+            using var textReader = new StringReader(NOTIFICATIONS_PAYLOAD);
+            using var jsonReader = new JsonTextReader(textReader);
+            GenericDownloadHandlerUtils.PopulateInto(jsonReader, buffer, serializer);
+        }
+
+        [Test]
+        public void RouteRootLevelConverterIntoProvidedBuffer()
+        {
+            var buffer = new List<INotification>();
+            JsonSerializer serializer = NewNotificationsSerializer();
+
+            PopulateIntoBuffer(buffer, serializer);
+
+            Assert.That(buffer.Count, Is.EqualTo(2));
+            Assert.That(buffer[0], Is.InstanceOf<EventStartedNotification>());
+            Assert.That(buffer[1], Is.InstanceOf<BadgeGrantedNotification>());
+            Assert.That(buffer[0].Id, Is.EqualTo("n-1"));
+        }
+
+        [Test]
+        public void NotDuplicateItemsWhenBufferIsClearedBetweenReuses()
+        {
+            var buffer = new List<INotification>();
+            JsonSerializer serializer = NewNotificationsSerializer();
+
+            PopulateIntoBuffer(buffer, serializer);
+            buffer.Clear();
+            PopulateIntoBuffer(buffer, serializer);
+
+            Assert.That(buffer.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void ThrowWhenConverterReturnsFreshInstanceInsteadOfPopulatingTarget()
+        {
+            var buffer = new List<INotification>();
+
+            JsonSerializer serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings
+            {
+                Converters = new JsonConverter[] { new FreshInstanceListConverter() },
+            });
+
+            using var textReader = new StringReader(NOTIFICATIONS_PAYLOAD);
+            using var jsonReader = new JsonTextReader(textReader);
+
+            Assert.Throws<JsonSerializationException>(() => GenericDownloadHandlerUtils.PopulateInto(jsonReader, buffer, serializer));
+        }
+
+        [Test]
+        public void LeaveBufferEmptyOnNullBodyViaConverterNullGuard()
+        {
+            var buffer = new List<INotification>();
+            JsonSerializer serializer = NewNotificationsSerializer();
+
+            using var textReader = new StringReader("null");
+            using var jsonReader = new JsonTextReader(textReader);
+            GenericDownloadHandlerUtils.PopulateInto(jsonReader, buffer, serializer);
+
+            Assert.That(buffer, Is.Empty);
+        }
+
+        [Test]
+        public void LeaveBufferEmptyOnEmptyBody()
+        {
+            var buffer = new List<INotification>();
+            JsonSerializer serializer = NewNotificationsSerializer();
+
+            using var textReader = new StringReader(string.Empty);
+            using var jsonReader = new JsonTextReader(textReader);
+            GenericDownloadHandlerUtils.PopulateInto(jsonReader, buffer, serializer);
+
+            Assert.That(buffer, Is.Empty);
+        }
+
+        [Test]
+        public void FallBackToPopulateWhenNoConverterMatchesRootType()
+        {
+            var target = new PlainDto();
+            JsonSerializer serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings
+            {
+                Converters = new JsonConverter[] { new NotificationJsonDtoConverter(true) },
+            });
+
+            using var textReader = new StringReader("{\"value\":42,\"name\":\"populated\"}");
+            using var jsonReader = new JsonTextReader(textReader);
+            GenericDownloadHandlerUtils.PopulateInto(jsonReader, target, serializer);
+
+            Assert.That(target.value, Is.EqualTo(42));
+            Assert.That(target.name, Is.EqualTo("populated"));
+        }
+
+        // The standard converter shape: allocates a fresh result instead of filling existingValue
+        private class FreshInstanceListConverter : JsonConverter<List<INotification>>
+        {
+            public override List<INotification>? ReadJson(JsonReader reader, Type objectType, List<INotification>? existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                JObject.Load(reader);
+                return new List<INotification>();
+            }
+
+            public override void WriteJson(JsonWriter writer, List<INotification>? value, JsonSerializer serializer) =>
+                throw new NotSupportedException();
+        }
+
+        private class PlainDto
+        {
+            // Field names mirror the JSON wire format
+            // ReSharper disable InconsistentNaming
+            public int value;
+            public string? name;
+
+            // ReSharper restore InconsistentNaming
+        }
+    }
+}

--- a/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs.meta
+++ b/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5b2189c09e6d4c4ab1647eb6a42b58b4
+timeCreated: 1786852140

--- a/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs
+++ b/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs
@@ -1,0 +1,114 @@
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.WebRequests.RequestsHub;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using UnityEngine.Networking;
+
+namespace DCL.WebRequests.Tests
+{
+    // Regression coverage for UNITY-EXPLORER-NQS (#7832): KTX2 conversion is enabled by a remote feature
+    // flag, so a machine whose OS cannot open the ktx_unity native plugin must route texture requests to
+    // the original URL instead of the media converter.
+    public class KtxNativeSupportShould
+    {
+        private const string ORIGINAL_URL = "https://peer.decentraland.org/content/contents/bafytexture";
+        private const string CONVERTER_URL_PREFIX = "https://converter.invalid/convert?url=";
+        private const string CONVERTER_URL_TEMPLATE = CONVERTER_URL_PREFIX + "{0}";
+
+        private IDecentralandUrlsSource urlsSource = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            KtxNativeSupport.Reset();
+
+            urlsSource = Substitute.For<IDecentralandUrlsSource>();
+            urlsSource.TransformUrl(Arg.Any<string>()).Returns(callInfo => callInfo.Arg<string>());
+            urlsSource.Url(DecentralandUrl.MediaConverter).Returns(CONVERTER_URL_TEMPLATE);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            KtxNativeSupport.Reset();
+        }
+
+        [Test]
+        public void RouteToOriginalUrl_WhenKtxNativeUnavailable()
+        {
+            KtxNativeSupport.probeOverride = static () => false;
+
+            var hub = new RequestHub(urlsSource);
+            hub.SetKTXEnabled(true);
+
+            using UnityWebRequest request = CreateTextureRequest(hub);
+
+            Assert.That(request.url, Is.EqualTo(ORIGINAL_URL));
+        }
+
+        [Test]
+        public void RouteToConverter_WhenKtxNativeAvailable()
+        {
+            KtxNativeSupport.probeOverride = static () => true;
+
+            var hub = new RequestHub(urlsSource);
+            hub.SetKTXEnabled(true);
+
+            using UnityWebRequest request = CreateTextureRequest(hub);
+
+            Assert.That(request.url, Does.StartWith(CONVERTER_URL_PREFIX));
+        }
+
+        [Test]
+        public void CacheProbeResult_AcrossReads()
+        {
+            var probeCalls = 0;
+
+            KtxNativeSupport.probeOverride = () =>
+            {
+                probeCalls++;
+                return true;
+            };
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.True);
+            Assert.That(KtxNativeSupport.IsSupported, Is.True);
+            Assert.That(probeCalls, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ReportUnsupported_WhenProbeThrowsDllNotFound()
+        {
+            KtxNativeSupport.probeOverride = static () => throw new DllNotFoundException("ktx_unity");
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.False);
+        }
+
+        [Test]
+        public void ReportUnsupported_WhenProbeThrowsUnexpectedException()
+        {
+            KtxNativeSupport.probeOverride = static () => throw new InvalidOperationException("corrupted install");
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.False);
+        }
+
+        [Test]
+        public void StayUnsupported_AfterRuntimeTrip()
+        {
+            KtxNativeSupport.probeOverride = static () => true;
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.True);
+
+            KtxNativeSupport.MarkUnsupported();
+
+            Assert.That(KtxNativeSupport.IsSupported, Is.False);
+        }
+
+        private static UnityWebRequest CreateTextureRequest(RequestHub hub)
+        {
+            InitializeRequest<GetTextureArguments, GetTextureWebRequest> initialize = hub.RequestDelegateFor<GetTextureArguments, GetTextureWebRequest>();
+            var arguments = new GetTextureArguments(TextureType.Albedo, useKtx: true);
+            return initialize(ORIGINAL_URL, ref arguments).UnityWebRequest;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs
+++ b/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs
@@ -7,9 +7,8 @@ using UnityEngine.Networking;
 
 namespace DCL.WebRequests.Tests
 {
-    // Regression coverage for UNITY-EXPLORER-NQS (#7832): KTX2 conversion is enabled by a remote feature
-    // flag, so a machine whose OS cannot open the ktx_unity native plugin must route texture requests to
-    // the original URL instead of the media converter.
+    // Regression coverage for UNITY-EXPLORER-NQS (#7832): a machine whose OS cannot open the ktx_unity
+    // native plugin must route texture requests to the original URL instead of the media converter.
     public class KtxNativeSupportShould
     {
         private const string ORIGINAL_URL = "https://peer.decentraland.org/content/contents/bafytexture";

--- a/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs.meta
+++ b/Explorer/Assets/DCL/WebRequests/Tests/KtxNativeSupportShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f917208b7cf84094ad62c6b3e2f68425
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -37,7 +37,7 @@ namespace DCL.WebRequests
 
         internal static GetTextureWebRequest Initialize(string url, GetTextureArguments textureArguments, IDecentralandUrlsSource urlsSource, bool ktxEnabled)
         {
-            bool useKtx = textureArguments.UseKtx && ktxEnabled && !WebRequestUtils.IsLocalhost(url);
+            bool useKtx = textureArguments.UseKtx && ktxEnabled && KtxNativeSupport.IsSupported && !WebRequestUtils.IsLocalhost(url);
             string requestUrl = useKtx ? string.Format(urlsSource.Url(DecentralandUrl.MediaConverter), Uri.EscapeDataString(url)) : url;
             UnityWebRequest webRequest = UnityWebRequest.Get(requestUrl);
 
@@ -101,8 +101,16 @@ namespace DCL.WebRequests
 
                 var ktxTexture = new KtxTexture();
 
-                // Open() can throw before allocating native state; keep it outside the try so Dispose only runs once that state exists.
-                var openResult = ktxTexture.Open(bufferWrapped.nativeArray.AsReadOnly());
+                // Open() can throw before allocating native state; keep it outside the try/finally so Dispose only runs once that state exists.
+                ErrorCode openResult;
+
+                try { openResult = ktxTexture.Open(bufferWrapped.nativeArray.AsReadOnly()); }
+                catch (Exception e) when (e is DllNotFoundException or EntryPointNotFoundException)
+                {
+                    // The OS failing to open the native plugin (or resolve a symbol in it) is per-machine-permanent, not transient.
+                    KtxNativeSupport.MarkUnsupported();
+                    throw;
+                }
 
                 try
                 {

--- a/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
@@ -1,0 +1,77 @@
+using DCL.Diagnostics;
+using KtxUnity;
+using System;
+using Unity.Collections;
+
+namespace DCL.WebRequests
+{
+    /// <summary>
+    ///     Local capability check for the ktx_unity native decoder. KTX2 conversion is toggled by a remote feature
+    ///     flag, so machines where the OS cannot open the native plugin (AV quarantine, missing VC++ runtime,
+    ///     corrupted install) must degrade to unconverted texture URLs instead of failing every converted request
+    ///     with <see cref="DllNotFoundException" />.
+    ///     Not thread-safe: all reads and writes are expected on the main thread; a racing double probe is
+    ///     benign (same cached result).
+    /// </summary>
+    public static class KtxNativeSupport
+    {
+        private const int PROBE_BUFFER_SIZE = 16;
+
+        internal static Func<bool>? probeOverride;
+
+        private static bool? isSupported;
+
+        public static bool IsSupported
+        {
+            get
+            {
+                isSupported ??= Probe();
+                return isSupported.Value;
+            }
+        }
+
+        /// <summary>
+        ///     A native load failure observed at runtime is per-machine-permanent: the capability stays off for the
+        ///     rest of the session.
+        /// </summary>
+        internal static void MarkUnsupported()
+        {
+            isSupported = false;
+        }
+
+        internal static void Reset()
+        {
+            isSupported = null;
+            probeOverride = null;
+        }
+
+        private static bool Probe()
+        {
+            try
+            {
+                if (probeOverride != null)
+                    return probeOverride();
+
+                using var probeBuffer = new NativeArray<byte>(PROBE_BUFFER_SIZE, Allocator.Temp);
+                var ktxTexture = new KtxTexture();
+
+                // Garbage input makes Open return an error code without throwing when the native library is
+                // loadable, so the throw below is the only unsupported signal; Dispose must not run if Open threw
+                // because native state only exists once Open returns. The error code is the expected healthy-lib
+                // outcome; the package logs it at Error level only under #if DEBUG (editor and development builds),
+                // where the "KTX error code" line from this deliberate garbage probe is expected and harmless.
+                ktxTexture.Open(probeBuffer.AsReadOnly());
+                ktxTexture.Dispose();
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                // A broken native install can fail in shapes beyond DllNotFound; the probe never throws and
+                // fails closed instead, with the exception type named in the warning to keep it visible.
+                ReportHub.LogWarning(ReportCategory.TEXTURE_WEB_REQUEST, $"ktx_unity probe failed ({e.GetType().Name}: {e.Message}); KTX2 conversion is disabled and textures fall back to unconverted URLs");
+                return false;
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs
@@ -6,12 +6,8 @@ using Unity.Collections;
 namespace DCL.WebRequests
 {
     /// <summary>
-    ///     Local capability check for the ktx_unity native decoder. KTX2 conversion is toggled by a remote feature
-    ///     flag, so machines where the OS cannot open the native plugin (AV quarantine, missing VC++ runtime,
-    ///     corrupted install) must degrade to unconverted texture URLs instead of failing every converted request
-    ///     with <see cref="DllNotFoundException" />.
-    ///     Not thread-safe: all reads and writes are expected on the main thread; a racing double probe is
-    ///     benign (same cached result).
+    ///     Local capability check for the ktx_unity native decoder: machines where the OS cannot open the plugin
+    ///     degrade to unconverted texture URLs. Main-thread only; a racing double probe is benign.
     /// </summary>
     public static class KtxNativeSupport
     {
@@ -31,8 +27,7 @@ namespace DCL.WebRequests
         }
 
         /// <summary>
-        ///     A native load failure observed at runtime is per-machine-permanent: the capability stays off for the
-        ///     rest of the session.
+        ///     A runtime native load failure is per-machine-permanent: the capability stays off for the session.
         /// </summary>
         internal static void MarkUnsupported()
         {
@@ -55,11 +50,7 @@ namespace DCL.WebRequests
                 using var probeBuffer = new NativeArray<byte>(PROBE_BUFFER_SIZE, Allocator.Temp);
                 var ktxTexture = new KtxTexture();
 
-                // Garbage input makes Open return an error code without throwing when the native library is
-                // loadable, so the throw below is the only unsupported signal; Dispose must not run if Open threw
-                // because native state only exists once Open returns. The error code is the expected healthy-lib
-                // outcome; the package logs it at Error level only under #if DEBUG (editor and development builds),
-                // where the "KTX error code" line from this deliberate garbage probe is expected and harmless.
+                // On a healthy lib, garbage input makes Open return an error code without throwing; Dispose must only run after Open succeeds.
                 ktxTexture.Open(probeBuffer.AsReadOnly());
                 ktxTexture.Dispose();
 
@@ -67,8 +58,7 @@ namespace DCL.WebRequests
             }
             catch (Exception e)
             {
-                // A broken native install can fail in shapes beyond DllNotFound; the probe never throws and
-                // fails closed instead, with the exception type named in the warning to keep it visible.
+                // A broken native install can fail in shapes beyond DllNotFound; fail closed on any exception.
                 ReportHub.LogWarning(ReportCategory.TEXTURE_WEB_REQUEST, $"ktx_unity probe failed ({e.GetType().Name}: {e.Message}); KTX2 conversion is disabled and textures fall back to unconverted URLs");
                 return false;
             }

--- a/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs.meta
+++ b/Explorer/Assets/DCL/WebRequests/Texture/KtxNativeSupport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d8e603bf2d342fdaebe70c49bcc8118
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Compounded bugsweep branch (`bugsweep/dataroom-3` → `dev`) that merges the changes from the following PRs, one commit per PR:

**Based on `dev`:**
- #9634 — fix: drop oversized comms scene messages instead of throwing — Fixes #9514
- #9633 — fix: gate scene JS exceptions out of production Sentry during local dev (Sentry UNITY-EXPLORER-P74)
- #9632 — fix: guard CTS double-dispose in LiveKit movement bus and scene runtime (Sentry UNITY-EXPLORER-NQG)
- #9626 — fix: emote play-timeout watchdog never fires, stranding emote intents — Fixes #9485
- #9625 — fix: report scene UI panel's real pixels-per-point as DevicePixelRatio — Fixes #9482
- #9600 — fix: unblock camera/avatar input after paste or Alt-Tab focus loss — Fixes #9502

**Based on `main` (only the PR's own changes were taken):**
- #9790 — fix: retry avatar thumbnail loads after a failed attempt instead of rethrowing forever — Fixes #8891, Fixes #8902
- #9791 — fix: evict corrupt Unity AB cache entries and retry the download once — Fixes #8023
- #9792 — fix: cancel stalled login profile fetch instead of abandoning it (Sentry UNITY-EXPLORER-NRB)
- #9793 — fix: send mention wallet strings, not UserId objects, in chat analytics — Fixes #9738
- #9794 — perf: eliminate per-message topic string alloc in comms receive path — Fixes #9206
- #9795 — fix: release CRDT sync buffer rent slot on failed batches — Fixes #7792
- #9796 — fix: make debug console log ingestion thread-safe via pending queue — Fixes #7907, Fixes #7908, Fixes #9346
- #9798 — perf: pool the off-main-thread EventBus publish continuation — Fixes #9182
- #9799 — fix: keep checked-out GLTF clones alive when AssetPreLoadCache clears — Fixes #9451, Fixes #9531
- #9801 — fix: fall back to unconverted textures when the ktx native decoder cannot load — Fixes #5150, Fixes #7832
- #9802 — fix: dispose never-shown AuthenticationScreenController without NRE (Sentry UNITY-EXPLORER-PC4)
- #9803 — fix: resize map render texture when screen resolution changes — Fixes #9692
- #9804 — perf: remove per-poll List allocation in notifications polling — Fixes #9263
- #9805 — fix: resolve private conversation user state without friends service — Fixes #9447
- #9806 — fix: left-pad private key bytes to 32 before rust sign-server init (Sentry UNITY-EXPLORER-PMW)
- #9807 — fix: discard duplicate scene facade for already-cached parcels and serialize realm changes — Fixes #8720, Fixes #8911
- #9810 — fix: guard thumbnail disposal on Succeeded so failed results don't NRE and abort cache cleanup — Fixes #8884
- #9811 — fix: abandon the parked connect await when an unestablished close aborts (Sentry UNITY-EXPLORER-PNT)

## Test Instructions

### Test Steps

1. **Movement stays unlocked after typing** (#9600): open the chat, paste some text into the input, then close the chat. Also Alt-Tab out and back while the chat input is focused. In both cases you can still walk and move the camera afterwards.
2. **Emotes never get stuck** (#9626): in a scene that plays its own emotes (e.g. the Genesis Plaza fishing minigame), interrupt/finish the scene animation, then open your emote wheel and play your own emotes — they all still work.
3. **Emote/backpack thumbnails recover** (#9790): open the backpack and the emote wheel — all thumbnails load. If one ever fails, closing and reopening the panel loads it instead of leaving a spinner forever.
4. **Chat mentions** (#9793): send a chat message that @mentions another user — the message sends normally with no errors.
5. **Sharp minimap in fullscreen** (#9803): start the client windowed, then switch to fullscreen — the minimap and the map (navmap satellite view) stay sharp instead of turning pixelated.
6. **Scene UI keeps the right size** (#9625): visit a scene with on-screen UI — the UI renders at the correct size, and doesn't resize when the window is moved between monitors with different resolutions.
7. **Changing realms/worlds** (#9807): jump between realms/worlds a few times in quick succession — everything loads normally each time, with no crash or scenes loading twice.
8. **Scene content stays loaded** (#9799): teleport between several scenes and back — scene objects keep loading and none silently disappear.
9. **Debug console under load** (#9796): open the debug console in a busy scene that logs a lot — it updates smoothly with no errors.
10. **Private chats in Creator Hub preview** (#9805): create a local scene in the Creator Hub and preview it (this starts the client in local scene development mode, where the friends system is disabled). Once in, open a private conversation with another user — the chat opens and works with no errors, and the call button correctly shows the user as unavailable instead of wrongly appearing callable.

All remaining changes (#9634, #9633, #9632, #9791, #9792, #9794, #9795, #9798, #9801, #9802, #9804, #9806, #9811) are internal fixes not directly experienceable — a general smoke test (log in, walk around, chat, teleport, quit) validates them.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
