### PR TITLE
chore: upgrade AltTester SDK to 2.3.2

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/Authentication.MainScreen.prefab
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/Authentication.MainScreen.prefab
@@ -1764,7 +1764,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5609746862316879584}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: f658ab9f-18ac-4281-a0a9-dd030d8224d6

--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/Lobby.ExistingAccount.Screen.prefab
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Assets/Prefabs/Lobby.ExistingAccount.Screen.prefab
@@ -996,7 +996,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5389577515283649128}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: f658ab9f-18ac-4281-a0a9-dd030d8224d6
@@ -1252,7 +1252,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7689646548246359426}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: 646623d5-3519-49df-93ed-ab668d7917db

--- a/Explorer/Assets/DCL/PluginSystem/DCL.Plugins.asmdef
+++ b/Explorer/Assets/DCL/PluginSystem/DCL.Plugins.asmdef
@@ -66,8 +66,6 @@
         "GUID:29f99fa49221a4df7aecb5cd50457e5f",
         "GUID:4fd6538c1c56b409fb53fdf0183170ec",
         "GUID:03a95e8e68fa74ca9a0d562b5f4e25a6",
-        "GUID:478b585cfbb242f4c977b9aec772e042",
-        "GUID:451516970bc990e418454aa78b72586e",
         "GUID:13c468c9ecfc44f249fb8fb69d3365ef",
         "GUID:a42927d1d4a3b4cda9b076a7adecb9cc",
         "GUID:63cde67b4a5d47449392dfc49fc0c3ed",
@@ -76,7 +74,9 @@
         "GUID:3c1a9be47d0f42e2a5b8c6d4e9f01a27",
         "GUID:f254b2009e854709a0ef0022a7ca697c",
         "GUID:4d072b9bce344c9bbcff885117cf1e6f",
-        "GUID:d9709898aa920584a8d1613950e6a7f5"
+        "GUID:d9709898aa920584a8d1613950e6a7f5",
+        "GUID:eee039289058c11488eadb061b907256",
+        "GUID:65a29c49e7f0a114b9b037bdd900b22d"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Explorer/Assets/DCL/SceneLoadingScreens/Assets/SceneLoadingScreen.prefab
+++ b/Explorer/Assets/DCL/SceneLoadingScreens/Assets/SceneLoadingScreen.prefab
@@ -1177,7 +1177,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5357728835287357475}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: 21e9d696-d866-4717-85c0-2b6e4f1c4d9d

--- a/Explorer/Assets/DCL/Tests/AltTesterPrefab.prefab
+++ b/Explorer/Assets/DCL/Tests/AltTesterPrefab.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 8822d0e283abb1d44964e22569f5a011, type: 3}
+  m_Sprite: {fileID: 21300000, guid: a9e8db0a71625a94a97f27dbd4d2e89c, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -314,7 +314,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 212363110374917436}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 651474b9cdd0b1d4a92d9d3416000da5, type: 3}
+  m_Script: {fileID: 11500000, guid: df192bb29e622bd4694ea5c2437659ba, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   Text: {fileID: 8575710879793556971}
@@ -842,7 +842,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 4a2e4cd0504c4964fbce0c4e31fb6410, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 5f14ae244fc98bc49b054c27ec3a710d, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -985,7 +985,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1889585028289878094}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fc365c0dc78f7e34f8ba48456cddc9a0, type: 3}
+  m_Script: {fileID: 11500000, guid: 802af312605840549b3dc437cb1fe036, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1936436057481477321
@@ -1088,7 +1088,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 72c67a25b84656e43af89d4eacc31abd, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 4f8180fcf473e7043aadda7decb898fc, type: 3}
   m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1163,7 +1163,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: fe5e6953523432d4f850960ddeaf5e19, type: 3}
+  m_Sprite: {fileID: 21300000, guid: cf6426de832f55c41ac985fbaf16091b, type: 3}
   m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1238,7 +1238,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 05e39baf58601be419cc09cdcfd8df9e, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 45ed05361037ca5438b93c8f6890b5e7, type: 3}
   m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1313,7 +1313,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 50a07d880f2f1a84386ea31e9e5f789a, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 2eb9e2929b505f04eb32f56d3ed81cca, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1388,7 +1388,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 34a92ecb1198e534a8d7bd1273e1226a, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 6a32ad35dcd05d84a85dfcb7437e805d, type: 3}
   m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1662,7 +1662,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 8822d0e283abb1d44964e22569f5a011, type: 3}
