### PR TITLE
chore: avoid hover state on base items

### DIFF
--- a/Explorer/Assets/DCL/Passport/Fields/EquippedItemPassportFieldView.cs
+++ b/Explorer/Assets/DCL/Passport/Fields/EquippedItemPassportFieldView.cs
@@ -80,11 +80,13 @@ namespace DCL.Passport.Fields
 
         public URN ItemId { get; set; }
 
+        public bool CanHover { get; set; } = true;
+
         public Action<URN>? EmoteClicked;
 
         public Action? WearableClicked;
 
-        private CancellationTokenSource cts;
+        private CancellationTokenSource? cts;
 
         private void Awake()
         {
@@ -92,14 +94,25 @@ namespace DCL.Passport.Fields
             ViewButton.onClick.AddListener(() => UIAudioEventsBus.Instance.SendPlayAudioEvent(BuyAudio));
         }
 
+        private void OnDisable()
+        {
+            ContainerTransform.localScale = Vector3.one;
+            HoverBackgroundTransform.localScale = Vector3.zero;
+            HoverBackgroundTransform.gameObject.SetActive(false);
+        }
+
         public void OnPointerEnter(PointerEventData eventData)
         {
+            if (!CanHover) return;
+
             AnimateHover();
             UIAudioEventsBus.Instance.SendPlayAudioEvent(HoverAudio);
         }
 
         public void OnPointerExit(PointerEventData eventData)
         {
+            if (!CanHover) return;
+
             AnimateExit();
         }
 

--- a/Explorer/Assets/DCL/Passport/Fields/EquippedItemPassportFieldView.cs
+++ b/Explorer/Assets/DCL/Passport/Fields/EquippedItemPassportFieldView.cs
@@ -96,6 +96,8 @@ namespace DCL.Passport.Fields
 
         private void OnDisable()
         {
+            cts?.SafeCancelAndDispose();
+            cts = null;
             ContainerTransform.localScale = Vector3.one;
             HoverBackgroundTransform.localScale = Vector3.zero;
             HoverBackgroundTransform.gameObject.SetActive(false);

--- a/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
@@ -57,8 +57,7 @@ namespace DCL.Passport.Modules
         private readonly List<(EquippedItemPassportFieldView view, string urn)> primaryListingCandidates = new ();
         private readonly Dictionary<string, int> onSalePrices = new (StringComparer.OrdinalIgnoreCase);
 
-        private Profile currentProfile;
-        private CancellationTokenSource getEquippedItemsCts;
+        private CancellationTokenSource? getEquippedItemsCts;
 
         public EquippedItemsPassportModuleController(
             EquippedItemsPassportModuleView view,
@@ -120,6 +119,7 @@ namespace DCL.Passport.Modules
                     equippedItemView.ViewButton.onClick.RemoveAllListeners();
                     equippedItemView.EmoteClicked = null;
                     equippedItemView.WearableClicked = null;
+                    equippedItemView.CanHover = true;
                 });
 
             emptyItemsPool = new ObjectPool<EquippedItemPassportFieldView>(
@@ -134,12 +134,8 @@ namespace DCL.Passport.Modules
                 actionOnRelease: emptyItemView => emptyItemView.gameObject.SetActive(false));
         }
 
-        public void Setup(Profile profile)
-        {
-            currentProfile = profile;
-
-            LoadEquippedItems();
-        }
+        public void Setup(Profile profile) =>
+            LoadEquippedItems(profile);
 
         public void Clear()
         {
@@ -160,23 +156,23 @@ namespace DCL.Passport.Modules
             return equippedItemView;
         }
 
