### PR TITLE
fix: bugsweep week 2026-W33

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/AuthenticationScreenCharacterPreviewController.cs
@@ -87,7 +87,7 @@ namespace DCL.AuthenticationScreenFlow
     [Serializable]
     public class AuthScreenEmotesSettings
     {
-        [field: SerializeField] public string IntroEmoteURN { get; private set; }
-        [field: SerializeField] public string JumpInEmoteURN { get; private set; }
+        [field: SerializeField] public string IntroEmoteURN { get; private set; } = null!;
+        [field: SerializeField] public string JumpInEmoteURN { get; private set; } = null!;
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
@@ -85,7 +85,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             scenesCache.AddPortableExperienceScene(portableExperienceScene, SMART_WEARABLE_ENTITY_ID);
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             Assert.IsNotNull(world.Get<CharacterEmoteComponent>(playerEntity).CurrentEmoteReference);
@@ -96,7 +96,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         public void StopSceneEmoteWhenItsSceneIsNoLongerLoaded()
         {
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             Assert.IsNull(world.Get<CharacterEmoteComponent>(playerEntity).CurrentEmoteReference);
@@ -142,7 +142,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new AvatarShapeComponent { BodyShape = BodyShape.MALE });
 
             for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
-                system!.Update(1f);
+                system.Update(1f);
 
             Assert.IsFalse(world.Has<CharacterEmoteIntent>(strandedEntity),
                 "A CharacterEmoteIntent whose asset never resolves must expire after StreamableLoadingDefaults.TIMEOUT seconds of elapsed play time.");
@@ -170,7 +170,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new AvatarShapeComponent { BodyShape = BodyShape.MALE });
 
             for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
-                system!.Update(1f);
+                system.Update(1f);
 
             Assert.IsTrue(world.Has<CharacterEmoteIntent>(movingEntity),
                 "An intent held back by the movement gate must survive: the avatar is moving, which is not a stuck state.");
@@ -185,7 +185,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             URN emoteUrn = world.Get<CharacterEmoteComponent>(playerEntity).EmoteUrn;
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert: a scene-change cancellation is an interruption, and it survives Reset().
             CharacterEmoteComponent emoteComponent = world.Get<CharacterEmoteComponent>(playerEntity);
@@ -205,7 +205,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             avatarView.IsLegacyAnimationPlaying.Returns(false);
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             CharacterEmoteComponent updated = world.Get<CharacterEmoteComponent>(playerEntity);
@@ -226,7 +226,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             emoteComponent.StopEmote = true;
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             CharacterEmoteComponent updated = world.Get<CharacterEmoteComponent>(playerEntity);

--- a/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
+++ b/Explorer/Assets/DCL/Backpack/CharacterPreview/BackpackCharacterPreviewController.cs
@@ -3,7 +3,6 @@ using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.AvatarRendering.Emotes;
 using DCL.AvatarRendering.Emotes.Equipped;
-using DCL.AvatarRendering.Loading.Components;
 using DCL.AvatarRendering.Wearables.Components;
 using DCL.Backpack.BackpackBus;
 using DCL.CharacterPreview;
@@ -15,7 +14,6 @@ using System.Threading;
 using DCL.Backpack.AvatarSection.Outfits.Commands;
 using UnityEngine;
 using Utility;
-using Random = UnityEngine.Random;
 
 namespace DCL.Backpack.CharacterPreview
 {
@@ -122,7 +120,7 @@ namespace DCL.Backpack.CharacterPreview
 
         private void OnFilterEvent(string? category, AvatarWearableCategoryEnum? categoryEnum, string? searchText)
         {
-            if (categoryEnum is AvatarWearableCategoryEnum c)
+            if (categoryEnum is { } c)
                 inputEventBus.OnChangePreviewFocus(c);
         }
 

--- a/Explorer/Assets/DCL/Backpack/Gifting/GiftingTextIds.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/GiftingTextIds.cs
@@ -5,72 +5,72 @@ namespace DCL.Backpack.Gifting
     public static class GiftingTextIds
     {
         // Footer
-        public const string DefaultInfoMessage =
+        public const string DEFAULT_INFO_MESSAGE =
             "Gifting an item cannot be undone.";
 
-        public const string SelectedItemInfoMessageFormat =
+        public const string SELECTED_ITEM_INFO_MESSAGE_FORMAT =
             "You are about to send <b>{0}</b> to <b>{1}</b>";
 
         // Shared formatting
-        public const string ColoredTextFormat =
+        public const string COLORED_TEXT_FORMAT =
             "<color=#{0}>{1}</color>";
 
         // Transfer in-progress
-        public const string WaitingForWalletMessage =
+        public const string WAITING_FOR_WALLET_MESSAGE =
             "A browser window should open for you to confirm the transaction.";
 
-        public const string WaitingForWalletMessageThirdWeb =
+        public const string WAITING_FOR_WALLET_MESSAGE_THIRD_WEB =
             "A window should open for you to confirm the transaction.";
 
-        public const string PreparingGiftTitle =
+        public const string PREPARING_GIFT_TITLE =
             "Preparing Gift for";
 
-        public const string DefaultStatusMessage =
+        public const string DEFAULT_STATUS_MESSAGE =
             "Processing...";
         
-        public const string GiftSentTextFormat =
+        public const string GIFT_SENT_TEXT_FORMAT =
             "Gift Sent to <color=#{0}>{1}</color>!";
 
         // Aliased from DCL.SharedAPI: this assembly depends on it, so the copy's single
         // definition cannot live here without creating a circular assembly reference.
-        public const string GiftOnItsWayMessage =
+        public const string GIFT_ON_ITS_WAY_MESSAGE =
             GiftReceivedNotification.GIFT_ON_ITS_WAY_MESSAGE;
 
-        public const string GiftReceivedTitleFormat =
-            "<color=#{0}>{1}</color> sent you something! " + GiftOnItsWayMessage;
+        public const string GIFT_RECEIVED_TITLE_FORMAT =
+            "<color=#{0}>{1}</color> sent you something! " + GIFT_ON_ITS_WAY_MESSAGE;
 
-        public const string GiftReceivedSenderTitleFormat =
-            "{0} sent you something! " + GiftOnItsWayMessage;
+        public const string GIFT_RECEIVED_SENDER_TITLE_FORMAT =
+            "{0} sent you something! " + GIFT_ON_ITS_WAY_MESSAGE;
 
-        public const string GiftReceivedFromFormat =
+        public const string GIFT_RECEIVED_FROM_FORMAT =
             "FROM <color=#{0}>{1}</color>";
         
         // Error dialog
-        public const string ErrorDialogTitle =
+        public const string ERROR_DIALOG_TITLE =
             "Something went wrong";
 
-        public const string ErrorDialogCancelText =
+        public const string ERROR_DIALOG_CANCEL_TEXT =
             "CLOSE";
 
-        public const string ErrorDialogConfirmText =
+        public const string ERROR_DIALOG_CONFIRM_TEXT =
             "TRY AGAIN";
 
-        public const string ErrorDialogDescription =
+        public const string ERROR_DIALOG_DESCRIPTION =
             "Your gift wasn't delivered. Please try again or contact Support.";
 
-        public const string ErrorDialogSupportLinkFormat =
+        public const string ERROR_DIALOG_SUPPORT_LINK_FORMAT =
             "<link=\"{0}\"><color=#D5A5E2>Contact Support</color></link>";
 
-        public const string RetryLogMessage =
+        public const string RETRY_LOG_MESSAGE =
             "User clicked RETRY.";
 
-        public const string JustNowMessage =
+        public const string JUST_NOW_MESSAGE =
             "Just now.";
         
-        public const string GiftOpenedTitle =
+        public const string GIFT_OPENED_TITLE =
             "ON ITS WAY TO YOUR BACKPACK";
 
-        public const string GiftLoading =
+        public const string GIFT_LOADING =
             "Loading...";
     }
 }

--- a/Explorer/Assets/DCL/Backpack/Gifting/Notifications/GiftReceivedPopupController.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Notifications/GiftReceivedPopupController.cs
@@ -54,8 +54,8 @@ namespace DCL.Backpack.Gifting.Notifications
 
         protected override void OnViewShow()
         {
-            viewInstance!.SubTitleText.text = GiftingTextIds.GiftOpenedTitle;
-            viewInstance.ItemNameText.text = GiftingTextIds.GiftLoading;
+            viewInstance!.SubTitleText.text = GiftingTextIds.GIFT_OPENED_TITLE;
+            viewInstance.ItemNameText.text = GiftingTextIds.GIFT_LOADING;
             viewInstance.GiftItemView.SetLoading();
 
             lifeCts = new CancellationTokenSource();
@@ -92,7 +92,7 @@ namespace DCL.Backpack.Gifting.Notifications
                 if (profile != null)
                 {
                     string hexColor = ColorUtility.ToHtmlStringRGB(profile.UserNameColor);
-                    viewInstance!.TitleText.text = string.Format(GiftingTextIds.GiftReceivedFromFormat, hexColor, profile.Name);
+                    viewInstance!.TitleText.text = string.Format(GiftingTextIds.GIFT_RECEIVED_FROM_FORMAT, hexColor, profile.Name);
                 }
 
                 if (itemData.HasValue)

--- a/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftSelection/GiftingFooterPresenter.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftSelection/GiftingFooterPresenter.cs
@@ -30,8 +30,8 @@ namespace DCL.Backpack.Gifting.Presenters
             view.SendGiftButton.interactable = isItemSelected;
             view.InfoMessageContainer.SetActive(true);
             view.InfoMessageLabel.text = isItemSelected
-                ? string.Format(GiftingTextIds.SelectedItemInfoMessageFormat, selectedItemName, recipient)
-                : GiftingTextIds.DefaultInfoMessage;
+                ? string.Format(GiftingTextIds.SELECTED_ITEM_INFO_MESSAGE_FORMAT, selectedItemName, recipient)
+                : GiftingTextIds.DEFAULT_INFO_MESSAGE;
         }
 
         public void Dispose()

--- a/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftTransfer/Commands/GiftTransferRequestCommand.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftTransfer/Commands/GiftTransferRequestCommand.cs
@@ -39,8 +39,8 @@ namespace DCL.Backpack.Gifting.Presenters.GiftTransfer.Commands
 
         public string GetWaitingMessage() =>
             web3Provider.IsThirdWebOTP