+  m_Sprite: {fileID: 21300000, guid: a9e8db0a71625a94a97f27dbd4d2e89c, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1916,7 +1916,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 25a0da3bd23a7fa488dddbe808077c27, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 617531928831c414983971e85227ced1, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -2041,7 +2041,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 3812597226495818757}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0e6efbba2fb4d984395ab65bb74c5d34, type: 3}
+  m_Script: {fileID: 11500000, guid: 1cf4fdc76bd8267468e34ad251c747d1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   Dialog: {fileID: 3786285706776509272}
@@ -2206,7 +2206,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 8822d0e283abb1d44964e22569f5a011, type: 3}
+  m_Sprite: {fileID: 21300000, guid: a9e8db0a71625a94a97f27dbd4d2e89c, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -2350,7 +2350,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 72c67a25b84656e43af89d4eacc31abd, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 4f8180fcf473e7043aadda7decb898fc, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -2661,7 +2661,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 4a2e4cd0504c4964fbce0c4e31fb6410, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 5f14ae244fc98bc49b054c27ec3a710d, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -2926,7 +2926,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 72c67a25b84656e43af89d4eacc31abd, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 4f8180fcf473e7043aadda7decb898fc, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3210,7 +3210,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 4a2e4cd0504c4964fbce0c4e31fb6410, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 5f14ae244fc98bc49b054c27ec3a710d, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3755,7 +3755,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 0f1a80f61f5b88b4e936cd2851440318, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ec0a1f3007218a547a19aff34caf3e4e, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3818,7 +3818,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5977863811711833246}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d187692c75363b842b0a863dfac6d44e, type: 3}
+  m_Script: {fileID: 11500000, guid: 35acdf08c156429499b2d5a0014ee2c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &6077940154558083666
@@ -3945,7 +3945,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6159525817960279506}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d19d5afb9a9fc1b4082566f125895057, type: 3}
+  m_Script: {fileID: 11500000, guid: d9461d95c13ca8b47a14f5f1aa3c444b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   InstrumentationSettings:
@@ -3957,8 +3957,8 @@ MonoBehaviour:
     hideGreenPopup: 0
     SecureMode: 0
   RunOnlyInDebugMode: 0
-  outlineShader: {fileID: 4800000, guid: 37d07aac6f4b1dc48924e98e1e398261, type: 3}
-  panelHighlightPrefab: {fileID: 1422609480502334, guid: c2c3ede7bbf3b184c9c6d7cc4cf5cad3, type: 3}
+  outlineShader: {fileID: 4800000, guid: 698c228925185b64cad97ac6452f5cf7, type: 3}
+  panelHighlightPrefab: {fileID: 1422609480502334, guid: a4994d58397195a41a556ffdd46ba2ac, type: 3}
 --- !u!114 &2971724717584492281
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3968,7 +3968,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6159525817960279506}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 96b56d6c81dea584c910fa6a028173dc, type: 3}
+  m_Script: {fileID: 11500000, guid: b45a0e81952915c43ac6b2462a8f7836, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1413397616073838405
@@ -3980,7 +3980,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6159525817960279506}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 034fc8215b30f0d45981e6bab63f47ed, type: 3}
+  m_Script: {fileID: 11500000, guid: 58fcf156a8930314ebb879c876169d07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &8390738367341526159
@@ -3992,7 +3992,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6159525817960279506}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6813daf4747c35e43b4754475126e192, type: 3}
+  m_Script: {fileID: 11500000, guid: e8eeb46a479712d48a47a9efd791f720, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &6243163902643143761
@@ -4380,7 +4380,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: f9301432d9da3b64ea48b722e25c926e, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 10f2419592c0831409279ea506c4b2c5, type: 3}
   m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -4919,7 +4919,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 63c8824f1ca5570478e7cacf6d64ba99, type: 3}
+  m_Sprite: {fileID: 21300000, guid: b541b27a958a4bf4bb70642ab6b97b11, type: 3}
   m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -5412,7 +5412,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8837510905525967454}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f286e42af0bc2af43b5a46c109f35f98, type: 3}