-        private void LoadEquippedItems()
+        private void LoadEquippedItems(Profile profile)
         {
             Clear();
             SetGridAsLoading();
 
             WearablePromise equippedWearablesPromise = WearablePromise.Create(
                 world,
-                WearableComponentsUtils.CreateGetWearablesByPointersIntention(currentProfile.Avatar.BodyShape, currentProfile.Avatar.Wearables, currentProfile.Avatar.ForceRender),
+                WearableComponentsUtils.CreateGetWearablesByPointersIntention(profile.Avatar.BodyShape, profile.Avatar.Wearables, profile.Avatar.ForceRender),
                 PartitionComponent.TOP_PRIORITY);
 
             EmotePromise equippedEmotesPromise = EmotePromise.Create(
                 world,
-                EmoteComponentsUtils.CreateGetEmotesByPointersIntention(currentProfile.Avatar.BodyShape, currentProfile.Avatar.Emotes),
+                EmoteComponentsUtils.CreateGetEmotesByPointersIntention(profile.Avatar.BodyShape, profile.Avatar.Emotes),
                 PartitionComponent.TOP_PRIORITY);
 
             getEquippedItemsCts = getEquippedItemsCts.SafeRestart();
-            AwaitEquippedItemsPromiseAsync(equippedWearablesPromise, equippedEmotesPromise, getEquippedItemsCts.Token).Forget();
+            AwaitEquippedItemsPromiseAsync(equippedWearablesPromise, equippedEmotesPromise, profile, getEquippedItemsCts.Token).Forget();
         }
 
         private void SetGridAsLoading()
@@ -189,11 +185,11 @@ namespace DCL.Passport.Modules
             }
         }
 
-        private void SetGridElements(List<IWearable> gridWearables, IReadOnlyList<IEmote> gridEmotes)
+        private void SetGridElements(List<IWearable> gridWearables, IReadOnlyList<IEmote> gridEmotes, Profile profile, CancellationToken ct)
         {
             ClearLoadingItems();
 
-            HashSet<string> hidesList = Wearable.ComposeHiddenCategories(currentProfile.Avatar.BodyShape, gridWearables, currentProfile.Avatar.ForceRender);
+            HashSet<string> hidesList = Wearable.ComposeHiddenCategories(profile.Avatar.BodyShape, gridWearables, profile.Avatar.ForceRender);
             var elementsAddedInTheGird = 0;
 
             foreach (IWearable wearable in gridWearables)
@@ -225,16 +221,19 @@ namespace DCL.Passport.Modules
                 equippedWearableItem.ItemPriceContainer.SetActive(false);
                 string wearableUrn = wearable.GetUrn();
                 var wearableItemView = equippedWearableItem;
-                equippedWearableItem.BuyButton.onClick.AddListener(() => OnBuyClicked(wearableItemView, wearableUrn, marketPlaceLink, rarityName, raritySprite, rarityColor));
+                equippedWearableItem.BuyButton.onClick.AddListener(() => OnBuyClicked(wearableItemView, wearableUrn, marketPlaceLink, rarityName, raritySprite, rarityColor, ct));
                 equippedWearableItem.WearableClicked = onWearableClicked;
 
-                if (wearable.IsOnChain() && marketPlaceLink != string.Empty)
+                bool hasMarketplaceActions = wearable.IsOnChain() && marketPlaceLink != string.Empty;
+                equippedWearableItem.CanHover = hasMarketplaceActions;
+
+                if (hasMarketplaceActions)
                 {
                     equippedWearableItem.ViewButton.onClick.AddListener(() => webBrowser.OpenUrlMainThreadOnly(marketPlaceLink));
                     primaryListingCandidates.Add((equippedWearableItem, wearableUrn));
                 }
 
-                WaitForThumbnailAsync(wearable, equippedWearableItem, getEquippedItemsCts.Token).Forget();
+                WaitForThumbnailAsync(wearable, equippedWearableItem, ct).Forget();
                 instantiatedEquippedItems.Add(equippedWearableItem);
                 elementsAddedInTheGird++;
             }
@@ -261,16 +260,19 @@ namespace DCL.Passport.Modules
                 equippedWearableItem.ItemPriceContainer.SetActive(false);
                 string emoteUrn = emote.GetUrn();
                 var emoteItemView = equippedWearableItem;