-                ? GiftingTextIds.WaitingForWalletMessageThirdWeb
-                : GiftingTextIds.WaitingForWalletMessage;
+                ? GiftingTextIds.WAITING_FOR_WALLET_MESSAGE_THIRD_WEB
+                : GiftingTextIds.WAITING_FOR_WALLET_MESSAGE;
 
         public async UniTask<GiftTransferResult> ExecuteAsync(GiftTransferParams data, CancellationToken ct)
         {

--- a/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftTransfer/GiftTransferController.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftTransfer/GiftTransferController.cs
@@ -65,7 +65,7 @@ namespace DCL.Backpack.Gifting.Presenters
                 viewInstance.MarketplaceLink.OnLinkClicked += OnMarketplaceActivityLinkClicked;
 
                 viewInstance.RecipientName.text = string.Format(
-                    GiftingTextIds.ColoredTextFormat,
+                    GiftingTextIds.COLORED_TEXT_FORMAT,
                     inputData.userNameColorHex,
                     inputData.recipientName
                 );
@@ -228,7 +228,7 @@ namespace DCL.Backpack.Gifting.Presenters
             switch (newState)
             {
                 case State.Waiting:
-                    viewInstance.TitleLabel.text = GiftingTextIds.PreparingGiftTitle;
+                    viewInstance.TitleLabel.text = GiftingTextIds.PREPARING_GIFT_TITLE;
                     viewInstance.StatusContainer.SetActive(true);
 
                     if (viewInstance.LongRunningHint != null)
@@ -241,7 +241,7 @@ namespace DCL.Backpack.Gifting.Presenters
         private void SetPhase(GiftTransferPhase phase, string? msg)
         {
             if (viewInstance == null || currentState != State.Waiting) return;
-            viewInstance.StatusText.text = msg ?? GiftingTextIds.DefaultStatusMessage;
+            viewInstance.StatusText.text = msg ?? GiftingTextIds.DEFAULT_STATUS_MESSAGE;
         }
 
         private void RequestClose()
@@ -254,17 +254,17 @@ namespace DCL.Backpack.Gifting.Presenters
             try
             {
                 string supportUrl = decentralandUrlsSource.Url(DecentralandUrl.Support);
-                string supportLink = string.Format(GiftingTextIds.ErrorDialogSupportLinkFormat, supportUrl);
+                string supportLink = string.Format(GiftingTextIds.ERROR_DIALOG_SUPPORT_LINK_FORMAT, supportUrl);
 
                 var dialogParams = new ConfirmationDialogParameter(
-                    GiftingTextIds.ErrorDialogTitle,
-                    GiftingTextIds.ErrorDialogCancelText,
-                    GiftingTextIds.ErrorDialogConfirmText,
+                    GiftingTextIds.ERROR_DIALOG_TITLE,
+                    GiftingTextIds.ERROR_DIALOG_CANCEL_TEXT,
+                    GiftingTextIds.ERROR_DIALOG_CONFIRM_TEXT,
                     viewInstance?.WarningIcon,
                     false,
                     false,
                     null,
-                    GiftingTextIds.ErrorDialogDescription,
+                    GiftingTextIds.ERROR_DIALOG_DESCRIPTION,
                     linkText: supportLink,
                     onLinkClickCallback: LinkCallback,
                     preserveAspect: true
@@ -276,7 +276,7 @@ namespace DCL.Backpack.Gifting.Presenters
 
                 if (result == ConfirmationResult.Confirm)
                 {
-                    ReportHub.Log(ReportCategory.GIFTING, GiftingTextIds.RetryLogMessage);
+                    ReportHub.Log(ReportCategory.GIFTING, GiftingTextIds.RETRY_LOG_MESSAGE);
                     await mvcManager.ShowAsync(IssueCommand(inputData), ct);
                 }
             }

--- a/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftTransferSuccess/GiftTransferSuccessController.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Presenters/GiftTransferSuccess/GiftTransferSuccessController.cs
@@ -27,7 +27,7 @@ namespace DCL.Backpack.Gifting.Presenters
             if (viewInstance != null)
             {
                 viewInstance.GiftSentText.text = string.Format(
-                    GiftingTextIds.GiftSentTextFormat,
+                    GiftingTextIds.GIFT_SENT_TEXT_FORMAT,
                     inputData.UserNameColorHex,
                     inputData.RecipientName
                 );

--- a/Explorer/Assets/DCL/Backpack/Gifting/Tests/UnitTests/GiftReceivedCopyShould.cs
+++ b/Explorer/Assets/DCL/Backpack/Gifting/Tests/UnitTests/GiftReceivedCopyShould.cs
@@ -1,4 +1,3 @@
-using DCL.Backpack.Gifting;
 using DCL.Notifications.NotificationEntry;
 using DCL.NotificationsBus;
 using DCL.NotificationsBus.NotificationTypes;
@@ -61,12 +60,12 @@ namespace DCL.Backpack.Gifting.Tests.UnitTests
         [Test]
         public void StateGiftOpenedPopupSubtitleIsOnItsWay()
         {
-            const string newGiftOpenedTitle = "ON ITS WAY TO YOUR BACKPACK";
+            const string NEW_GIFT_OPENED_TITLE = "ON ITS WAY TO YOUR BACKPACK";
 
-            Assert.That(GiftingTextIds.GiftOpenedTitle, Is.EqualTo(newGiftOpenedTitle),
-                "GiftingTextIds.GiftOpenedTitle (the received-gift popup subtitle) must say the gift is on its way, not that it has already arrived.");
-            Assert.That(GiftingTextIds.GiftOpenedTitle, Is.Not.EqualTo(OLD_GIFT_OPENED_TITLE),
-                "GiftingTextIds.GiftOpenedTitle regressed to the old \"ITEM OPENED\" copy, which - combined with the popup's Open Backpack CTA - implied immediate availability.");
+            Assert.That(GiftingTextIds.GIFT_OPENED_TITLE, Is.EqualTo(NEW_GIFT_OPENED_TITLE),
+                "GiftingTextIds.GIFT_OPENED_TITLE (the received-gift popup subtitle) must say the gift is on its way, not that it has already arrived.");
+            Assert.That(GiftingTextIds.GIFT_OPENED_TITLE, Is.Not.EqualTo(OLD_GIFT_OPENED_TITLE),
+                "GiftingTextIds.GIFT_OPENED_TITLE regressed to the old \"ITEM OPENED\" copy, which - combined with the popup's Open Backpack CTA - implied immediate availability.");
         }
 
         [Test]
@@ -81,11 +80,11 @@ namespace DCL.Backpack.Gifting.Tests.UnitTests
             view.Configure(notification);
 
             string title = view.TitleText.text;
-            const string oldTitle = "0x123456 sent you something!";
+            const string OLD_TITLE = "0x123456 sent you something!";
 
             Assert.That(title, Does.Contain(ON_ITS_WAY_SENTENCE),
                 "GiftToastView.Configure (short-address variant) must tell the recipient the gift is still on its way.");
-            Assert.That(title, Is.Not.EqualTo(oldTitle),
+            Assert.That(title, Is.Not.EqualTo(OLD_TITLE),
                 "GiftToastView.Configure (short-address variant) regressed to the old copy, which implied the gift already arrived.");
         }
 
@@ -97,11 +96,11 @@ namespace DCL.Backpack.Gifting.Tests.UnitTests
             view.UpdateSenderName("Alice", Color.white);
 
             string title = view.TitleText.text;
-            const string oldTitle = "<color=#FFFFFF><b>Alice</b></color> sent you something!";
+            const string OLD_TITLE = "<color=#FFFFFF><b>Alice</b></color> sent you something!";
 
             Assert.That(title, Does.Contain(ON_ITS_WAY_SENTENCE),
                 "GiftToastView.UpdateSenderName (resolved-name variant) must tell the recipient the gift is still on its way.");
-            Assert.That(title, Is.Not.EqualTo(oldTitle),
+            Assert.That(title, Is.Not.EqualTo(OLD_TITLE),
                 "GiftToastView.UpdateSenderName (resolved-name variant) regressed to the old copy, which implied the gift already arrived.");
         }
 
@@ -118,11 +117,11 @@ namespace DCL.Backpack.Gifting.Tests.UnitTests
             view.Configure(notification);
 
             string header = view.HeaderText.text;
-            const string oldHeader = "0x123456 sent you a something!";
+            const string OLD_HEADER = "0x123456 sent you a something!";
 
             Assert.That(header, Does.Contain(ON_ITS_WAY_SENTENCE),
                 "GiftNotificationView.Configure (short-address variant) must tell the recipient the gift is still on its way.");
-            Assert.That(header, Is.Not.EqualTo(oldHeader),
+            Assert.That(header, Is.Not.EqualTo(OLD_HEADER),
                 "GiftNotificationView.Configure (short-address variant) regressed to the old copy, which implied the gift already arrived.");
         }
 
@@ -134,11 +133,11 @@ namespace DCL.Backpack.Gifting.Tests.UnitTests
             view.UpdateSenderName("Alice", Color.white);
 
             string header = view.HeaderText.text;
-            const string oldHeader = "<color=#FFFFFF>Alice</color> sent you something!";
+            const string OLD_HEADER = "<color=#FFFFFF>Alice</color> sent you something!";
 
             Assert.That(header, Does.Contain(ON_ITS_WAY_SENTENCE),
-                "GiftNotificationView.UpdateSenderName (resolved-name variant, GiftingTextIds.GiftReceivedTitleFormat) must tell the recipient the gift is still on its way.");
-            Assert.That(header, Is.Not.EqualTo(oldHeader),
+                "GiftNotificationView.UpdateSenderName (resolved-name variant, GiftingTextIds.GIFT_RECEIVED_TITLE_FORMAT) must tell the recipient the gift is still on its way.");
+            Assert.That(header, Is.Not.EqualTo(OLD_HEADER),
                 "GiftNotificationView.UpdateSenderName (resolved-name variant) regressed to the old copy, which implied the gift already arrived.");
         }
 

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/ChatInputView.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatInput/ChatInputView.cs
@@ -18,52 +18,51 @@ namespace DCL.Chat.ChatInput
         [Serializable]
         public class EmojiContainer
         {
-            [field: SerializeField] internal EmojiPanelConfigurationSO emojiPanelConfiguration { get; private set; }
-            [field: SerializeField] internal EmojiButtonView emojiPanelButton { get; private set; }
-            [field: SerializeField] internal EmojiPanelView emojiPanel { get; private set; }
-            [field: SerializeField] internal AudioClipConfig addEmojiAudio { get; private set; }
-            [field: SerializeField] internal AudioClipConfig openEmojiPanelAudio { get; private set; }
+            [field: SerializeField] internal EmojiPanelConfigurationSO emojiPanelConfiguration { get; private set; } = null!;
+            [field: SerializeField] internal EmojiButtonView emojiPanelButton { get; private set; } = null!;
+            [field: SerializeField] internal EmojiPanelView emojiPanel { get; private set; } = null!;
+            [field: SerializeField] internal AudioClipConfig addEmojiAudio { get; private set; } = null!;
+            [field: SerializeField] internal AudioClipConfig openEmojiPanelAudio { get; private set; } = null!;
 
             [field: SerializeField]
             [field: Tooltip("Space kept between the input field's top edge and the emoji panel's bottom edge.")]
             internal float emojiPanelGap { get; private set; } = 5f;
         }
 
-        [field: SerializeField] public CustomInputField inputField { get; private set; }
-        [field: SerializeField] internal RectTransform pastePopupPosition { get; private set; }
+        [field: SerializeField] public CustomInputField inputField { get; private set; } = null!;
+        [field: SerializeField] internal RectTransform pastePopupPosition { get; private set; } = null!;
 
-        [SerializeField] private GameObject inputFieldContainer;
-        [SerializeField] private LayoutElement layoutElement;
+        [SerializeField] private GameObject inputFieldContainer = null!;
+        [SerializeField] private LayoutElement layoutElement = null!;
 
         [field: Header("Blocked")]
-        [field: SerializeField] internal Button maskButton { get; private set; }
-        [SerializeField] private GameObject maskContainer;
-        [SerializeField] private TMP_Text maskText;
+        [field: SerializeField] internal Button maskButton { get; private set; } = null!;
+        [SerializeField] private GameObject maskContainer = null!;
+        [SerializeField] private TMP_Text maskText = null!;
 
         [Header("Suggestion Panel")]
-        [field: SerializeField] internal InputSuggestionPanelView suggestionPanel { get; private set; }
+        [field: SerializeField] internal InputSuggestionPanelView suggestionPanel { get; private set; } = null!;
 
         [Header("Focus Visuals")]
-        [SerializeField] private GameObject outlineObject;
-        [SerializeField] private GameObject characterCounterObject;
-        [SerializeField] private CharacterCounterView characterCounter;
-        [SerializeField] private GameObject emojiButtonObject;
-        [SerializeField] private Image backgroundImage;
-        [SerializeField] private TextMeshProUGUI inputPlaceholderObject;
+        [SerializeField] private GameObject outlineObject = null!;
+        [SerializeField] private GameObject characterCounterObject = null!;
+        [SerializeField] private CharacterCounterView characterCounter = null!;
+        [SerializeField] private GameObject emojiButtonObject = null!;
+        [SerializeField] private TextMeshProUGUI inputPlaceholderObject = null!;
         [SerializeField] private Color focusedBackgroundColor;
         [SerializeField] private Color unfocusedBackgroundColor;
 
         [field: Header("Emojis")]
-        [field: SerializeField] internal EmojiContainer emojiContainer { get; private set; }
+        [field: SerializeField] internal EmojiContainer emojiContainer { get; private set; } = null!;
 
         [field: Header("Audio")]
-        [field: SerializeField] internal AudioClipConfig chatInputTextAudio { get; private set; }
-        [field: SerializeField] internal AudioClipConfig enterInputAudio { get; private set; }
+        [field: SerializeField] internal AudioClipConfig chatInputTextAudio { get; private set; } = null!;
+        [field: SerializeField] internal AudioClipConfig enterInputAudio { get; private set; } = null!;
 
         [field: Header("Event Bus")]
-        [field: SerializeField] internal ViewEventBus inputEventBus { get; private set; }
+        [field: SerializeField] internal ViewEventBus inputEventBus { get; private set; } = null!;
 
-        private ChatConfig.ChatConfig chatConfig;
+        private ChatConfig.ChatConfig chatConfig = null!;
 
         public void ApplyFocusStyle()
         {
@@ -91,10 +90,10 @@ namespace DCL.Chat.ChatInput
             inputField.DeactivateInputField();
         }
 
-        public void Initialize(ChatConfig.ChatConfig chatConfig, ITextFormatter textFormatter)
+        public void Initialize(ChatConfig.ChatConfig config, ITextFormatter textFormatter)
         {
             characterCounter.SetMaximumLength(inputField.characterLimit);
-            this.chatConfig = chatConfig;
+            chatConfig = config;
             inputField.SetTextFormatter(textFormatter);
         }
 

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Core/ChatReactionsFactory.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Core/ChatReactionsFactory.cs
@@ -11,7 +11,6 @@ using DCL.Friends.UserBlocking;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Multiplayer.Connections.Messaging.Hubs;
 using DCL.Settings.Settings;
-using DCL.Utilities;
 using DCL.Web3.Identities;
 using UnityEngine;
 using Utility;

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Networking/MultiplayerReactionMessageBus.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatReactions/Networking/MultiplayerReactionMessageBus.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading;
-using Cysharp.Threading.Tasks;
 using DCL.Chat.ChatReactions.Configs;
 using DCL.Chat.History;
 using DCL.Chat.MessageBus.Deduplication;
@@ -11,11 +10,9 @@ using DCL.Multiplayer.Connections.Messaging;
 using DCL.Multiplayer.Connections.Messaging.Hubs;
 using DCL.Multiplayer.Connections.Messaging.Pipe;
 using DCL.Multiplayer.Deduplication;
-using DCL.Utilities;
 using DCL.Web3;
 using DCL.Web3.Identities;
 using Decentraland.Kernel.Comms.Rfc4;
-using LiveKit.Proto;
 using UnityEngine;
 using Utility;
 
@@ -108,15 +105,15 @@ namespace DCL.Chat.ChatReactions.Networking
 
             switch (routing.ChannelType)
             {
-                case History.ChatChannel.ChatChannelType.NEARBY:
+                case ChatChannel.ChatChannelType.NEARBY:
                     SendChatReactionTo(emojiIndex, messageId, address, messagePipesHub.IslandPipe());
                     SendChatReactionTo(emojiIndex, messageId, address, messagePipesHub.ScenePipe());
                     break;
-                case History.ChatChannel.ChatChannelType.USER:
+                case ChatChannel.ChatChannelType.USER:
                     SendChatReactionTo(emojiIndex, messageId, address, messagePipesHub.ChatPipe(),
                         topic: routing.ChannelId, recipient: routing.ChannelId);
                     break;
-                case History.ChatChannel.ChatChannelType.COMMUNITY:
+                case ChatChannel.ChatChannelType.COMMUNITY:
                     SendChatReactionTo(emojiIndex, messageId, address, messagePipesHub.ChatPipe(),
                         topic: routing.ChannelId, recipient: routingUser);
                     break;

--- a/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
+++ b/Explorer/Assets/DCL/Chat/_Refactor/ChatServices/UserStateService/PrivateConversationUserStateService.cs
@@ -363,6 +363,8 @@ namespace DCL.Chat.ChatServices
         {
         }
 
+        // Wire format serialized with JsonUtility: field names must match the JSON keys.
+        // ReSharper disable InconsistentNaming
         [Serializable]
         public struct ParticipantPrivacyMetadata
         {

--- a/Explorer/Assets/DCL/EmojiPanel/EmojiPanelView.cs
+++ b/Explorer/Assets/DCL/EmojiPanel/EmojiPanelView.cs
@@ -20,22 +20,22 @@ namespace DCL.Emoji
         public event Action? SearchInputBlurred;
 
         [field: SerializeField]
-        public List<EmojiSectionToggle> EmojiSections { get; private set; }
+        public List<EmojiSectionToggle> EmojiSections { get; private set; } = null!;
 
         [field: SerializeField]
-        public LoopListView2 EmojiLoopList { get; private set; }
+        public LoopListView2 EmojiLoopList { get; private set; } = null!;
 
         [field: SerializeField]
-        public SearchBarView SearchPanelView { get; private set; }
+        public SearchBarView SearchPanelView { get; private set; } = null!;
 
         [field: SerializeField]
-        public EmojiTooltipView TooltipView { get; private set; }
+        public EmojiTooltipView TooltipView { get; private set; } = null!;
 
         [field: SerializeField]
-        public RectMask2D ViewportMask { get; private set; }
+        public RectMask2D ViewportMask { get; private set; } = null!;
 
-        private CanvasGroup canvasGroup;
-        private RectTransform rectTransform;
+        private CanvasGroup canvasGroup = null!;
+        private RectTransform rectTransform = null!;
         private bool isInitialized;
 
         private readonly Vector3[] anchorCorners = new Vector3[4];

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/ClientWebSocketApiImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/ClientWebSocketApiImplementation.cs
@@ -97,7 +97,15 @@ namespace CrdtEcsBridge.JsModulesImplementation
             if (!webSockets.TryGetValue(websocketId, out WebSocketRental webSocket))
                 throw new ArgumentException($"WebSocket with id {websocketId} does not exist.");
 
-            await webSocket.WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, ct);
+            try
+            {
+                await webSocket.WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, ct);
+            }
+            catch (Exception e) when (e is OperationCanceledException or ObjectDisposedException
+                                      || e.InnerException is ObjectDisposedException)
+            {
+                // Expected during scene teardown when Dispose races with a pending close.
+            }
         }
 
         public async UniTask<IWebSocketApi.ReceiveResponse> ReceiveAsync(int websocketId, CancellationToken ct)

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/ClientWebSocketApiImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/ClientWebSocketApiImplementation.cs
@@ -101,10 +101,9 @@ namespace CrdtEcsBridge.JsModulesImplementation
             {
                 await webSocket.WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, ct);
             }
-            catch (Exception e) when (e is OperationCanceledException or ObjectDisposedException
-                                      || e.InnerException is ObjectDisposedException)
+            catch (OperationCanceledException)
             {
-                // Expected during scene teardown when Dispose races with a pending close.
+                // Expected during scene teardown when the close is cancelled mid-flight.
             }
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/ClientWebSocketApiImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/ClientWebSocketApiImplementation.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using Microsoft.ClearScript.JavaScript;
 using Utility.Multithreading;
 using Utility.Networking;
-using Utility;
 
 namespace CrdtEcsBridge.JsModulesImplementation
 {
@@ -279,7 +278,7 @@ namespace CrdtEcsBridge.JsModulesImplementation
 
         private class WebSocketRental : IDisposable
         {
-            public readonly DCLSemaphoreSlim SendLock = new (1, 1);
+            public readonly DCLSemaphoreSlim SendLock = new ();
             public readonly DCLWebSocket WebSocket = new ();
 
             public void Dispose()

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/CleanUpGltfContainerSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Systems/CleanUpGltfContainerSystem.cs
@@ -40,21 +40,21 @@ namespace ECS.Unity.GLTFContainer.Systems
 
         protected override void Update(float t)
         {
-            FinalizeGLTFContainerQuery(World);
+            FinalizeGltfContainerQuery(World);
         }
 
         [Query]
         [All(typeof(DeleteEntityIntention))]
-        private void FinalizeGLTFContainer(ref GltfContainerComponent component)
+        private void FinalizeGltfContainer(ref GltfContainerComponent component)
         {
-            DestroyGLTFContainer(ref component, false);
+            DestroyGltfContainer(ref component, false);
         }
 
         [Query]
         [All(typeof(GltfContainerComponent))]
         private void DestroyWithScenePartition(ref GltfContainerComponent component)
         {
-            DestroyGLTFContainer(ref component, LODUtils.ShouldGoToTheBridge(scenePartition));
+            DestroyGltfContainer(ref component, LODUtils.ShouldGoToTheBridge(scenePartition));
         }
 
         public void FinalizeComponents(in Query query)
@@ -62,7 +62,7 @@ namespace ECS.Unity.GLTFContainer.Systems
             DestroyWithScenePartitionQuery(World);
         }
 
-        private void DestroyGLTFContainer(ref GltfContainerComponent component, bool partitionAllowsBridge)
+        private void DestroyGltfContainer(ref GltfContainerComponent component, bool partitionAllowsBridge)
         {
             if (component.Promise.TryGetResult(World, out StreamableLoadingResult<GltfContainerAsset> result) && result.Succeeded)
             {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/GLTFContainer/Tests/FinalizeGltfContainerLoadingSystemShould.cs
@@ -36,8 +36,8 @@ namespace ECS.Unity.GLTFContainer.Tests
     {
         private readonly GltfContainerTestResources resources = new ();
 
-        private CreateGltfAssetFromAssetBundleSystem createGltfAssetFromAssetBundleSystem;
-        private EntityEventBuffer<GltfContainerComponent> eventBuffer;
+        private CreateGltfAssetFromAssetBundleSystem createGltfAssetFromAssetBundleSystem = null!;
+        private EntityEventBuffer<GltfContainerComponent> eventBuffer = null!;
 
         //Required since all tests invoke TearDown, but not all used resources; therefore it could trigger a negative ref count
         private bool usedResources;
@@ -101,7 +101,7 @@ namespace ECS.Unity.GLTFContainer.Tests
 
             LogAssert.ignoreFailingMessages = true;
 
-            system!.Update(0);
+            system.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
             Assert.That(component.State, Is.EqualTo(LoadingState.FinishedWithError));
@@ -124,7 +124,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             world.Add(component.Promise.Entity, new StreamableLoadingResult<GltfContainerAsset>(asset));
 
             // Without the destroyed-Root guard this throws EcsSystemException (NRE at Root.transform)
-            system!.Update(0);
+            system.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
             Assert.That(component.State, Is.EqualTo(LoadingState.FinishedWithError));
@@ -132,7 +132,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             Assert.That(eventBuffer.Relations, Contains.Item(new EntityRelation<GltfContainerComponent>(e, component)));
 
             // A second update on the consumed promise must be a no-op, not an "already consumed" throw
-            Assert.DoesNotThrow(() => system!.Update(0));
+            Assert.DoesNotThrow(() => system.Update(0));
         }
 
         [Test]
@@ -181,7 +181,7 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.RENDERER_WITH_LEGACY_ANIM_HASH });
             AddTransformToEntity(e);
 
-            system!.Update(0);
+            system.Update(0);
 
             Assert.That(world.Get<GltfContainerComponent>(e).State, Is.EqualTo(LoadingState.Finished));
             Assert.That(asset.Renderers, Is.Not.Empty);
@@ -202,10 +202,10 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH, IsDirty = true });
             AddTransformToEntity(e);
 
