### PR TITLE
feat(urls): allow overriding dcl-lists for fixtures

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -22,6 +22,7 @@ namespace Global.AppArgs
         public const string REALM = "realm";
         public const string COMMS_ADAPTER = "comms-adapter";
         public const string GATEKEEPER_URL = "gatekeeper-url";
+        public const string DCL_LISTS_URL = "dcl-lists-url";
         public const string LOCAL_SCENE = "local-scene";
         public const string POSITION = "position";
         public const string SPAWN_POINT = "spawnpoint";

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -257,6 +257,7 @@ namespace Global.Dynamic
 
             applicationParametersParser.TryGetValue(AppArgsFlags.GATEKEEPER_URL, out string? cliGatekeeperUrl);
             applicationParametersParser.TryGetValue(AppArgsFlags.OPTIMIZED_ASSETS_URL, out string? cliOptimizedAssetsUrl);
+            applicationParametersParser.TryGetValue(AppArgsFlags.DCL_LISTS_URL, out string? cliDclListsUrl);
 
             // local-ab only: the embedded abgen JIT server reads the scene through the preview server's own
             // content endpoints — no SDK-side sidecar or proxy involved. Its base URL becomes the
@@ -277,7 +278,8 @@ namespace Global.Dynamic
                 debugSettings.GatekeeperMode,
                 debugSettings.CustomGatekeeperUrl,
                 cliGatekeeperUrl,
-                cliOptimizedAssetsUrl);
+                cliOptimizedAssetsUrl,
+                cliDclListsUrl);
             DiagnosticInfoUtils.LogEnvironment(decentralandUrlsSource);
 
             splashScreen = await assetsProvisioner.ProvideInstanceAsync(splashScreenRef, ct: ct);

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/DecentralandUrlsSource.cs
@@ -42,6 +42,7 @@ namespace DCL.Browser.DecentralandUrls
         private readonly string decentralandDomain;
         private readonly string? gatekeeperBaseOverride;
         private readonly string? optimizedAssetsBaseOverride;
+        private readonly string? dclListsBaseOverride;
         private readonly bool isTodayEnvironment;
 
         public DecentralandUrlsSource(
@@ -51,7 +52,8 @@ namespace DCL.Browser.DecentralandUrls
             GatekeeperMode gatekeeperMode = GatekeeperMode.Org,
             string customGatekeeperUrl = "",
             string? cliGatekeeperUrl = null,
-            string? cliOptimizedAssetsUrl = null)
+            string? cliOptimizedAssetsUrl = null,
+            string? cliDclListsUrl = null)
         {
             decentralandDomain = environment.ToString()!.ToLower();
             isTodayEnvironment = environment == DecentralandEnvironment.Today;
@@ -60,6 +62,7 @@ namespace DCL.Browser.DecentralandUrls
             gatekeeperBaseOverride = ResolveGatekeeperOverride(gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, out string source);
             ReportHub.Log(ReportCategory.STARTUP, $"Gatekeeper base override: {gatekeeperBaseOverride ?? "(default)"} (source: {source})");
             optimizedAssetsBaseOverride = cliOptimizedAssetsUrl?.TrimEnd('/');
+            dclListsBaseOverride = cliDclListsUrl?.TrimEnd('/');
 
             if (isTodayEnvironment)
             {
@@ -248,7 +251,7 @@ namespace DCL.Browser.DecentralandUrls
                 DecentralandUrl.BuilderApiDtos => $"https://builder-api.decentraland.{ENV}/v1/collections/[COL-ID]/items",
                 DecentralandUrl.BuilderApiContent => $"https://builder-api.decentraland.{ENV}/v1/storage/contents/",
                 DecentralandUrl.BuilderApiNewsletter => $"https://builder-api.decentraland.{ENV}/v1/newsletter",
-                DecentralandUrl.POI => $"https://dcl-lists.decentraland.{ENV}/pois",
+                DecentralandUrl.POI => $"{dclListsBaseOverride ?? $"https://dcl-lists.decentraland.{ENV}"}/pois",
                 DecentralandUrl.Map => $"https://places.decentraland.{ENV}/api/map",
                 DecentralandUrl.ContentModerationReport => $"https://places.decentraland.{ENV}/api/report",
                 DecentralandUrl.Gatekeeper => ResolveGatekeeperBaseUrl($"https://comms-gatekeeper.decentraland.{ENV}"),

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
@@ -95,8 +95,9 @@ namespace DCL.Browser
             GatekeeperMode gatekeeperMode = GatekeeperMode.Org,
             string customGatekeeperUrl = "",
             string? cliGatekeeperUrl = null,
-            string? cliOptimizedAssetsUrl = null)
-            : base(environment, realmData, launchMode, gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, cliOptimizedAssetsUrl)
+            string? cliOptimizedAssetsUrl = null,
+            string? cliDclListsUrl = null)
+            : base(environment, realmData, launchMode, gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, cliOptimizedAssetsUrl, cliDclListsUrl)
         {
             envSupported = SUPPORTED_ENVS.Contains(environment);
 

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -95,6 +95,19 @@ namespace DCL.Browser.DecentralandUrls.Tests
         }
 
         [Test]
+        public void ApplyCliOverrideForDclListsFixture()
+        {
+            InitializeFeatureFlags(optimizedAssets: false);
+            var urlsSource = new DecentralandUrlsSource(
+                DecentralandEnvironment.Org,
+                new IRealmData.Fake(),
+                ILaunchMode.PLAY,
+                cliDclListsUrl: "https://fixture.example.com");
+
+            Assert.AreEqual("https://fixture.example.com/pois", urlsSource.Url(DecentralandUrl.POI));
+        }
+
+        [Test]
         public void ComposeRegistryEndpointsForWearablesWorldsAndProfilesOffTheUnifiedBase()
         {
             InitializeFeatureFlags(optimizedAssets: true, assetBundleFallback: true);

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -118,6 +118,20 @@ For embedded links you will need to place value after `=` sign, instead of space
 
 ---
 
+### `dcl-lists-url`
+**Type:** String (URL)
+**Description:** Overrides the base URL used for dcl-lists requests such as
+the Points of Interest endpoint. This is intended for controlled local and
+end-to-end fixture runs; the production default remains
+`https://dcl-lists.decentraland.{env}`.
+
+**Usage:**
+```bash
+--dcl-lists-url https://fixture.example.com
+```
+
+---
+
 ### `local-scene`
 **Type:** Bool
 **Description:** Enables local scene development mode.


### PR DESCRIPTION
## Summary
- Add `--dcl-lists-url` as an explicit client-side base URL override.
- Wire the override through `MainSceneLoader`, `GatewayUrlsSource`, and `DecentralandUrlsSource`.
- Add URL-source coverage and document the argument.

This lets ephemeral fixtures use their task URL without redirecting the shared `dcl-lists.decentraland.*` hostname.