-                equippedWearableItem.BuyButton.onClick.AddListener(() => OnBuyClicked(emoteItemView, emoteUrn, marketPlaceLink, rarityName, raritySprite, rarityColor));
+                equippedWearableItem.BuyButton.onClick.AddListener(() => OnBuyClicked(emoteItemView, emoteUrn, marketPlaceLink, rarityName, raritySprite, rarityColor, ct));
                 equippedWearableItem.EmoteClicked = onEmoteClicked;
 
-                if (emote.IsOnChain() && rarityName != "base" && marketPlaceLink != string.Empty)
+                bool hasEmoteMarketplaceActions = emote.IsOnChain() && rarityName != "base" && marketPlaceLink != string.Empty;
+                equippedWearableItem.CanHover = hasEmoteMarketplaceActions;
+
+                if (hasEmoteMarketplaceActions)
                 {
                     equippedWearableItem.ViewButton.onClick.AddListener(() => webBrowser.OpenUrlMainThreadOnly(marketPlaceLink));
                     primaryListingCandidates.Add((equippedWearableItem, emoteUrn));
                 }
 
-                WaitForThumbnailAsync(emote, equippedWearableItem, getEquippedItemsCts.Token).Forget();
+                WaitForThumbnailAsync(emote, equippedWearableItem, ct).Forget();
                 instantiatedEquippedItems.Add(equippedWearableItem);
                 elementsAddedInTheGird++;
             }
@@ -285,7 +287,7 @@ namespace DCL.Passport.Modules
             }
 
             if (primaryListingCandidates.Count > 0)
-                ResolvePrimaryListingsAsync(getEquippedItemsCts.Token).Forget();
+                ResolvePrimaryListingsAsync(ct).Forget();
         }
 
         private async UniTaskVoid ResolvePrimaryListingsAsync(CancellationToken ct)
@@ -355,6 +357,7 @@ namespace DCL.Passport.Modules
         private async UniTaskVoid AwaitEquippedItemsPromiseAsync(
             WearablePromise equippedWearablesPromise,
             EmotePromise equippedEmotesPromise,
+            Profile profile,
             CancellationToken ct
         )
         {
@@ -364,7 +367,7 @@ namespace DCL.Passport.Modules
                 var emotesUniTaskAsync = await equippedEmotesPromise.ToUniTaskAsync(world, cancellationToken: ct);
                 var currentWearables = wearablesUniTaskAsync.Result!.Value.Asset.Wearables;
                 using var consumed = emotesUniTaskAsync.Result!.Value.Asset.ConsumeEmotes();
-                SetGridElements(currentWearables, consumed.Value);
+                SetGridElements(currentWearables, consumed.Value, profile, ct);
             }
             catch (OperationCanceledException) { }
             catch (Exception e)
@@ -433,7 +436,7 @@ namespace DCL.Passport.Modules
             instantiatedEmptyItems.Clear();
         }
 
-        private void OnBuyClicked(EquippedItemPassportFieldView itemView, string urn, string marketplaceLink, string rarityName, Sprite raritySprite, Color rarityColor)
+        private void OnBuyClicked(EquippedItemPassportFieldView itemView, string urn, string marketplaceLink, string rarityName, Sprite raritySprite, Color rarityColor, CancellationToken ct)
         {
             var visuals = new CreditPurchaseBuyHandler.ItemVisuals(
                 itemView.AssetNameText.text,
@@ -447,7 +450,7 @@ namespace DCL.Passport.Modules
                                          urn, marketplaceLink, visuals,
                                          CreditPurchaseModalControllerParams.SOURCE_PASSPORT_EQUIPPED,
                                          resolving => itemView.BuyButton.interactable = !resolving,
-                                         getEquippedItemsCts.Token)
+                                         ct)
                                     .Forget();
         }
 


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #9851
Removes hover state from base wearables/emotes in equipped items in passport

## Test Instructions

### Test Steps
1. Open the client
2. Open a passport
3. Check that when hovering base wearables or emotes nothing happens and when hovering other items it either shows the "View" or "Buy" buttons

### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