+  m_Script: {fileID: 11500000, guid: 9291367ab06ca9d4fafb3001f3b091c6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   content: {fileID: 0}

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarUI.UpperLayout.prefab
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarUI.UpperLayout.prefab
@@ -304,6 +304,57 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2701087397543794371
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7953449017702476265}
+  - component: {fileID: 2406820888901058002}
+  m_Layer: 0
+  m_Name: 'ProfileWidget '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7953449017702476265
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2701087397543794371}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8162449972253969497}
+  - {fileID: 2066465738160586826}
+  m_Father: {fileID: 5604293973387185170}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 32, y: 32}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2406820888901058002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2701087397543794371}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
+  altID: 578d9b4e-0531-4cb3-abd7-aa79506c1b3e
 --- !u!1 &2979024856919112084
 GameObject:
   m_ObjectHideFlags: 0
@@ -441,6 +492,52 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3223751696269984791
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2066465738160586826}
+  - component: {fileID: 4958791656658143303}
+  m_Layer: 0
+  m_Name: Fade View
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2066465738160586826
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3223751696269984791}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7953449017702476265}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4958791656658143303
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3223751696269984791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 38b1c5e9144d4ef39861c60d5bc3c592, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <fadeTime>k__BackingField: 0.3
+  <canvasGroup>k__BackingField: {fileID: 0}
 --- !u!1 &4144449722529127514
 GameObject:
   m_ObjectHideFlags: 0
@@ -1741,915 +1838,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <fadeTime>k__BackingField: 0.3
   <canvasGroup>k__BackingField: {fileID: 4315976975754457615}