-            system!.Update(0);
+            system.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
-            GltfContainerAsset promiseAsset = component.Promise.Result.Value.Asset;
+            GltfContainerAsset promiseAsset = component.Promise.Result!.Value.Asset!;
 
             Assert.That(promiseAsset.DecodedVisibleSDKColliders.Count, Is.EqualTo(196));
             Assert.That(promiseAsset.DecodedVisibleSDKColliders.All(c => c.Collider.gameObject.layer == PhysicsLayers.ON_POINTER_EVENT_LAYER), Is.True);
@@ -226,11 +226,11 @@ namespace ECS.Unity.GLTFContainer.Tests
             Entity e = world.Create(component, new CRDTEntity(100), new PBGltfContainer { Src = GltfContainerTestResources.SCENE_WITH_COLLIDER_HASH });
             AddTransformToEntity(e);
 
-            system!.Update(0);
+            system.Update(0);
 
             component = world.Get<GltfContainerComponent>(e);
 
-            GltfContainerAsset promiseAsset = component.Promise.Result.Value.Asset;
+            GltfContainerAsset promiseAsset = component.Promise.Result!.Value.Asset!;
 
             // 1 Collider
             Assert.That(promiseAsset.InvisibleColliders.All(c => c.IsActiveByEntity), Is.True);

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Common/Systems/LoadSystemBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Common/Systems/LoadSystemBase.cs
@@ -137,7 +137,7 @@ namespace ECS.StreamableLoading.Common.Systems
                 {
                     // If there's an ongoing request for the same intention, piggyback on it
                     if (cache.OngoingRequests.SyncTryGetValue(intentionId,
-                            out UniTaskCompletionSource<OngoingRequestResult<TAsset>>? cachedSource))
+                            out UniTaskCompletionSource<OngoingRequestResult<TAsset>> cachedSource))
                     {
                         ReportHub.Log(ReportCategory.STREAMABLE_LOADING,
                             $"[Cache] Hit (Ongoing Request) for: {intention.CommonArguments.URL}");

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadProviderBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadProviderBase.cs
@@ -105,8 +105,13 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
             // The textures fetching need to finish before the GLTF loading can continue its flow...
             Promise promiseResult = await texturePromise.ToUniTaskAsync(world, cancellationToken: new CancellationToken());
 
+            // Surface the failure through the ITextureDownload contract (Success/Error), like RequestAsync does for the GLTF itself
             if (promiseResult.Result is { Succeeded: false })
-                throw new Exception(GetTextureErrorMessage(promiseResult));
+                return new TextureDownloadResult(null)
+                {
+                    Error = GetTextureErrorMessage(promiseResult),
+                    Success = false,
+                };
 
             return new TextureDownloadResult(promiseResult.Result?.Asset!.EnsureTexture2D())
             {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadProviderBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/GLTF/DownloadProvider/GltFastDownloadProviderBase.cs
@@ -64,7 +64,7 @@ namespace ECS.StreamableLoading.GLTF.DownloadProvider
             byte[] data = Array.Empty<byte>();
             string error = string.Empty;
             string text = string.Empty;
-            bool success = false;
+            bool success;
 
             DownloadHandler? downloadHandler = null;
 

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Tests/LoadSystemBaseIrrecoverableFailureShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/Tests/LoadSystemBaseIrrecoverableFailureShould.cs
@@ -172,7 +172,10 @@ namespace ECS.StreamableLoading.Tests
                 // Stopping the listener aborts a still-pending GetContextAsync with an exception; irrelevant to
                 // the assertions above, just drain it so it doesn't surface as an unobserved task exception.
                 try { await serverTask; }
-                catch (Exception) { }
+                catch (Exception)
+                {
+                    // Ignored: the test only asserts the system state that follows the failure.
+                }
             }
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
@@ -38,13 +38,13 @@ namespace Global.Dynamic
 {
     public class BootstrapContainer : DCLGlobalContainer<BootstrapSettings>
     {
-        private IReportsHandlingSettings reportHandlingSettings;
+        private IReportsHandlingSettings reportHandlingSettings = null!;
 
         public bool EnableAnalytics => Analytics.Enabled;
-        public DiagnosticsContainer DiagnosticsContainer { get; private set; }
-        public IDecentralandUrlsSource DecentralandUrlsSource { get; private set; }
-        public UnityAppWebBrowser WebBrowser { get; private set; }
-        public IWeb3AccountFactory Web3AccountFactory { get; private set; }
+        public DiagnosticsContainer DiagnosticsContainer { get; private set; } = null!;
+        public IDecentralandUrlsSource DecentralandUrlsSource { get; private set; } = null!;
+        public UnityAppWebBrowser WebBrowser { get; private set; } = null!;
+        public IWeb3AccountFactory Web3AccountFactory { get; private set; } = null!;
         public IAssetsProvisioner? AssetsProvisioner { get; private init; }
         public IBootstrap? Bootstrap { get; private set; }
         public IWeb3IdentityCache? IdentityCache { get; private set; }
@@ -53,12 +53,12 @@ namespace Global.Dynamic
 
         // The auth request id this instance's login flow is waiting a signin deep link for (null when not logging in).
         public ReactiveProperty<string?> DeeplinkLoginAwaitingSigninRequestId { get; } = new (null);
-        public AnalyticsContainer Analytics { get; private set; }
-        public DebugSettings.DebugSettings DebugSettings { get; private set; }
-        public VolumeBus VolumeBus { get; private set; }
+        public AnalyticsContainer Analytics { get; private set; } = null!;
+        public DebugSettings.DebugSettings DebugSettings { get; private set; } = null!;
+        public VolumeBus VolumeBus { get; private set; } = null!;
         public IReportsHandlingSettings ReportHandlingSettings => reportHandlingSettings;
-        public IAppArgs AppArgs { get; private set; }
-        public ILaunchMode LaunchMode { get; private set; }
+        public IAppArgs AppArgs { get; private set; } = null!;
+        public ILaunchMode LaunchMode { get; private set; } = null!;
         public bool UseRemoteAssetBundles { get; private set; }
         public bool UseLocalAssetBundles { get; private set; }
         public DecentralandEnvironment Environment { get; private set; }
@@ -71,7 +71,7 @@ namespace Global.Dynamic
         /// </summary>
         public string? LocalAbBaseUrl { get; private set; }
         public RealmClock RealmClock { get; } = new ();
-        public WebRequestsContainer WebRequestsContainer { get; private set; }
+        public WebRequestsContainer WebRequestsContainer { get; private set; } = null!;
 
         public override void Dispose()
         {

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -584,7 +584,7 @@ namespace Global.Dynamic
             bool hasMinimumSpecs = minimumSpecsGuard.HasMinimumSpecs() && !forceShow;
 
             if (!hasMinimumSpecs && !skipScreen)
-                SavedQualitySettingsApplier.EnforceLowPreset();
+                SavedQualitySettingsApplier.EnforceLowPresetOnce();
 
             bool userWantsToSkip = DCLPlayerPrefs.GetBool(DCLPrefKeys.DONT_SHOW_MIN_SPECS_SCREEN);
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
@@ -1,5 +1,4 @@
 using Arch.Core;
-using DCL.SceneRunner.Scene;
 using CommunicationData.URLHelpers;
 using CrdtEcsBridge.Components;
 using Cysharp.Threading.Tasks;
@@ -7,25 +6,18 @@ using DCL.AssetsProvision;
 using DCL.Audio;
 using DCL.AvatarRendering.AvatarShape.UnityInterface;
 using DCL.AvatarRendering.Emotes;
-using DCL.AvatarRendering.Emotes.Play;
-using DCL.Multiplayer.Emotes;
 using DCL.Character.Plugin;
 using DCL.DebugUtilities;
 using DCL.Diagnostics;
-using DCL.ECSComponents;
 using DCL.FeatureFlags;
 using DCL.Gizmos.Plugin;
 using DCL.Input;
 using DCL.Interaction.Utility;
 using DCL.Ipfs;
-using DCL.Landscape.Utils;
 using DCL.MapPins.Bus;
 using DCL.Multiplayer.Connections.DecentralandUrls;
-using DCL.Multiplayer.Connections.RoomHubs;
-using DCL.Multiplayer.Profiles.Tables;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.Optimization.Pools;
-using DCL.PerformanceAndDiagnostics;
 using DCL.PluginSystem;
 using DCL.PluginSystem.Global;
 using DCL.PluginSystem.World;
@@ -86,56 +78,56 @@ namespace Global
         public readonly PartitionDataContainer PartitionDataContainer = new ();
         public readonly IMapPinsEventBus MapPinsEventBus = new MapPinsEventBus();
 
-        private IAssetsProvisioner assetsProvisioner;
+        private IAssetsProvisioner assetsProvisioner = null!;
         public Entity PlayerEntity { get; set; }
-        public RealmData RealmData { get; private set; }
-        public PublishIpfsEntityCommand PublishIpfsEntityCommand { get; private set; }
+        public RealmData RealmData { get; private set; } = null!;
+        public PublishIpfsEntityCommand PublishIpfsEntityCommand { get; private set; } = null!;
 
         public ComponentsContainer ComponentsContainer { get; private set; }
-        public CharacterContainer CharacterContainer { get; private set; }
-        public MediaPlayerContainer MediaContainer { get; private set; }
-        public EmotesContainer EmotesContainer { get; private set; }
-        public ProfilesContainer ProfilesContainer { get; private set; }
-        public QualityContainer QualityContainer { get; private set; }
-        public ExposedGlobalDataContainer ExposedGlobalDataContainer { get; private set; }
-        public WebRequestsContainer WebRequestsContainer { get; private set; }
-        public IReadOnlyList<IDCLWorldPlugin> ECSWorldPlugins { get; private set; }
-        public IEmoteStorage EmoteStorage { get; private set; }
+        public CharacterContainer CharacterContainer { get; private set; } = null!;
+        public MediaPlayerContainer MediaContainer { get; private set; } = null!;
+        public EmotesContainer EmotesContainer { get; private set; } = null!;
+        public ProfilesContainer ProfilesContainer { get; private set; } = null!;
+        public QualityContainer QualityContainer { get; private set; } = null!;
+        public ExposedGlobalDataContainer ExposedGlobalDataContainer { get; private set; } = null!;
+        public WebRequestsContainer WebRequestsContainer { get; private set; } = null!;
+        public IReadOnlyList<IDCLWorldPlugin> ECSWorldPlugins { get; private set; } = null!;
+        public IEmoteStorage EmoteStorage { get; private set; } = null!;
 
-        public ISystemMemoryCap MemoryCap { get; private set; }
+        public ISystemMemoryCap MemoryCap { get; private set; } = null!;
 
-        public SceneLoadingLimit SceneLoadingLimit { get; private set; }
+        public SceneLoadingLimit SceneLoadingLimit { get; private set; } = null!;
 
         /// <summary>
         ///     Some plugins may implement both interfaces
         /// </summary>
-        public IReadOnlyList<IDCLGlobalPlugin> SharedPlugins { get; private set; }
+        public IReadOnlyList<IDCLGlobalPlugin> SharedPlugins { get; private set; } = null!;
         public ECSWorldSingletonSharedDependencies SingletonSharedDependencies { get; private set; }
-        public Profiler Profiler { get; private set; }
-        public IEntityCollidersGlobalCache EntityCollidersGlobalCache { get; private set; }
+        public Profiler Profiler { get; private set; } = null!;
+        public IEntityCollidersGlobalCache EntityCollidersGlobalCache { get; private set; } = null!;
         public IPartitionSettings PartitionSettings => StaticSettings.PartitionSettings;
         public IRealmPartitionSettings RealmPartitionSettings => StaticSettings.RealmPartitionSettings;
-        public StaticSettings StaticSettings { get; private set; }
-        public CacheCleaner CacheCleaner { get; private set; }
-        public IEthereumApi EthereumApi { get; private set; }
-        public IInputBlock InputBlock { get; private set; }
-        public IScenesCache ScenesCache { get; private set; }
-        public ISceneReadinessReportQueue SceneReadinessReportQueue { get; private set; }
-        public HttpFeatureFlagsProvider FeatureFlagsProvider { get; private set; }
-        public IPortableExperiencesController PortableExperiencesController { get; private set; }
-        public SmartWearableCache SmartWearableCache { get; private set; }
-        public ImageControllerProvider ImageControllerProvider { get; private set; }
-        public IDebugContainerBuilder DebugContainerBuilder { get; private set; }
-        public ISceneRestrictionBusController SceneRestrictionBusController { get; private set; }
+        public StaticSettings StaticSettings { get; private set; } = null!;
+        public CacheCleaner CacheCleaner { get; private set; } = null!;
+        public IEthereumApi EthereumApi { get; private set; } = null!;
+        public IInputBlock InputBlock { get; private set; } = null!;
+        public IScenesCache ScenesCache { get; private set; } = null!;
+        public ISceneReadinessReportQueue SceneReadinessReportQueue { get; private set; } = null!;
+        public HttpFeatureFlagsProvider FeatureFlagsProvider { get; private set; } = null!;
+        public IPortableExperiencesController PortableExperiencesController { get; private set; } = null!;
+        public SmartWearableCache SmartWearableCache { get; private set; } = null!;
+        public ImageControllerProvider ImageControllerProvider { get; private set; } = null!;
+        public IDebugContainerBuilder DebugContainerBuilder { get; private set; } = null!;
+        public ISceneRestrictionBusController SceneRestrictionBusController { get; private set; } = null!;
         public GPUInstancingService GPUInstancingService { get; private set; }
-        public ILoadingStatus LoadingStatus { get; private set; }
-        public ILaunchMode LaunchMode { get; private set; }
-        public WorldManifestProvider WorldManifestProvider { get; private set; }
+        public ILoadingStatus LoadingStatus { get; private set; } = null!;
+        public ILaunchMode LaunchMode { get; private set; } = null!;
+        public WorldManifestProvider WorldManifestProvider { get; private set; } = null!;
 
-        public IGltfContainerAssetsCache GltfContainerAssetsCache { get; private set; }
-        public AssetPreLoadCache AssetPreLoadCache { get; private set; }
-        public CharacterDataPropagationUtility CharacterDataPropagationUtility { get; private set; }
-        public DiskCache<ISSDescriptorMetadata, SerializeMemoryIterator<StringDiskSerializer.State>> ISSDescriptorDiskCache { get; private set; }
+        public IGltfContainerAssetsCache GltfContainerAssetsCache { get; private set; } = null!;
+        public AssetPreLoadCache AssetPreLoadCache { get; private set; } = null!;
+        public CharacterDataPropagationUtility CharacterDataPropagationUtility { get; private set; } = null!;
+        public DiskCache<ISSDescriptorMetadata, SerializeMemoryIterator<StringDiskSerializer.State>> ISSDescriptorDiskCache { get; private set; } = null!;
 
         public void Dispose()
         {
@@ -294,7 +286,7 @@ namespace Global
                 new GltfContainerPlugin(sharedDependencies, container.CacheCleaner, container.SceneReadinessReportQueue, launchMode, useRemoteAssetBundles, useLocalAssetBundles, container.WebRequestsContainer.WebRequestController, container.LoadingStatus, container.GltfContainerAssetsCache, appArgs, componentsContainer.ComponentPoolsRegistry.RootContainerTransform()),
                 new TransformsPlugin(sharedDependencies, exposedPlayerTransform, exposedGlobalDataContainer.ExposedCameraData),
                 new BillboardPlugin(exposedGlobalDataContainer.ExposedCameraData),
-                new NFTShapePlugin(decentralandUrlsSource, container.assetsProvisioner, sharedDependencies.FrameTimeBudget, componentsContainer.ComponentPoolsRegistry, container.WebRequestsContainer.WebRequestController, container.CacheCleaner, container.MediaContainer.mediaFactoryBuilder),
+                new NFTShapePlugin(decentralandUrlsSource, container.assetsProvisioner, sharedDependencies.FrameTimeBudget, componentsContainer.ComponentPoolsRegistry, container.WebRequestsContainer.WebRequestController, container.MediaContainer.mediaFactoryBuilder),
                 new TextShapePlugin(sharedDependencies.FrameTimeBudget, container.CacheCleaner, componentsContainer.ComponentPoolsRegistry, assetsProvisioner),
                 new MaterialsPlugin(sharedDependencies, container.MediaContainer.mediaFactoryBuilder),
                 textureResolvePlugin,

--- a/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
@@ -274,7 +274,9 @@ namespace Global
             });
 
             var renderFeature = container.QualityContainer.RendererFeaturesCache.GetRendererFeature<GPUInstancingRenderFeature>();
-            if (enableGPUInstancing && renderFeature != null && renderFeature.Settings != null && renderFeature.Settings.FrustumCullingAndLODGenComputeShader != null)
+            if (!SystemInfo.supportsComputeShaders)
+                ReportHub.LogWarning(ReportCategory.GPU_INSTANCING, "Compute shaders not supported on this platform; GPU instancing disabled.");
+            else if (enableGPUInstancing && renderFeature != null && renderFeature.Settings != null && renderFeature.Settings.FrustumCullingAndLODGenComputeShader != null)
             {
                 container.GPUInstancingService = new GPUInstancingService(renderFeature.Settings);
                 renderFeature.Initialize(container.GPUInstancingService, container.RealmData);

--- a/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
@@ -274,7 +274,7 @@ namespace Global
             });
 
             var renderFeature = container.QualityContainer.RendererFeaturesCache.GetRendererFeature<GPUInstancingRenderFeature>();
-            if (!SystemInfo.supportsComputeShaders)
+            if (!UnityEngine.SystemInfo.supportsComputeShaders)
                 ReportHub.LogWarning(ReportCategory.GPU_INSTANCING, "Compute shaders not supported on this platform; GPU instancing disabled.");
             else if (enableGPUInstancing && renderFeature != null && renderFeature.Settings != null && renderFeature.Settings.FrustumCullingAndLODGenComputeShader != null)
             {

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/PlayMode/IntegrationTestsSuite.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/PlayMode/IntegrationTestsSuite.cs
@@ -13,10 +13,8 @@ using DCL.Multiplayer.Connections.RoomHubs;
 using DCL.Multiplayer.Profiles.Poses;
 using DCL.Optimization.PerformanceBudgeting;
 using DCL.PluginSystem;
-using DCL.PluginSystem.Global;
 using DCL.PluginSystem.World;
 using DCL.Profiles;
-using DCL.Settings;
 using DCL.Time;
 using DCL.Web3;
 using DCL.Web3.Identities;
@@ -34,7 +32,6 @@ using DCL.CharacterMotion.Components;
 using DCL.Multiplayer.Movement;
 using DCL.PerformanceAndDiagnostics.Analytics;
 using DCL.SDKComponents.InputModifier.Components;
-using DCL.Utilities;
 using DCL.Utility;
 using DCL.WebRequests.Analytics;
 using DCL.WebRequests.ChromeDevtool;
@@ -45,7 +42,6 @@ using Global.Versioning;
 using SceneRuntime.Factory.WebSceneSource;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
-using UnityEngine.UIElements;
 
 namespace Global.Tests.PlayMode
 {

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
@@ -22,24 +22,6 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
 {
     public class SignedFetchWrap : JsApiWrapper
     {
-        private static readonly string[] AUTH_CHAIN_HEADER_NAMES =
-        {
-            // AuthLinkType.SIGNER
-            "x-identity-auth-chain-0",
-
-            // AuthLinkType.ECDSA_EPHEMERAL
-            "x-identity-auth-chain-1",
-
-            // AuthLinkType.ECDSA_SIGNED_ENTITY
-            "x-identity-auth-chain-2",
-
-            // AuthLinkType.ECDSA_EIP_1654_EPHEMERAL
-            "x-identity-auth-chain-3",
-
-            // AuthLinkType.ECDSA_EIP_1654_SIGNED_ENTITY
-            "x-identity-auth-chain-4",
-        };
-
         private readonly IWebRequestController webController;
         private readonly string decentralandEnvironment;
         private readonly ISceneData sceneData;
@@ -109,7 +91,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
 
             foreach (AuthLink link in authChain)
             {
-                headers[AUTH_CHAIN_HEADER_NAMES[authChainIndex]] = link.ToJson();
+                headers[$"x-identity-auth-chain-{authChainIndex}"] = link.ToJson();
                 authChainIndex++;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/SignedFetchWrap.cs
@@ -15,7 +15,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Security.Cryptography;
 using UnityEngine;
-using Utility;
 using Utility.Times;
 
 namespace SceneRuntime.Apis.Modules.SignedFetch
@@ -290,6 +289,8 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
             return JsonUtility.ToJson(metadata);
         }
 
+        // Wire format serialized with JsonUtility: field names must match the JSON keys.
+        // ReSharper disable InconsistentNaming
         [Serializable]
         internal struct SignatureMetadata
         {
@@ -312,5 +313,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch
                 public string serverName;
             }
         }
+
+        // ReSharper restore InconsistentNaming
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/Tests/SignedFetchWrapShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/SignedFetch/Tests/SignedFetchWrapShould.cs
@@ -1,4 +1,3 @@
-using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Ipfs;
 using DCL.Multiplayer.Connections.DecentralandUrls;
@@ -28,19 +27,19 @@ namespace SceneRuntime.Apis.Modules.SignedFetch.Tests
         /// </summary>
         private const int MAX_CONTINUATION_TICKS = 10;
 
-        private IWebRequestController webController;
-        private ISceneData sceneData;
-        private IRealmData realmData;
-        private IWeb3IdentityCache identityCache;
-        private CancellationTokenSource disposeCts;
-        private SignedFetchWrap signedFetchWrap;
+        private IWebRequestController webController = null!;
+        private ISceneData sceneData = null!;
+        private IRealmData realmData = null!;
+        private IWeb3IdentityCache identityCache = null!;
+        private CancellationTokenSource disposeCts = null!;
+        private SignedFetchWrap signedFetchWrap = null!;
 
         private Vector2Int sceneBase;
-        private string sceneID;
+        private string sceneID = null!;
 
-        private string realmName;
-        private string realmHostname;
-        private string realmProtocol;
+        private string realmName = null!;
+        private string realmHostname = null!;
+        private string realmProtocol = null!;
 
 
         [SetUp]
@@ -78,7 +77,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch.Tests
             // Setup identity cache with a mock identity
             var mockIdentity = Substitute.For<IWeb3Identity>();
             // Return a new AuthChain with a signer link each time Sign is called
-            mockIdentity.Sign(Arg.Any<string>()).Returns(callInfo =>
+            mockIdentity.Sign(Arg.Any<string>()).Returns(_ =>
             {
                 var authChain = AuthChain.Create();
                 authChain.SetSigner("0x1234567890123456789012345678901234567890");
@@ -99,7 +98,7 @@ namespace SceneRuntime.Apis.Modules.SignedFetch.Tests
         [TearDown]
         public void TearDown()
         {
-            disposeCts?.Dispose();
+            disposeCts.Dispose();
         }
 
         [Test]
@@ -112,17 +111,17 @@ namespace SceneRuntime.Apis.Modules.SignedFetch.Tests
             string method = "GET";
 
             // Act
-            string result = signedFetchWrap.GetSignedHeaders(url, body, headers, method) as string;
+            string? result = signedFetchWrap.GetSignedHeaders(url, body, headers, method) as string;
 
             // Assert
             Assert.IsNotNull(result, "GetSignedHeaders should return a non-null result");
 
             // Parse the returned headers JSON
-            Dictionary<string, string>? headersDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(result);
+            Dictionary<string, string>? headersDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(result!);
             Assert.IsNotNull(headersDict, "Headers should be deserializable");
 
             // Extract the signature metadata from headers
-            Assert.IsTrue(headersDict.ContainsKey("x-identity-metadata"), "Headers should contain x-identity-metadata");
+            Assert.IsTrue(headersDict!.ContainsKey("x-identity-metadata"), "Headers should contain x-identity-metadata");
             string signatureMetadataJson = headersDict["x-identity-metadata"];
 
             // Parse the signature metadata JSON

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/SceneRuntimeImpl.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/SceneRuntimeImpl.cs
@@ -82,9 +82,9 @@ namespace SceneRuntime
         }
 
         /// <remarks>
-        ///     <see cref="SceneFacade" /> is a component in the global scene as an
+        ///     <c>SceneFacade</c> is a component in the global scene as an
         ///     <see cref="ISceneFacade" />. It owns its <see cref="SceneRuntimeImpl" /> through its
-        ///     <see cref="deps" /> field, which in turns owns its <see cref="V8ScriptEngine" />. So that also
+        ///     <c>deps</c> field, which in turns owns its <see cref="V8ScriptEngine" />. So that also
         ///     shall be the chain of Dispose calls.
         /// </remarks>
         public void Dispose()

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/SceneRuntimeShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Tests/SceneRuntimeShould.cs
@@ -25,8 +25,8 @@ namespace SceneRuntime.Tests
 {
     public class SceneRuntimeShould
     {
-        private IInstancePoolsProvider poolsProvider;
-        private ISceneExceptionsHandler sceneExceptionsHandler;
+        private IInstancePoolsProvider poolsProvider = null!;
+        private ISceneExceptionsHandler sceneExceptionsHandler = null!;
 
         [SetUp]
         public void SetUp()

--- a/Explorer/Assets/DCL/Infrastructure/Utility/EventBus/EventBus.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/EventBus/EventBus.cs
@@ -66,7 +66,7 @@ namespace Utility
 
             public static void Schedule(Action<T> typedDelegate, T evt)
             {
-                if (!POOL.TryDequeue(out PooledContinuation<T>? continuation))
+                if (!POOL.TryDequeue(out PooledContinuation<T> continuation))
                     continuation = new PooledContinuation<T>();
 
                 continuation.typedDelegate = typedDelegate;

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
@@ -131,6 +131,10 @@ namespace Utility.Networking
                 await ws.CloseAsync(statusType, description, cancellationToken);
 #endif
             }
+            catch (System.Net.WebSockets.WebSocketException e) when (e.InnerException is ObjectDisposedException)
+            {
+                // Mono surfaces the Dispose() race as a WebSocketException wrapping the ObjectDisposedException.
+            }
             catch (System.Net.WebSockets.WebSocketException e)
             {
                 throw new WebSocketException(e);

--- a/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/Networking/DCLWebSocket.cs
@@ -17,6 +17,7 @@ namespace Utility.Networking
 
         // Once TCP connects, neither Abort() nor a CancellationToken unparks mono's ConnectAsync, so failing a pending connection means abandoning its await via this token.
         private readonly CancellationTokenSource connectAbort = new ();
+        private volatile bool disposed;
 #endif
 
         public WebSocketState State
@@ -36,6 +37,7 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
             ws.Dispose();
 #else
+            disposed = true;
             connectAbort.SafeCancelAndDispose();
             ws.Dispose();
 #endif
@@ -114,6 +116,10 @@ namespace Utility.Networking
 #if UNITY_WEBGL && (!UNITY_EDITOR || EDITOR_DEBUG_WEBGL)
                 await ws.CloseAsync(status, description, cancellationToken);
 #else
+                // A racing Dispose() nulls Mono's inner socket; bail before touching ws.
+                if (disposed)
+                    return;
+
                 // Mono's close path derefs an inner socket that only exists after a successful upgrade; per WHATWG, close() outside an established connection aborts instead.
                 if (State is not (WebSocketState.Open or WebSocketState.CloseReceived or WebSocketState.CloseSent))
                 {
@@ -128,6 +134,10 @@ namespace Utility.Networking
             catch (System.Net.WebSockets.WebSocketException e)
             {
                 throw new WebSocketException(e);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Dispose() ran between the disposed-flag check and the actual ws call.
             }
         }
 

--- a/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
+++ b/Explorer/Assets/DCL/Landscape/TerrainGenerator.cs
@@ -71,14 +71,14 @@ namespace DCL.Landscape
             timeProfiler = new TimeProfiler(measureTime);
         }
 
-        public void Initialize(TerrainGenerationData terrainGenData, int[] treeRendererKeys,
-            LandscapeData landscapeData)
+        public void Initialize(TerrainGenerationData generationData, int[] treeRendererKeys,
+            LandscapeData landscape)
         {
-            this.terrainGenData = terrainGenData;
-            Trees = new TreeData(treeRendererKeys, terrainGenData);
-            this.landscapeData = landscapeData;
-            ParcelSize = terrainGenData.parcelSize;
-            factory = new TerrainFactory(terrainGenData);
+            terrainGenData = generationData;
+            Trees = new TreeData(treeRendererKeys, generationData);
+            landscapeData = landscape;
+            ParcelSize = generationData.parcelSize;
+            factory = new TerrainFactory(generationData);
 
             boundariesGenerator = new TerrainBoundariesGenerator(factory, ParcelSize);
 
@@ -152,7 +152,7 @@ namespace DCL.Landscape
 
             TerrainModel = new TerrainModel(ParcelSize, worldManifest.GetOccupiedParcels(), terrainGenData.borderPadding);
 
-            float startMemory = profilingProvider.SystemUsedMemoryInBytes / (1024 * 1024);
+            float startMemory = (float)profilingProvider.SystemUsedMemoryInBytes / (1024 * 1024);
 
             try
             {
@@ -221,7 +221,7 @@ namespace DCL.Landscape
                 DestroyPartialTerrain();
             }
 
-            float endMemory = profilingProvider.SystemUsedMemoryInBytes / (1024 * 1024);
+            float endMemory = (float)profilingProvider.SystemUsedMemoryInBytes / (1024 * 1024);
             ReportHub.Log(ReportCategory.LANDSCAPE, $"The landscape generation took {endMemory - startMemory}MB of memory");
         }
 
@@ -358,8 +358,6 @@ namespace DCL.Landscape
         private static int ComputeChamferDistanceField(NativeArray<byte> src, NativeArray<int> dist,
             int width, RectInt workingArea)
         {
-            int n = src.Length;
-
             // Initialize working area pixels
             for (int y = workingArea.yMin; y <= workingArea.yMax; y++)
             for (int x = workingArea.xMin; x <= workingArea.xMax; x++)
@@ -450,8 +448,6 @@ namespace DCL.Landscape
             int minValue = 255 - (stepSize * maxPixelDistance);
 
             ReportHub.Log(ReportCategory.LANDSCAPE, $"Distance field: max chamfer={maxChamferDistance}, max pixels={maxPixelDistance}, stepSize={stepSize}, range=[{minValue}, 255]");
-
-            int n = src.Length;
 
             // Write back mapped values
             for (int y = area.yMin; y <= area.yMax; y++)

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkController.cs
@@ -26,7 +26,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas
         private Texture2D? currentOwnedTexture;
         private readonly AtlasChunk atlasChunk;
 
-        private string CHUNKS_API => decentralandUrlsSource.Url(DecentralandUrl.ApiChunks);
+        private string chunksApi => decentralandUrlsSource.Url(DecentralandUrl.ApiChunks);
 
         public ParcelChunkController(
             IWebRequestController webRequestController,
@@ -62,7 +62,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas
         {
             atlasChunk.MainSpriteRenderer.color = AtlasChunkConstants.INITIAL_COLOR;
 
-            var url = $"{CHUNKS_API}?center={mapPosition.x},{mapPosition.y}&width={chunkSize}&height={chunkSize}&size={parcelSize}";
+            var url = $"{chunksApi}?center={mapPosition.x},{mapPosition.y}&width={chunkSize}&height={chunkSize}&size={parcelSize}";
             var textureTask = webRequestController.GetTextureAsync(
                 new CommonArguments(URLAddress.FromString(url)),
                 new GetTextureArguments(TextureType.Albedo),
@@ -78,7 +78,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas
 
             try
             {
-                currentOwnedTexture = await textureTask!;
+                currentOwnedTexture = await textureTask;
                 await UniTask.SwitchToMainThread();
                 texture = currentOwnedTexture;
             }

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/ParcelAtlas/ParcelChunkController.cs
@@ -82,6 +82,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas
                 await UniTask.SwitchToMainThread();
                 texture = currentOwnedTexture;
             }
+            catch (OperationCanceledException) { return; }
             catch (Exception e)
             {
                 ReportHub.LogException(e, ReportCategory.UI);

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
@@ -95,6 +95,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas.SatelliteAtlas
                 await UniTask.SwitchToMainThread();
                 texture = currentOwnedTexture;
             }
+            catch (OperationCanceledException) { return; }
             catch (Exception e)
             {
                 ReportHub.LogException(e, ReportCategory.UI);
@@ -115,6 +116,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas.SatelliteAtlas
 
                 atlasChunk.MainSpriteRenderer.sprite.name = chunkId.ToString();
             }
+            catch (OperationCanceledException) { return; }
             catch (Exception e)
             {
                 ReportHub.LogException(e, ReportCategory.UI);

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/Atlas/SatelliteAtlas/SatelliteChunkController.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using UnityEngine;
 using Utility;
 using UnityEngine.AddressableAssets;
-using Object = UnityEngine.Object;
 
 namespace DCL.MapRenderer.MapLayers.Atlas.SatelliteAtlas
 {
@@ -91,7 +90,7 @@ namespace DCL.MapRenderer.MapLayers.Atlas.SatelliteAtlas
 
             try
             {
-                currentOwnedTexture = await textureTask!;
+                currentOwnedTexture = await textureTask;
                 await UniTask.SwitchToMainThread();
                 texture = currentOwnedTexture;
             }

--- a/Explorer/Assets/DCL/Multiplayer/Deduplication/MessageDeduplication.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Deduplication/MessageDeduplication.cs
@@ -57,24 +57,24 @@ namespace DCL.Multiplayer.Deduplication
         [Serializable]
         internal struct RegisteredStamp : IEquatable<RegisteredStamp>
         {
-            public string walletId;
-            public T timestamp;
+            public string WalletId;
+            public T Timestamp;
 
             public RegisteredStamp(string walletId, T timestamp)
             {
-                this.walletId = walletId;
-                this.timestamp = timestamp;
+                WalletId = walletId;
+                Timestamp = timestamp;
             }
 
             public bool Equals(RegisteredStamp other) =>
-                walletId == other.walletId
-                && timestamp.Equals(other.timestamp);
+                WalletId == other.WalletId
+                && Timestamp.Equals(other.Timestamp);
 
             public override bool Equals(object? obj) =>
                 obj is RegisteredStamp other && Equals(other);
 
             public override int GetHashCode() =>
-                HashCode.Combine(walletId, timestamp);
+                HashCode.Combine(WalletId, Timestamp);
         }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Systems/LiveKitMovementMessageBus.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Systems/LiveKitMovementMessageBus.cs
@@ -57,9 +57,9 @@ namespace DCL.Multiplayer.Movement
         }
 
         // TODO move to the ctor (dependencies refactoring required)
-        public void InitializeEncoder(MessageEncodingSettings messageEncodingSettings, IMultiplayerMovementSettings settingsValue, ParcelEncoder parcelEncoder)
+        public void InitializeEncoder(MessageEncodingSettings messageEncodingSettings, IMultiplayerMovementSettings settings, ParcelEncoder parcelEncoder)
         {
-            this.settingsValue = settingsValue;
+            settingsValue = settings;
             messageEncoder = new NetworkMessageEncoder(messageEncodingSettings, parcelEncoder);
             compressMessage = (message, compressed) => WriteToProto(messageEncoder.Compress(message), compressed);
         }

--- a/Explorer/Assets/DCL/Multiplayer/Movement/Tests/LiveKitMovementMessageBusDisposalShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Movement/Tests/LiveKitMovementMessageBusDisposalShould.cs
@@ -17,8 +17,8 @@ namespace DCL.Multiplayer.Movement.Tests
     [TestFixture]
     public class LiveKitMovementMessageBusDisposalShould
     {
-        private World world;
-        private LiveKitMovementMessageBus bus;
+        private World world = null!;
+        private LiveKitMovementMessageBus bus = null!;
 
         [SetUp]
         public void SetUp()

--- a/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftNotificationView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftNotificationView.cs
@@ -14,21 +14,21 @@ namespace DCL.Notifications.NotificationEntry
     {
         public event Action<NotificationType, INotification>? NotificationClicked;
         public NotificationType NotificationType { get; set; }
-        public INotification Notification { get; set; }
+        public INotification Notification { get; set; } = null!;
         [field: SerializeField] public Color NormalColor { get; private set; }
         [field: SerializeField] public Color HoveredColor { get; private set; }
-        [field: SerializeField] public Image Background { get; private set; }
-        [field: SerializeField] public Button MainButton { get; private set; }
-        [field: SerializeField] public TMP_Text HeaderText { get; set; }
-        [field: SerializeField] public TMP_Text TitleText { get; set; }
-        [field: SerializeField] public TMP_Text GiftNameText { get; set; }
-        [field: SerializeField] public TMP_Text TimeText { get; set; }
-        [field: SerializeField] public Button CloseButton { get; set; }
-        [field: SerializeField] public GameObject UnreadImage { get; set; }
-        [field: SerializeField] public Image NotificationTypeImage { get; set; }
-        [field: SerializeField] public ImageView NotificationImage { get; set; }
-        [field: SerializeField] public Image NotificationImageBackground { get; set; }
-        [field: SerializeField] public AudioClipConfig AcceptedNotificationAudio { get; private set; }
+        [field: SerializeField] public Image Background { get; private set; } = null!;
+        [field: SerializeField] public Button MainButton { get; private set; } = null!;
+        [field: SerializeField] public TMP_Text HeaderText { get; set; } = null!;
+        [field: SerializeField] public TMP_Text TitleText { get; set; } = null!;
+        [field: SerializeField] public TMP_Text GiftNameText { get; set; } = null!;
+        [field: SerializeField] public TMP_Text TimeText { get; set; } = null!;
+        [field: SerializeField] public Button CloseButton { get; set; } = null!;
+        [field: SerializeField] public GameObject UnreadImage { get; set; } = null!;
+        [field: SerializeField] public Image NotificationTypeImage { get; set; } = null!;
+        [field: SerializeField] public ImageView NotificationImage { get; set; } = null!;
+        [field: SerializeField] public Image NotificationImageBackground { get; set; } = null!;
+        [field: SerializeField] public AudioClipConfig AcceptedNotificationAudio { get; private set; } = null!;
 
         private void PlayAcceptedNotificationAudio()
         {
@@ -53,13 +53,13 @@ namespace DCL.Notifications.NotificationEntry
                 ? $"{notification.Metadata.SenderAddress.Substring(0, 4)}..." 
                 : notification.Metadata.SenderAddress;
 
-            HeaderText.text = string.Format(GiftingTextIds.GiftReceivedSenderTitleFormat, shortAddr);
+            HeaderText.text = string.Format(GiftingTextIds.GIFT_RECEIVED_SENDER_TITLE_FORMAT, shortAddr);
         }
         
         public void UpdateSenderName(string playerName, Color nameColor)
         {
             string hexColor = ColorUtility.ToHtmlStringRGB(nameColor);
-            HeaderText.text = string.Format(GiftingTextIds.GiftReceivedTitleFormat, hexColor, playerName);
+            HeaderText.text = string.Format(GiftingTextIds.GIFT_RECEIVED_TITLE_FORMAT, hexColor, playerName);
         }
 
         private void OnPointerClick()

--- a/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftToastView.cs
+++ b/Explorer/Assets/DCL/Notifications/NotificationEntry/GiftToastView.cs
@@ -12,15 +12,15 @@ namespace DCL.Notifications.NotificationEntry
 {
     public class GiftToastView : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
     {
-        public event Action<NotificationType, INotification> NotificationClicked;
+        public event Action<NotificationType, INotification>? NotificationClicked;
         public NotificationType NotificationType { get; set; }
-        public INotification Notification { get; set; }
+        public INotification Notification { get; set; } = null!;
 
-        [field: SerializeField] public Image Background { get; private set; }
-        [field: SerializeField] public Button MainButton { get; private set; }
-        [field: SerializeField] public TMP_Text TitleText { get; set; }
-        [field: SerializeField] public ImageView NotificationImage { get; private set; }
-        [field: SerializeField] public AudioClipConfig NotificationAudio { get; private set; }
+        [field: SerializeField] public Image Background { get; private set; } = null!;
+        [field: SerializeField] public Button MainButton { get; private set; } = null!;
+        [field: SerializeField] public TMP_Text TitleText { get; set; } = null!;
+        [field: SerializeField] public ImageView NotificationImage { get; private set; } = null!;
+        [field: SerializeField] public AudioClipConfig NotificationAudio { get; private set; } = null!;
 
         [field: SerializeField] public Color NormalColor { get; private set; } = Color.white;
         [field: SerializeField] public Color HoveredColor { get; private set; } = new (0.9f, 0.9f, 0.9f);
@@ -60,13 +60,13 @@ namespace DCL.Notifications.NotificationEntry
                 ? notification.Metadata.SenderAddress.Substring(0, 6) + "..."
                 : notification.Metadata.SenderAddress;
 
-            TitleText.text = string.Format(GiftingTextIds.GiftReceivedSenderTitleFormat, shortAddr);
+            TitleText.text = string.Format(GiftingTextIds.GIFT_RECEIVED_SENDER_TITLE_FORMAT, shortAddr);
         }
 
-        public void UpdateSenderName(string name, Color nameColor)
+        public void UpdateSenderName(string senderName, Color nameColor)
         {
             string hexColor = ColorUtility.ToHtmlStringRGB(nameColor);
-            TitleText.text = string.Format(GiftingTextIds.GiftReceivedSenderTitleFormat, $"<color=#{hexColor}><b>{name}</b></color>");
+            TitleText.text = string.Format(GiftingTextIds.GIFT_RECEIVED_SENDER_TITLE_FORMAT, $"<color=#{hexColor}><b>{senderName}</b></color>");
         }
     }
 }

--- a/Explorer/Assets/DCL/Passport/Fields/EquippedItemPassportFieldView.cs
+++ b/Explorer/Assets/DCL/Passport/Fields/EquippedItemPassportFieldView.cs
@@ -84,7 +84,7 @@ namespace DCL.Passport.Fields
 
         public Action? WearableClicked;
 
-        private CancellationTokenSource cts;
+        private CancellationTokenSource? cts;
 
         private void Awake()
         {

--- a/Explorer/Assets/DCL/Passport/Modules/Creations/MarketplaceCatalogResponse.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/Creations/MarketplaceCatalogResponse.cs
@@ -1,5 +1,6 @@
 using System;
 
+// ReSharper disable InconsistentNaming
 namespace DCL.Passport.Modules.Creations
 {
     // Server schema: https://marketplace-api.decentraland.{ENV}/v3/catalog/items (GET, response.data[] — /v1/items shape plus priceCredits)

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/CategoryExclusionMatrixShould.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Tests/CategoryExclusionMatrixShould.cs
@@ -6,8 +6,8 @@ namespace DCL.Diagnostics.Tests
 {
     public class CategoryExclusionMatrixShould
     {
-        private ICategorySeverityMatrix baseMatrix;
-        private CategoryExclusionMatrix matrix;
+        private ICategorySeverityMatrix baseMatrix = null!;
+        private CategoryExclusionMatrix matrix = null!;
 
         [SetUp]
         public void SetUp()

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/UnityObjectUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/UnityObjectUtils.cs
@@ -1,6 +1,5 @@
 ﻿using DCL.Diagnostics;
 using DCL.Utility;
-using Sentry;
 using Sentry.Unity;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/UnityObjectUtils.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Optimization/UnityObjectUtils.cs
@@ -51,8 +51,11 @@ namespace Utility
         /// </summary>
         public static void SafeDestroyGameObject<T>(T? component) where T: Component
         {
-            // If Application is quitting component may be already invalid
-            if (IsQuitting && (!component || !component.gameObject))
+            // Null reference check is fast in comparison to Unity's overloaded operator
+            if (ReferenceEquals(component, null)) return;
+
+            // Component or its game object may already be invalid (destroyed externally or during quit)
+            if (!component || !component.gameObject)
                 return;
 
             if (!Application.isPlaying)

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
@@ -270,7 +270,7 @@ namespace DCL.PlacesAPIService
             {
                 await client.SetPlaceFavoriteAsync(placeId, isFavorite, ct);
             }
-            catch (Exception _)
+            catch (Exception)
             {
                 // Returning original value in case of exception.
                 TryUpdateCachedPlaceFavorite(placeId, cachedIsFavorite);

--- a/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
+++ b/Explorer/Assets/DCL/PlacesAPIService/PlacesAPIService.cs
@@ -123,7 +123,14 @@ namespace DCL.PlacesAPIService
             if (worldsByCoords.TryGetValue(coords, out PlacesData.PlaceInfo? cachedPlace))
                 return cachedPlace;
 
-            PlacesData.PlacesAPIResponse response = await client.GetWorldAsync($"{coords.x},{coords.y}", realmName, ct);
+            PlacesData.PlacesAPIResponse response;
+
+            try { response = await client.GetWorldAsync($"{coords.x},{coords.y}", realmName, ct); }
+            catch (NotAPlaceException)
+            {
+                worldsByCoords[coords] = null;
+                return null;
+            }
 
             if (!response.ok)
                 return null;

--- a/Explorer/Assets/DCL/PluginSystem/World/NFTShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/NFTShapePlugin.cs
@@ -8,7 +8,6 @@ using DCL.Optimization.PerformanceBudgeting;
 using DCL.Optimization.Pools;
 using DCL.PluginSystem.Global;
 using DCL.PluginSystem.World.Dependencies;
-using DCL.ResourcesUnloading;
 using DCL.SDKComponents.MediaStream;
 using DCL.SDKComponents.NFTShape.Component;
 using DCL.SDKComponents.NFTShape.Frames.FramePrefabs;
@@ -23,8 +22,6 @@ using ECS.LifeCycle.Systems;
 using ECS.StreamableLoading.Cache;
 using ECS.StreamableLoading.NFTShapes;
 using ECS.StreamableLoading.NFTShapes.URNs;
-using ECS.StreamableLoading.Textures;
-using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -51,7 +48,6 @@ namespace DCL.PluginSystem.World
             IPerformanceBudget instantiationFrameTimeBudgetProvider,
             IComponentPoolsRegistry componentPoolsRegistry,
             IWebRequestController webRequestController,
-            CacheCleaner cacheCleaner,
             MediaFactoryBuilder mediaFactoryBuilder)
         {
             this.framePrefabs = new AssetProvisionerFramePrefabs(assetsProvisioner);

--- a/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
+++ b/Explorer/Assets/DCL/Prefs/DCLPrefKeys.cs
@@ -17,6 +17,7 @@ namespace DCL.Prefs
         public const string LOGGEDIN_EMAIL = "LoggedInEmail";
 
         public const string DONT_SHOW_MIN_SPECS_SCREEN = "dontShowMinSpecsScreen";
+        public const string MIN_SPECS_LOW_PRESET_ENFORCED = "minSpecsLowPresetEnforced";
 
         public const string GPUI_ENABLED = "alfa-gpui";
 

--- a/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileConverter.cs
+++ b/Explorer/Assets/DCL/Profiles/SharedAPI/ProfileConverter.cs
@@ -1,5 +1,6 @@
 ﻿using CommunicationData.URLHelpers;
 using DCL.AvatarRendering.Loading.Components;
+using DCL.Diagnostics;
 using DCL.Utility;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -50,7 +51,7 @@ namespace DCL.Profiles
             return DeserializeProfileList(jObject, existingValue);
         }
 
-        private Profile DeserializeProfileList(JObject root, Profile? profile)
+        private Profile? DeserializeProfileList(JObject root, Profile? profile)
         {
             // Temporary support two schemes: from catalyst and centralized
             // TODO remove before releasing
@@ -61,13 +62,17 @@ namespace DCL.Profiles
             JToken? avatars = root["avatars"];
 
             if (avatars is not { Type: JTokenType.Array })
-                throw new ArgumentException("\"avatars\" is not a JSON array");
+            {
+                ReportHub.LogWarning(ReportCategory.PROFILE, $"Profile response \"avatars\" field is not a JSON array (type: {avatars?.Type.ToString() ?? "missing"})");
+                return null;
+            }
 
             // We only care about the first element, it's never an array in reality
             foreach (JToken? item in avatars.Children())
                 return DeserializeProfile(item, profile);
 
-            throw new ArgumentException("\"avatars\" array is empty");
+            ReportHub.LogWarning(ReportCategory.PROFILE, "Profile response \"avatars\" array is empty");
+            return null;
         }
 
         private Profile DeserializeProfile(JToken? jToken, Profile? profile)

--- a/Explorer/Assets/DCL/Profiles/Systems/LoadProfilesBatchSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/LoadProfilesBatchSystem.cs
@@ -1,12 +1,9 @@
 ﻿using Arch.Core;
 using Arch.SystemGroups;
 using Cysharp.Threading.Tasks;
-using DCL.Diagnostics;
 using DCL.Optimization.Pools;
 using DCL.Optimization.ThreadSafePool;
-using DCL.Utilities.Extensions;
 using DCL.Utility.Types;
-using DCL.Web3;
 using DCL.WebRequests;
 using ECS.Groups;
 using ECS.Prioritization.Components;
@@ -14,9 +11,7 @@ using ECS.StreamableLoading.Cache;
 using ECS.StreamableLoading.Common.Components;
 using ECS.StreamableLoading.Common.Systems;
 using ECS.StreamableLoading.DeferredLoading;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using UnityEngine.Pool;
 

--- a/Explorer/Assets/DCL/Profiles/Systems/LoadProfilesBatchSystem.cs
+++ b/Explorer/Assets/DCL/Profiles/Systems/LoadProfilesBatchSystem.cs
@@ -97,8 +97,11 @@ namespace DCL.Profiles
                     {
                         bool batched = result.Value.Count > 1;
 
-                        foreach (Profile dto in result.Value)
+                        foreach (Profile? dto in result.Value)
                         {
+                            // ProfileConverter deserializes malformed profile entries to null
+                            if (dto == null) continue;
+
                             intention.Ids.Remove(dto.UserId);
                             profileRepository.ResolveProfile(dto.UserId, dto, batched);
                         }

--- a/Explorer/Assets/DCL/Quality/Runtime/SavedQualitySettingsApplier.cs
+++ b/Explorer/Assets/DCL/Quality/Runtime/SavedQualitySettingsApplier.cs
@@ -118,11 +118,17 @@ namespace DCL.Quality.Runtime
         /// <summary>
         ///     Forces the Low preset by clearing any custom overrides and saving the Low preset level.
         ///     Called before QualitySettingsController is created (e.g. when minimum specs are not met).
+        ///     Applies only once per installation: after the first enforcement the saved preset is left untouched
+        ///     so quality settings the user changes afterwards survive restarts.
         /// </summary>
-        public static void EnforceLowPreset()
+        public static void EnforceLowPresetOnce()
         {
+            if (DCLPlayerPrefs.GetBool(DCLPrefKeys.MIN_SPECS_LOW_PRESET_ENFORCED))
+                return;
+
             DeleteCustomSettings();
-            DCLPlayerPrefs.SetInt(DCLPrefKeys.PS_QUALITY_PRESET, EnumUtils.ToInt(QualityPresetLevel.Low), save: true);
+            DCLPlayerPrefs.SetInt(DCLPrefKeys.PS_QUALITY_PRESET, EnumUtils.ToInt(QualityPresetLevel.Low));
+            DCLPlayerPrefs.SetBool(DCLPrefKeys.MIN_SPECS_LOW_PRESET_ENFORCED, true, save: true);
         }
     }
 }

--- a/Explorer/Assets/DCL/RealmNavigation/Tests/TeleportControllerShould.cs
+++ b/Explorer/Assets/DCL/RealmNavigation/Tests/TeleportControllerShould.cs
@@ -16,10 +16,10 @@ namespace DCL.RealmNavigation.Tests
 {
     public class TeleportControllerShould
     {
-        private World world;
+        private World world = null!;
         private Entity playerEntity;
-        private TeleportController controller;
-        private IRetrieveScene retrieveScene;
+        private TeleportController controller = null!;
+        private IRetrieveScene retrieveScene = null!;
 
         [SetUp]
         public void SetUp()

--- a/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/SceneUI/Tests/UICanvasInformationSystemShould.cs
@@ -33,10 +33,10 @@ namespace DCL.SDKComponents.SceneUI.Tests
 
         private readonly List<PBUiCanvasInformation> publishedComponents = new ();
 
-        private IECSToCRDTWriter ecsToCRDTWriter;
-        private GameObject canvasGameObject;
-        private PanelSettings panelSettings;
-        private UIDocument canvas;
+        private IECSToCRDTWriter ecsToCRDTWriter = null!;
+        private GameObject canvasGameObject = null!;
+        private PanelSettings panelSettings = null!;
+        private UIDocument canvas = null!;
 
         [SetUp]
         public void SetUp()

--- a/Explorer/Assets/DCL/Social/WebSocketRpcTransport.cs
+++ b/Explorer/Assets/DCL/Social/WebSocketRpcTransport.cs
@@ -112,24 +112,28 @@ namespace DCL.SocialService
 
         public virtual async UniTask SendMessageAsync(byte[] data, CancellationToken ct)
         {
-            if (isDisposed) return;
+            if (isDisposed || !isConnected) return;
 
             try { await webSocket.SendAsync(data, WebSocketMessageType.Binary, true, ct); }
             catch (WebSocketException e)
             {
                 OnErrorEvent?.Invoke(e);
             }
+            catch (ObjectDisposedException) { }
+            catch (InvalidOperationException) { }
         }
 
         public virtual async UniTask SendMessageAsync(string data, CancellationToken ct)
         {
-            if (isDisposed) return;
+            if (isDisposed || !isConnected) return;
 
             try { await webSocket.SendAsync(Encoding.UTF8.GetBytes(data), WebSocketMessageType.Text, true, ct); }
             catch (WebSocketException e)
             {
                 OnErrorEvent?.Invoke(e);
             }
+            catch (ObjectDisposedException) { }
+            catch (InvalidOperationException) { }
         }
 
         public void Close() =>

--- a/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
+++ b/Explorer/Assets/DCL/Tests/PlayMode/PerformanceTests/PerformanceBenchmark.cs
@@ -30,7 +30,7 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         protected SampleGroup? iterationDownloadedData;
 
         protected IWebRequestController? controller;
-        protected PerformanceTestWebRequestsAnalytics analytics;
+        protected PerformanceTestWebRequestsAnalytics analytics = null!;
 
         private MockedReportScope? reportScope;
 
@@ -48,7 +48,7 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         }
 
         [OneTimeSetUp]
-        public void SetupFF()
+        public void SetupFeatureFlags()
         {
             FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(new FeatureFlagsResultDto
             {
@@ -58,7 +58,7 @@ namespace DCL.Tests.PlayMode.PerformanceTests
         }
 
         [OneTimeTearDown]
-        public void ResetFF()
+        public void ResetFeatureFlags()
         {
             FeatureFlagsConfiguration.Reset();
         }

--- a/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
+++ b/Explorer/Assets/DCL/UI/DebugMenu/DebugMenuController.cs
@@ -22,18 +22,18 @@ namespace DCL.UI.DebugMenu
 
         private readonly DebugMenuConsoleLogHistory logsHistory = new ();
 
-        private ConsolePanelView consolePanelView;
-        private AbConversionPanelView abConversionPanelView;
-        private MetricsPanelView metricsPanelView;
+        private ConsolePanelView consolePanelView = null!;
+        private AbConversionPanelView abConversionPanelView = null!;
+        private MetricsPanelView metricsPanelView = null!;
 
         private DebugPanelView? visiblePanel;
 
         private IInputBlock? inputBlock;
 
-        private Button consoleButton;
-        private Button abConversionButton;
-        private Button metricsButton;
-        private Button debugPanelButton;
+        private Button consoleButton = null!;
+        private Button abConversionButton = null!;
+        private Button metricsButton = null!;
+        private Button debugPanelButton = null!;
 
         private bool shouldRefreshConsole;
         private bool shouldHideDebugPanelOwnToggle;
@@ -168,7 +168,7 @@ namespace DCL.UI.DebugMenu
             }
 
             // Cheap when nothing changed: a version check against the conversion metrics.
-            abConversionPanelView?.Refresh();
+            abConversionPanelView.Refresh();
 
             UpdateAbConversionAttention();
             UpdateMetricsPanel();

--- a/Explorer/Assets/DCL/UI/Profiles/Names/Tests/ProfileNameEditorControllerShould.cs
+++ b/Explorer/Assets/DCL/UI/Profiles/Names/Tests/ProfileNameEditorControllerShould.cs
@@ -22,10 +22,10 @@ namespace DCL.UI.ProfileNames.Tests
         private const string PREFAB_PATH = "Assets/DCL/UI/Profiles/Names/Assets/ProfileNameEditor.prefab";
         private const string OWNED_NAME = "test2000";
 
-        private GameObject viewGameObject;
-        private ProfileNameEditorView view;
-        private ProfileNameEditorController controller;
-        private Profile profile;
+        private GameObject viewGameObject = null!;
+        private ProfileNameEditorView view = null!;
+        private ProfileNameEditorController controller = null!;
+        private Profile? profile;
 
         [SetUp]
         public void SetUp()
@@ -83,7 +83,7 @@ namespace DCL.UI.ProfileNames.Tests
                 "current (unclaimed) display name, or Save can never be enabled (#9550)");
         }
 
-        private void InvokeSetUpClaimed(ProfileNameEditorView.ClaimedNameConfig config, Profile profile, INftNamesProvider.PaginatedNamesResponse names)
+        private void InvokeSetUpClaimed(ProfileNameEditorView.ClaimedNameConfig config, Profile claimedProfile, INftNamesProvider.PaginatedNamesResponse names)
         {
             // SetUpClaimed is a local function nested in OnBeforeViewShow/SetUpAsync; the compiler
             // emits it as a private instance method on the controller (it closes over the
@@ -92,7 +92,7 @@ namespace DCL.UI.ProfileNames.Tests
                 .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
                 .Single(m => m.Name.Contains("SetUpClaimed"));
 
-            setUpClaimed.Invoke(controller, new object[] { config, profile, names });
+            setUpClaimed.Invoke(controller, new object[] { config, claimedProfile, names });
         }
     }
 }

--- a/Explorer/Assets/DCL/WebRequests/RequestEnvelope.cs
+++ b/Explorer/Assets/DCL/WebRequests/RequestEnvelope.cs
@@ -1,17 +1,14 @@
 using DCL.Diagnostics;
-using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Optimization.Pools;
 using DCL.Web3.Chains;
 using DCL.Web3.Identities;
 using DCL.WebRequests.RequestsHub;
-using Sentry;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using UnityEngine.Networking;
-using UnityEngine.Pool;
 
 namespace DCL.WebRequests
 {

--- a/Explorer/Assets/DCL/WebRequests/RequestEnvelope.cs
+++ b/Explorer/Assets/DCL/WebRequests/RequestEnvelope.cs
@@ -192,18 +192,28 @@ namespace DCL.WebRequests
     /// </remarks>
     internal static class AuthChainHeaderNames
     {
-        private static readonly string[] AUTH_CHAIN_HEADER_NAMES;
+        private static string[] names = Build(Enum.GetNames(typeof(AuthLinkType)).Length);
 
-        static AuthChainHeaderNames()
+        private static string[] Build(int count)
         {
-            int maxAuthChainHeaders = Enum.GetNames(typeof(AuthLinkType)).Length;
-            AUTH_CHAIN_HEADER_NAMES = new string[maxAuthChainHeaders];
+            var result = new string[count];
 
-            for (var i = 0; i < maxAuthChainHeaders; i++)
-                AUTH_CHAIN_HEADER_NAMES[i] = $"x-identity-auth-chain-{i}";
+            for (var i = 0; i < count; i++)
+                result[i] = $"x-identity-auth-chain-{i}";
+
+            return result;
         }
 
-        public static string Get(int index) =>
-            AUTH_CHAIN_HEADER_NAMES[index];
+        public static string Get(int index)
+        {
+            string[] snapshot = names;
+
+            if (index < snapshot.Length)
+                return snapshot[index];
+
+            var grown = Build(index + 1);
+            names = grown;
+            return grown[index];
+        }
     }
 }

--- a/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
+++ b/Explorer/Assets/DCL/WebRequests/RequestsHub/RequestHub.cs
@@ -55,14 +55,14 @@ namespace DCL.WebRequests.RequestsHub
 
         public IDecentralandUrlsSource UrlsSource { get; }
 
-        private void Add<T, TWebRequest>(IDictionary<Key, object> map, InitializeRequest<T, TWebRequest> requestDelegate)
+        private void Add<T, TWebRequest>(IDictionary<Key, object> target, InitializeRequest<T, TWebRequest> requestDelegate)
             where T: struct
             where TWebRequest: struct, ITypedWebRequest
         {
             InitializeRequest<T, TWebRequest> invokeWithTransformedUrl
                 = (string url, ref T arguments) => requestDelegate.Invoke(UrlsSource.TransformUrl(url), ref arguments);
 
-            map.Add(Key.NewKey<T, TWebRequest>(), invokeWithTransformedUrl);
+            target.Add(Key.NewKey<T, TWebRequest>(), invokeWithTransformedUrl);
         }
 
         public InitializeRequest<T, TWebRequest> RequestDelegateFor<T, TWebRequest>()

--- a/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs
+++ b/Explorer/Assets/DCL/WebRequests/Tests/GenericDownloadHandlerPopulateIntoShould.cs
@@ -116,7 +116,7 @@ namespace DCL.WebRequests.Tests
         // The standard converter shape: allocates a fresh result instead of filling existingValue
         private class FreshInstanceListConverter : JsonConverter<List<INotification>>
         {
-            public override List<INotification>? ReadJson(JsonReader reader, Type objectType, List<INotification>? existingValue, bool hasExistingValue, JsonSerializer serializer)
+            public override List<INotification> ReadJson(JsonReader reader, Type objectType, List<INotification>? existingValue, bool hasExistingValue, JsonSerializer serializer)
             {
                 JObject.Load(reader);
                 return new List<INotification>();

--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -59,10 +59,10 @@ namespace DCL.WebRequests
             {
                 string? contentType = webRequest.UnityWebRequest.GetResponseHeader("Content-Type");
 
-                return contentType == "image/ktx2" ? ExecuteKtxAsync(webRequest, ct) : ExecuteNoCompressionAsync(webRequest, ct);
+                return contentType == "image/ktx2" ? ExecuteKtxAsync(webRequest) : ExecuteNoCompressionAsync(webRequest);
             }
 
-            private UniTask<Texture2D> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest, CancellationToken ct)
+            private UniTask<Texture2D?> ExecuteNoCompressionAsync(GetTextureWebRequest webRequest)
             {
                 Texture2D texture;
 
@@ -86,10 +86,10 @@ namespace DCL.WebRequests
                 texture.filterMode = filterMode;
                 texture.SetDebugName(webRequest.url);
                 ProfilingCounters.TexturesAmount.Value++;
-                return UniTask.FromResult(texture);
+                return UniTask.FromResult<Texture2D?>(texture);
             }
 
-            private async UniTask<Texture2D> ExecuteKtxAsync(GetTextureWebRequest webRequest, CancellationToken ct)
+            private async UniTask<Texture2D?> ExecuteKtxAsync(GetTextureWebRequest webRequest)
             {
                 // TODO: .data creates an array
                 var data = webRequest.UnityWebRequest.downloadHandler?.data;


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Automated bugsweep for week 2026-W33 (issues created Mon 2026-08-10 through Sun 2026-08-16), plus two follow-up issues picked up during review (#9814, #9674). Collected 24 issues, fixed 11 (covering 13 issue numbers including 2 duplicate groups), skipped 14.

### Fixed

- Fixes #9689 — `NotAPlaceException` propagating unhandled through `DonationsService` to Sentry. Wrapped `GetWorldAsync` in a try/catch, caching the null result for the coordinate.
- Fixes #9733 — `ArgumentException` when profile response `"avatars"` field is not a JSON array. Changed `DeserializeProfileList` to return `null` with a `ReportHub.LogWarning` instead of throwing. Review follow-up: `LoadProfilesBatchSystem` now skips the null entries Newtonsoft inserts for malformed profiles in batched responses; single-profile paths already handled null via their retry loops.
- Fixes #9735 — Signed-fetch header emission capped auth chains at 5 links. Removed hardcoded array in `SignedFetchWrap` and made `AuthChainHeaderNames` in `RequestEnvelope` grow dynamically.
- Fixes #9764 — `SafeDestroyGameObject` null guard only active during quit. Added `ReferenceEquals` fast null check and made the destroyed-object guard unconditional (`IsQuitting` is no longer needed there; it stays in use by `SafeDestroy` and the pools).
- Fixes #9761, #9676 — WebSocket `Dispose`/`CloseAsync` race. `DCLWebSocket` owns the race entirely: a `volatile bool disposed` guard plus catches for `ObjectDisposedException` and for the Mono variant where it arrives wrapped inside a `WebSocketException`. `ClientWebSocketApiImplementation.CloseAsync` only absorbs `OperationCanceledException`.
- Fixes #9760 — `WebSocketRpcTransport.SendMessageAsync` only caught `WebSocketException`. Added `!isConnected` early return and catches for `ObjectDisposedException` and `InvalidOperationException`.
- Fixes #9679 — `OperationCanceledException` treated as error in map chunk controllers. Added `catch (OperationCanceledException) { return; }` before generic catch blocks in both `SatelliteChunkController` and `ParcelChunkController`.
- Fixes #9745 — GPU instancing dispatched compute shader on platforms without compute support. Added `SystemInfo.supportsComputeShaders` check before creating `GPUInstancingService`.
- Fixes #9814 — Graphics settings reset on every restart for machines below minimum specs. `MainSceneLoader` called `EnforceLowPreset()` on every launch where the specs check failed, wiping the saved preset and any Custom overrides before `QualitySettingsController` read them. Now `EnforceLowPresetOnce()` records a `MIN_SPECS_LOW_PRESET_ENFORCED` pref marker and only forces Low the first time; afterwards user changes persist like on any other machine. (The Arc B-series regex gap lives in the `alfa-minimum-requirements` feature flag payload and is not part of this PR.)
- Fixes #9674 — `Error on GLTF Texture download ... No more sources left` reported to Sentry as an unhandled exception (duplicates #8059, #8667). `GltFastDownloadProviderBase.RequestTextureAsync` threw a plain `Exception` that escaped GLTFast's task chain and left sibling texture tasks unobserved. It now returns a `TextureDownloadResult` with `Success = false` and the error message, the same `ITextureDownload` contract `RequestAsync` already uses for the GLTF file, so GLTFast logs `TextureDownloadFailed` and fails the import through the regular path. A GLTF with an unavailable texture still fails to load; that is unchanged.

### Not worked on

- #9736 — `[UUAV] init: failed to start uuav helper: helper did not say Hello`: UUAV init fallback requires cross-assembly `InternalsVisibleTo` changes spanning 3 assemblies (UUAVClient, UUAV.AVProCompat, AvProSwitch); the error is caught and logged but the architectural fallback is too complex for this sweep.
- #9696 — `Nearby Voice Chat tip: fix overlay behavior or remove`: root cause is prefab Canvas sort order (binary .prefab file); controller-level fix requires injecting new dependencies across existing wiring.
- #9751 — `Allow sending DMs to users who are offline`: feature request (labeled feature/suggestion), not a bug.
- #9749 — `local-ab follow-ups: mirror content-edit reconversions in the AB panel; fall back to production CDN when the sidecar can't start`: enhancement (labeled enhancement), not a bug.
- #9695 — `Tech Debt: Harden media buffering loop against mid-wait error/close in UUAV backend`: tech debt (labeled tech debt), not a bug.
- #9741 — `System.NullReferenceException: Object reference not set to an instance of an object.`: already being fixed in open PR https://github.com/decentraland/unity-explorer/pull/9765.
- #9738 — `System.ArgumentException: Could not determine JSON object type for type DCL.Profiles.UserId.`: already being fixed in open PR https://github.com/decentraland/unity-explorer/pull/9765.
- #9762 — `DCL.Web3.Web3Exception: RPC eth_call failed: code 3 execution reverted: You ... are not authorised to use this classroom.`: expected smart contract authorization error, not a client bug.
- #9753 — `U3CRunScenesForEquippedWearablesAsyncU3Ed__31...`: native `EXCEPTION_ACCESS_VIOLATION_READ` crash; requires platform-specific debugging, complexity too high.
- #9743 — `Mac OBS window capture broken after v0.168.0-alpha native binary changes`: Mac-only native binary issue; requires macOS testing environment the sweep cannot provide.
- #9729 — `[QA] Genesis Plaza | Assets fail to finish loading after returning from Meta Gamimall`: intermittent (could not reproduce on follow-up), likely transient network issue.
- #9714 — `Fishing Pond completely non-functional when scene backend is unreachable`: root cause in scene backend/scene code; labeled content-team, fix belongs in scene code.
- #9677 — `Camera input detaches from mouse after returning from background (AFK)`: intermittent (2/10), complex D3D/input interaction after background; requires specific reproduction.
- #9686 — `System.NullReferenceException: Object reference not set to an instance of an object.`: generic il2cpp NullRef in `GetFirst` with no source paths; insufficient info to locate source.

### Automated steps and human review

The cross-model auth review (Claude and Codex) was **waived** by Alejandro Jimenez (no Codex credentials on this machine). The CI gate runs next as an automated step. The Lint job is intentionally left red for the team's manual lint pass. Full human DEV review and QA remain required: this PR stays a draft until the team takes it.

## Test Instructions

This PR touches many unrelated areas (profiles, WebSockets, map, GLTF loading, graphics settings, GPU instancing), so QA please run a **full smoke test** of the client on the PR build, then pay special attention to the points below. None of them require technical tooling.

**Graphics settings persistence (#9814)**
- On a machine that shows the "minimum requirements not met" screen at startup: the first launch should come up in Low quality. Change the quality preset (e.g. to Medium or High), change a couple of individual settings (resolution, render distance), close the client completely and reopen. Everything you changed must still be there.
- On a machine that passes the requirements check: same steps; settings must also survive a restart (this should behave as before).
- Toggle "Don't show again" on the minimum requirements screen, restart, and confirm the graphics settings are still preserved.

**Profiles (#9733)**
- Walk around a crowded place (Genesis Plaza spawn, a busy event) and confirm other avatars, their names and their profile pictures load. Open a few passports (own and other users'). Nothing should appear as a blank or "unknown" profile for people that are clearly there.

**Scenes using WebSockets and RPC (#9761, #9676, #9760)**
- Visit scenes that keep a live connection (multiplayer minigames, chat-driven or backend-driven scenes such as the Fishing Pond or casino-style games) and then teleport away mid-interaction, several times in a row. The client must stay stable, and the next scene must load normally.
- Teleport between worlds and Genesis Plaza repeatedly, including while a scene is still loading.

**Map (#9679)**
- Open the map, zoom and pan quickly across large areas, switch between satellite and parcel views, and close the map while tiles are still loading. Reopen and confirm tiles fill in correctly.

**Content with broken textures (#9674)**
- Visit a few worlds and Genesis Plaza scenes with lots of external textures. Models whose textures fail to download should simply not appear (or appear without that model) and the rest of the scene must keep loading; there must be no freeze or crash.

**Places and donations (#9689)**
- Open the donations or place info UI on parcels that are not registered as a place (an empty parcel, a road). The UI must handle the "no place" case gracefully instead of hanging or erroring.

**Wallet and signed requests (#9735)**
- Log in with a wallet and perform actions that need a signed request: claiming a name, changing the avatar and saving, deploying a profile change, opening a scene that requires authentication. All must go through.

**GPU instancing (#9745)**
- On a low-end or older laptop (integrated GPU), confirm the world renders and there are no visual gaps in trees, grass or repeated props.

**General**
- Quit the client from the menu and via the window close button after a long session and confirm it exits cleanly.

## Quality Checklist
- [x] Changes have been tested locally (compilation verified per commit)
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered (all fixes are defensive guards, no hot-path changes)

Requested by Alejandro Jimenez via Slack