---- !u!1001 &1049386857507292966
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 5604293973387185170}
-    m_Modifications:
-    - target: {fileID: 149006659849766582, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 149006659849766582, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 149006659849766582, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 149006659849766582, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 149006659849766582, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 363515293539314694, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 447767288900774538, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 447767288900774538, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 447767288900774538, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 200.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 447767288900774538, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 100.35
-      objectReference: {fileID: 0}
-    - target: {fileID: 447767288900774538, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 656839858989987251, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 833553104246579207, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 833553104246579207, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 833553104246579207, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 833553104246579207, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 84
-      objectReference: {fileID: 0}
-    - target: {fileID: 833553104246579207, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -9.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 1118666486741674552, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1118666486741674552, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1118666486741674552, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 102.44
-      objectReference: {fileID: 0}
-    - target: {fileID: 1118666486741674552, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 1544756424268337630, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1544756424268337630, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1544756424268337630, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 153
-      objectReference: {fileID: 0}
-    - target: {fileID: 1544756424268337630, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -88
-      objectReference: {fileID: 0}
-    - target: {fileID: 1806595204790209810, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1952672235144063778, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1952672235144063778, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1952672235144063778, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 68
-      objectReference: {fileID: 0}
-    - target: {fileID: 1999042224746692006, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 367
-      objectReference: {fileID: 0}
-    - target: {fileID: 2225639335322644723, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2225639335322644723, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2225639335322644723, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -98
-      objectReference: {fileID: 0}
-    - target: {fileID: 2225639335322644723, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -142.48401
-      objectReference: {fileID: 0}
-    - target: {fileID: 2361442920140400118, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2361442920140400118, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2361442920140400118, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 2361442920140400118, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -14.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 2435578464431465326, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2435578464431465326, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2435578464431465326, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 2435578464431465326, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 125
-      objectReference: {fileID: 0}
-    - target: {fileID: 2435578464431465326, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -32
-      objectReference: {fileID: 0}
-    - target: {fileID: 2486793712646182022, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2486793712646182022, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2486793712646182022, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 153
-      objectReference: {fileID: 0}
-    - target: {fileID: 2486793712646182022, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -201
-      objectReference: {fileID: 0}
-    - target: {fileID: 2736657349224603559, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2736657349224603559, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2736657349224603559, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 153
-      objectReference: {fileID: 0}
-    - target: {fileID: 2736657349224603559, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -52.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_TargetGraphic
-      value: 
-      objectReference: {fileID: 6707969730068558145}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_FadeDuration
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.a
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.b
-      value: 0.9882353
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.g
-      value: 0.9882353
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.r
-      value: 0.9882353
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.b
-      value: 0.9882353
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.g
-      value: 0.9882353
-      objectReference: {fileID: 0}
-    - target: {fileID: 2799635841986115080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.r
-      value: 0.9882353
-      objectReference: {fileID: 0}
-    - target: {fileID: 2850157362190994420, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 30
-      objectReference: {fileID: 0}
-    - target: {fileID: 2850157362190994420, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 30
-      objectReference: {fileID: 0}
-    - target: {fileID: 2873917264595470134, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2873917264595470134, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2873917264595470134, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 306
-      objectReference: {fileID: 0}
-    - target: {fileID: 2873917264595470134, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 201
-      objectReference: {fileID: 0}
-    - target: {fileID: 2873917264595470134, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 153
-      objectReference: {fileID: 0}
-    - target: {fileID: 2873917264595470134, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -266.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3164934755188625893, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Name
-      value: ProfileWidget
-      objectReference: {fileID: 0}
-    - target: {fileID: 3164934755188625893, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3494033333838787708, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3494033333838787708, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3494033333838787708, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 72.58
-      objectReference: {fileID: 0}
-    - target: {fileID: 3494033333838787708, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 54.29
-      objectReference: {fileID: 0}
-    - target: {fileID: 3494033333838787708, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -14.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 3946988034471178050, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3946988034471178050, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3946988034471178050, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3946988034471178050, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4363480955202125246, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4363480955202125246, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4363480955202125246, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 4363480955202125246, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 75
-      objectReference: {fileID: 0}
-    - target: {fileID: 4363480955202125246, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -20
-      objectReference: {fileID: 0}
-    - target: {fileID: 4665447407717722650, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4665447407717722650, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4665447407717722650, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 4665447407717722650, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -9.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4858291099790369080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4858291099790369080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4858291099790369080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 250
-      objectReference: {fileID: 0}
-    - target: {fileID: 4858291099790369080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 39.4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4858291099790369080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 125
-      objectReference: {fileID: 0}
-    - target: {fileID: 4858291099790369080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -113.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4867353107941892829, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4867353107941892829, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4867353107941892829, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 4867353107941892829, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 88.44
-      objectReference: {fileID: 0}
-    - target: {fileID: 4867353107941892829, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 5202954973667359572, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5202954973667359572, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5202954973667359572, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 130
-      objectReference: {fileID: 0}
-    - target: {fileID: 5202954973667359572, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 125
-      objectReference: {fileID: 0}
-    - target: {fileID: 5202954973667359572, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -104
-      objectReference: {fileID: 0}
-    - target: {fileID: 5228223446040617401, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5399689864100955811, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 5399689864100955811, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 5399689864100955811, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5399689864100955811, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5690891463911048314, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5690891463911048314, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5690891463911048314, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 156
-      objectReference: {fileID: 0}
-    - target: {fileID: 5690891463911048314, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 178
-      objectReference: {fileID: 0}
-    - target: {fileID: 5690891463911048314, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -9.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5727108152927481385, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5727108152927481385, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5727108152927481385, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 153
-      objectReference: {fileID: 0}
-    - target: {fileID: 5727108152927481385, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -117
-      objectReference: {fileID: 0}
-    - target: {fileID: 5877115019243546634, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5877115019243546634, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5877115019243546634, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 446
-      objectReference: {fileID: 0}
-    - target: {fileID: 5912558610233554149, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5912558610233554149, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5912558610233554149, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 5912558610233554149, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 95
-      objectReference: {fileID: 0}
-    - target: {fileID: 5912558610233554149, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -32
-      objectReference: {fileID: 0}
-    - target: {fileID: 6488240074719360273, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6488240074719360273, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6488240074719360273, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 6488240074719360273, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 106.58
-      objectReference: {fileID: 0}
-    - target: {fileID: 6488240074719360273, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -14.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627630295502461413, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627630295502461413, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627630295502461413, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 446
-      objectReference: {fileID: 0}
-    - target: {fileID: 6627630295502461413, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -29.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6780058889780194640, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6780058889780194640, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6780058889780194640, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 153
-      objectReference: {fileID: 0}
-    - target: {fileID: 6780058889780194640, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6827291156829205339, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6827291156829205339, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6827291156829205339, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 153
-      objectReference: {fileID: 0}
-    - target: {fileID: 6827291156829205339, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -65
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 32
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 32
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7078192909543979200, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7269291478053338860, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7269291478053338860, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7269291478053338860, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 156
-      objectReference: {fileID: 0}
-    - target: {fileID: 7269291478053338860, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 226.58
-      objectReference: {fileID: 0}
-    - target: {fileID: 7269291478053338860, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -14.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 7477156036910135036, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7477156036910135036, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7477156036910135036, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 220.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 7477156036910135036, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 14.650002
-      objectReference: {fileID: 0}
-    - target: {fileID: 7477156036910135036, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -68
-      objectReference: {fileID: 0}
-    - target: {fileID: 7800620263123725287, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7800620263123725287, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7800620263123725287, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 16
-      objectReference: {fileID: 0}
-    - target: {fileID: 7800620263123725287, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 212.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 7800620263123725287, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 7846748625437787228, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7846748625437787228, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7846748625437787228, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 7846748625437787228, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 84
-      objectReference: {fileID: 0}
-    - target: {fileID: 7846748625437787228, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -9.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 7903397570594201269, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Alpha
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8079076780070729544, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: <ProfilePictureView>k__BackingField
-      value: 
-      objectReference: {fileID: 8802532285000384940}
-    - target: {fileID: 8419079392565781790, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 43.97
-      objectReference: {fileID: 0}
-    - target: {fileID: 8419079392565781790, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 16.95
-      objectReference: {fileID: 0}
-    - target: {fileID: 8486975125003500587, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8486975125003500587, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8486975125003500587, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 8486975125003500587, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 132.58
-      objectReference: {fileID: 0}
-    - target: {fileID: 8486975125003500587, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -14.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 8532396370851822974, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8667994790311820080, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842069803793742325, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8965938301174026105, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8965938301174026105, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8965938301174026105, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 68
-      objectReference: {fileID: 0}
-    - target: {fileID: 8965938301174026105, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -0.01499939
-      objectReference: {fileID: 0}
-    - target: {fileID: 9123167509379526391, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9123167509379526391, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9123167509379526391, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 125
-      objectReference: {fileID: 0}
-    - target: {fileID: 9123167509379526391, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 9199684697179890385, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Color.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9199684697179890385, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Color.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9199684697179890385, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9201780729106875205, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      propertyPath: <viewAnimationElement>k__BackingField
-      value: 
-      objectReference: {fileID: 4958791656658143303}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 7217937649262533783, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      insertIndex: 1
-      addedObject: {fileID: 8162449972253969497}
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3164934755188625893, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2406820888901058002}
-  m_SourcePrefab: {fileID: 100100000, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
---- !u!1 &2701087397543794371 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3164934755188625893, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-  m_PrefabInstance: {fileID: 1049386857507292966}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &2406820888901058002
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2701087397543794371}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
-  altID: 578d9b4e-0531-4cb3-abd7-aa79506c1b3e
---- !u!114 &4958791656658143303 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5350559431428411233, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-  m_PrefabInstance: {fileID: 1049386857507292966}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 38b1c5e9144d4ef39861c60d5bc3c592, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &6707969730068558145 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6018873042885719655, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-  m_PrefabInstance: {fileID: 1049386857507292966}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2701087397543794371}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &7953449017702476265 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6985215476544204495, guid: 2936d4da401930d4f8fef6fefb4010b1, type: 3}
-  m_PrefabInstance: {fileID: 1049386857507292966}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2987018616467084711
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3534,6 +2722,10 @@ PrefabInstance:
       propertyPath: m_Color.r
       value: 0.9882353
       objectReference: {fileID: 0}
+    - target: {fileID: 8114625593911211747, guid: 571c63ddcf1523b45a64fabd71cb6dd5, type: 3}
+      propertyPath: <Animator>k__BackingField
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 8350839749097872697, guid: 571c63ddcf1523b45a64fabd71cb6dd5, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -4197,6 +3389,10 @@ PrefabInstance:
     - target: {fileID: 7727841365288015261, guid: 571c63ddcf1523b45a64fabd71cb6dd5, type: 3}
       propertyPath: m_Color.r
       value: 0.9882353
+      objectReference: {fileID: 0}
+    - target: {fileID: 8114625593911211747, guid: 571c63ddcf1523b45a64fabd71cb6dd5, type: 3}
+      propertyPath: <Animator>k__BackingField
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 8350839749097872697, guid: 571c63ddcf1523b45a64fabd71cb6dd5, type: 3}
       propertyPath: m_Sprite
@@ -5944,54 +5140,13 @@ PrefabInstance:
     - {fileID: 605195446501450412, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
---- !u!1 &52989549808054595 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8279587512889529381, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 8240251751527589222}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2090352738614828343 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8023494731595085905, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 8240251751527589222}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2954173465583071388 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6531367703513470458, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 8240251751527589222}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &4520530142144955990 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5541511638230278960, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 8240251751527589222}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &5043809341729408888 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4009457732993393182, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 8240251751527589222}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &7425791407916319598 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1537685419818722824, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 8240251751527589222}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &8162449972253969497 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 224503025678412095, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
   m_PrefabInstance: {fileID: 8240251751527589222}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &8802532285000384940 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 609007630589666506, guid: d64840fd5d5fce94fbdc7bddcba01226, type: 3}
-  m_PrefabInstance: {fileID: 8240251751527589222}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 946db314bdcc52a41a226ff3aa3acbbd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &8553170414100292711
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Explorer/Assets/DCL/UI/Sidebar/SidebarUI.UpperLayout.prefab
+++ b/Explorer/Assets/DCL/UI/Sidebar/SidebarUI.UpperLayout.prefab
@@ -351,7 +351,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2701087397543794371}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: 578d9b4e-0531-4cb3-abd7-aa79506c1b3e
@@ -2125,7 +2125,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7490815415717683088}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: 6d5004d7-5a52-4250-b98a-5799f5e8c011
@@ -2426,7 +2426,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8942068644871046246}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: c02afb7d-0abf-405e-9ecc-48f8cf439f42
@@ -2805,7 +2805,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8206282766637760415}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: 6f7c9619-29d4-4dfd-8aad-f8b10f56939a
@@ -3110,7 +3110,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 387287709822616881}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: bcd4b7ed-97f9-419c-8df8-d8a0218388d2
@@ -3446,7 +3446,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 183411571288936256}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: 31e1fb4b-d737-4351-bc21-97e00f715ebe
@@ -3718,7 +3718,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7622781240046919012}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: a7a98fe6-eca1-4f67-996e-2049c9e020bb
@@ -4431,7 +4431,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 3078779584757382257}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: e4146db9-0b45-4c41-8cf0-2cde69a0ce0a
@@ -4741,7 +4741,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2925648907289079589}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: 9335caa1-070d-47cd-92f8-2ab0bee06003
@@ -4996,7 +4996,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2722842281692472996}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: 2b8e4546-23be-4e65-973b-7928eb02f238
@@ -5448,7 +5448,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 4049380762749021776}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: d5ac3302-135f-4d89-9af3-56df31776664
@@ -5843,7 +5843,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 3671733143938358266}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: 6c66dc7b-5c51-4b1c-bd27-0814d9c837ae
@@ -6164,7 +6164,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 3475900214682956899}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ea1b65aaa149fa438425d71fd8122ab, type: 3}
+  m_Script: {fileID: 11500000, guid: ccb518956bdb80a43a6725ce85d9fa79, type: 3}
   m_Name: 
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK::AltTester.AltTesterUnitySDK.AltId
   altID: bab6108c-7cce-45a1-9bcd-40412c1f435e

--- a/Explorer/Assets/Plugins/AltTester/AltTesterEditorSettings.asset
+++ b/Explorer/Assets/Plugins/AltTester/AltTesterEditorSettings.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 073b5878cbef2364cb928faafba64ca5, type: 3}
+  m_Script: {fileID: 11500000, guid: 8775a984e9d6279448cd0893c1c48334, type: 3}
   m_Name: AltTesterEditorSettings
   m_EditorClassIdentifier: AltTester.AltTesterUnitySDK.Editor::AltTester.AltTesterUnitySDK.Editor.AltEditorConfiguration
   appendToName: 0

--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "arch.systemgroups.visualiser": "https://github.com/m3taphysics/Arch.SystemGroups.Visualiser.git?path=/Packages/arch.systemgroups.visualiser",
-    "com.alttester.sdk": "2.3.0",
+    "com.alttester.sdk": "2.3.2",
     "com.arch.systemgroups": "https://github.com/mikhail-dcl/Arch.SystemGroups.git?path=/Arch.SystemGroups",
     "com.atteneder.draco": "4.0.2",
     "com.atteneder.gltfast": "https://github.com/decentraland/unity-gltf.git",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "hash": "e368e96fa8145bfca6ad2947ca60c427d4a81d74"
     },
     "com.alttester.sdk": {
-      "version": "2.3.0",
+      "version": "2.3.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -20,7 +20,7 @@
         "com.unity.modules.unitywebrequest": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.1.0",
         "com.unity.test-framework": "1.1.33",
-        "com.unity.ugui": "2.0.0"
+        "com.unity.ugui": "1.0.0"
       },
       "url": "https://package.openupm.com"
     },


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Upgrades `com.alttester.sdk` from `2.3.0` to `2.3.2`.

The 2.3.2 package regenerated **336 of 340** `.meta` GUIDs, which broke every project reference into it — the `AltId` components on our UI prefabs, and the whole `AltTesterPrefab` (runner, input, dialog, console viewer, outline shader, panel prefab, editor sprites). Without the remap those show up as missing scripts and the AltTester overlay does not come up, so automation cannot attach.

Rebuilt the old→new GUID map by matching relative paths between the two `Library/PackageCache` folders, then remapped the **24 GUIDs the project actually references** across 6 assets:

| File | Refs |
|---|---|
| `Explorer/Assets/DCL/Tests/AltTesterPrefab.prefab` | 28 |
| `Explorer/Assets/DCL/UI/Sidebar/SidebarUI.UpperLayout.prefab` | 13 |
| `Explorer/Assets/DCL/AuthenticationScreenFlow/.../Lobby.ExistingAccount.Screen.prefab` | 2 |
| `Explorer/Assets/DCL/AuthenticationScreenFlow/.../Authentication.MainScreen.prefab` | 1 |
| `Explorer/Assets/DCL/SceneLoadingScreens/Assets/SceneLoadingScreen.prefab` | 1 |
| `Explorer/Assets/Plugins/AltTester/AltTesterEditorSettings.asset` | 1 |

`DCL.Plugins.asmdef` also picks up the new `AltTester.AltTesterUnitySDK` / `.Driver` asmdef GUIDs.

Notes on why this is safe:

- Sub-asset `fileID`s are unchanged — `11500000` (MonoScript), `21300000` (single-sprite textures; the new metas carry an empty `nameFileIdTable`), `4800000` (shader), and `1422609480502334` for `AltTester_Panel.prefab`, which is byte-identical between the two versions.
- The four files 2.3.2 drops (`Examples/**` and `Resources` folder metas) were not referenced, so nothing is orphaned.
- Every GUID now referenced was verified to resolve to a real `.meta` in `com.alttester.sdk@365075d32da4`, and no old GUID remains anywhere in the repo.
- Each asset is byte-exact against its previous version with only the 32-char GUID substitutions applied (raw-binary rewrite, no line-ending churn on the `binary`-attributed prefabs).

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 9855
```

**Expected result**:
Explorer launches with the AltTester overlay reachable and no missing-script warnings on the auth screen, loading screen, or sidebar.

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run 9855
```

**Expected result**:
Same as above through the full first-run auth flow — `AltId` is attached to auth-screen and sidebar elements, so a broken reference would surface there first.

**Automation** (if applicable):
```bash
metaforge explorer test 9855
```

The `Category=InWorld` suite is the real check here: it drives the client through AltTester, so it only passes if every remapped reference resolved. Dispatched on this PR.

### Prerequisites
- [ ] Nothing beyond a normal Explorer build — no feature flag or config change

### Test Steps
1. Open the project in Unity and let it reimport; the Console must show no `The referenced script ... is missing` warnings.
2. Open `Explorer/Assets/DCL/Tests/AltTesterPrefab.prefab` and confirm every component resolves, the outline shader is assigned on `AltRunner`, and `panelHighlightPrefab` points at `AltTester_Panel`.
3. Open `SidebarUI.UpperLayout.prefab`, `Authentication.MainScreen.prefab`, `Lobby.ExistingAccount.Screen.prefab`, and `SceneLoadingScreen.prefab` — the `AltId` components must be present, not "missing script".
4. Enter Project Settings / the AltTester editor window and confirm `AltTesterEditorSettings.asset` loads its inspector rather than showing an unresolved script.
5. Run the in-world suite and confirm it attaches and passes.

### Additional Testing Notes
- If Unity was open while this branch was checked out, reimport before judging: a stale AssetDatabase can report missing scripts that a fresh import resolves.
- 2.3.2 adds `NativeInputHandler`, `BaseUiToolkitFindElement`, and `AltGetVisualElementPropertyCommand`. This PR only restores the existing references — it does not adopt those, so no UI Toolkit query support is expected yet.
- 2.3.2 also changed import settings on the editor sprites (mipmaps, wrap mode, max size). Editor-window cosmetics only; nothing ships in a player build.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
