### PR TITLE
feat: engine-info loading-screen visible

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/EngineInfo/WriteEngineInfoSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/EngineInfo/WriteEngineInfoSystem.cs
@@ -16,11 +16,13 @@ namespace ECS.Unity.EngineInfo
     {
         private readonly ISceneStateProvider sceneStateProvider;
         private readonly IECSToCRDTWriter ecsToCRDTWriter;
+        private readonly Func<bool> isLoadingScreenOn;
 
-        internal WriteEngineInfoSystem(World world, ISceneStateProvider sceneStateProvider, IECSToCRDTWriter ecsToCRDTWriter) : base(world)
+        internal WriteEngineInfoSystem(World world, ISceneStateProvider sceneStateProvider, IECSToCRDTWriter ecsToCRDTWriter, Func<bool> isLoadingScreenOn) : base(world)
         {
             this.sceneStateProvider = sceneStateProvider;
             this.ecsToCRDTWriter = ecsToCRDTWriter;
+            this.isLoadingScreenOn = isLoadingScreenOn;
         }
 
         public override void Initialize()
@@ -35,12 +37,13 @@ namespace ECS.Unity.EngineInfo
 
         private void PropagateToScene()
         {
-            ecsToCRDTWriter.PutMessage<PBEngineInfo, ISceneStateProvider>(static (component, provider) =>
+            ecsToCRDTWriter.PutMessage<PBEngineInfo, (ISceneStateProvider provider, bool sceneHidden)>(static (component, data) =>
             {
-                component.TickNumber = provider.TickNumber;
-                component.FrameNumber = (uint)(MultithreadingUtility.FrameCount - provider.EngineStartInfo.FrameNumber);
-                component.TotalRuntime = (float)(DateTime.Now - provider.EngineStartInfo.Timestamp).TotalSeconds;
-            }, SpecialEntitiesID.SCENE_ROOT_ENTITY, sceneStateProvider);
+                component.TickNumber = data.provider.TickNumber;
+                component.FrameNumber = (uint)(MultithreadingUtility.FrameCount - data.provider.EngineStartInfo.FrameNumber);
+                component.TotalRuntime = (float)(DateTime.Now - data.provider.EngineStartInfo.Timestamp).TotalSeconds;
+                component.SceneHidden = data.sceneHidden;
+            }, SpecialEntitiesID.SCENE_ROOT_ENTITY, (sceneStateProvider, isLoadingScreenOn()));
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Tests/WriteEngineInfoSystemShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Tests/WriteEngineInfoSystemShould.cs
@@ -1,0 +1,133 @@
+using CRDT;
+using CrdtEcsBridge.Components;
+using CrdtEcsBridge.ECSToCRDTWriter;
+using DCL.ECSComponents;
+using ECS.TestSuite;
+using ECS.Unity.EngineInfo;
+using NSubstitute;
+using NUnit.Framework;
+using SceneRunner.Scene;
+using System;
+
+namespace ECS.Unity.Tests
+{
+    public class WriteEngineInfoSystemShould : UnitySystemTestBase<WriteEngineInfoSystem>
+    {
+        private IECSToCRDTWriter ecsToCRDTWriter = null!;
+        private SceneStateProvider sceneStateProvider = null!;
+        private bool loadingScreenOn;
+
+        [SetUp]
+        public void Setup()
+        {
+            ecsToCRDTWriter = Substitute.For<IECSToCRDTWriter>();
+            sceneStateProvider = new SceneStateProvider();
+            sceneStateProvider.Start(new SceneEngineStartInfo(DateTime.Now, 0));
+            loadingScreenOn = false;
+
+            system = new WriteEngineInfoSystem(world, sceneStateProvider, ecsToCRDTWriter, () => loadingScreenOn);
+        }
+
+        [Test]
+        public void WriteSceneHiddenTrueWhileLoadingScreenIsOn()
+        {
+            // Arrange
+            loadingScreenOn = true;
+
+            // Act
+            system.Update(0);
+
+            // Assert
+            AssertPutMessageReceived(expectedSceneHidden: true);
+        }
+
+        [Test]
+        public void WriteSceneHiddenFalseWhileLoadingScreenIsOff()
+        {
+            // Arrange
+            loadingScreenOn = false;
+
+            // Act
+            system.Update(0);
+
+            // Assert
+            AssertPutMessageReceived(expectedSceneHidden: false);
+        }
+
+        [Test]
+        public void UpdateSceneHiddenWhenLoadingScreenStateFlips()
+        {
+            // Arrange
+            loadingScreenOn = true;
+
+            // Act
+            system.Update(0);
+
+            // Assert
+            AssertPutMessageReceived(expectedSceneHidden: true);
+            ecsToCRDTWriter.ClearReceivedCalls();
+
+            // Act
+            loadingScreenOn = false;
+            system.Update(0);
+
+            // Assert
+            AssertPutMessageReceived(expectedSceneHidden: false);
+            ecsToCRDTWriter.ClearReceivedCalls();
+
+            // Act
+            loadingScreenOn = true;
+            system.Update(0);
+
+            // Assert
+            AssertPutMessageReceived(expectedSceneHidden: true);
+        }
+
+        [Test]
+        public void WriteEngineInfoOnInitialize()
+        {
+            // Arrange
+            loadingScreenOn = true;
+
+            // Act
+            system.Initialize();
+
+            // Assert
+            AssertPutMessageReceived(expectedSceneHidden: true);
+        }
+
+        [Test]
+        public void ApplySceneHiddenToComponent()
+        {
+            // Arrange
+            loadingScreenOn = true;
+            Action<PBEngineInfo, (ISceneStateProvider provider, bool sceneHidden)>? prepareMessage = null;
+            (ISceneStateProvider provider, bool sceneHidden) capturedData = default;
+
+            ecsToCRDTWriter.PutMessage(
+                Arg.Do<Action<PBEngineInfo, (ISceneStateProvider provider, bool sceneHidden)>>(action => prepareMessage = action),
+                Arg.Any<CRDTEntity>(),
+                Arg.Do<(ISceneStateProvider provider, bool sceneHidden)>(data => capturedData = data));
+
+            // Act
+            system.Update(0);
+            var component = new PBEngineInfo();
+            prepareMessage!(component, capturedData);
+
+            // Assert
+            Assert.That(component.SceneHidden, Is.True);
+            Assert.That(component.TickNumber, Is.EqualTo(sceneStateProvider.TickNumber));
+        }
+
+        private void AssertPutMessageReceived(bool expectedSceneHidden)
+        {
+            ecsToCRDTWriter.Received(1)
+                           .PutMessage(
+                                Arg.Any<Action<PBEngineInfo, (ISceneStateProvider provider, bool sceneHidden)>>(),
+                                SpecialEntitiesID.SCENE_ROOT_ENTITY,
+                                Arg.Is<(ISceneStateProvider provider, bool sceneHidden)>(data =>
+                                    data.provider == sceneStateProvider
+                                    && data.sceneHidden == expectedSceneHidden));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Tests/WriteEngineInfoSystemShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/Tests/WriteEngineInfoSystemShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d29f4c475fb6462f96bd2c6c87395d70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/Global/SceneSharedContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/SceneSharedContainer.cs
@@ -54,7 +54,7 @@ namespace Global
             ECSWorldSingletonSharedDependencies sharedDependencies = staticContainer.SingletonSharedDependencies;
             ExposedGlobalDataContainer exposedGlobalDataContainer = staticContainer.ExposedGlobalDataContainer;
 
-            var systemsDependencies = new SystemsDependencies(roomHub, staticContainer.EntityCollidersGlobalCache);
+            var systemsDependencies = new SystemsDependencies(roomHub, staticContainer.EntityCollidersGlobalCache, staticContainer.LoadingStatus);
 
             var ecsWorldFactory = new ECSWorldFactory(sharedDependencies,
                 systemsDependencies,

--- a/Explorer/Assets/DCL/Infrastructure/SceneRunner/ECSWorld/ECSWorldFactory.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRunner/ECSWorld/ECSWorldFactory.cs
@@ -21,6 +21,7 @@ using ECS.StreamableLoading.DeferredLoading;
 using ECS.Unity.EngineInfo;
 using ECS.Unity.ExplorerUiEvents;
 using ECS.Unity.Systems;
+using System;
 using System.Collections.Generic;
 using SystemGroups.Visualiser;
 using Utility.Multithreading;
@@ -34,6 +35,7 @@ namespace SceneRunner.ECSWorld
         private readonly IPartitionSettings partitionSettings;
         private readonly IReadOnlyCameraSamplingData cameraSamplingData;
         private readonly IReadOnlyList<IDCLWorldPlugin> plugins;
+        private readonly Func<bool> isLoadingScreenOn;
 
         public ECSWorldFactory(
             ECSWorldSingletonSharedDependencies sharedDependencies,
@@ -48,6 +50,7 @@ namespace SceneRunner.ECSWorld
             this.systemsDependencies = systemsDependencies;
             this.partitionSettings = partitionSettings;
             this.cameraSamplingData = cameraSamplingData;
+            isLoadingScreenOn = systemsDependencies.LoadingStatus.IsLoadingScreenOn;
         }
 
         public ECSWorldFacade CreateWorld(in ECSWorldFactoryArgs args)
@@ -82,7 +85,7 @@ namespace SceneRunner.ECSWorld
             // Prioritization
             PartitionAssetEntitiesSystem.InjectToWorld(ref builder, partitionSettings, scenePartition, cameraSamplingData, componentPoolsRegistry.GetReferenceTypePool<PartitionComponent>().EnsureNotNull(), persistentEntities.SceneRoot);
             AssetsDeferredLoadingSystem.InjectToWorld(ref builder, singletonDependencies.LoadingBudget, singletonDependencies.MemoryBudget);
-            WriteEngineInfoSystem.InjectToWorld(ref builder, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter);
+            WriteEngineInfoSystem.InjectToWorld(ref builder, sharedDependencies.SceneStateProvider, sharedDependencies.EcsToCRDTWriter, isLoadingScreenOn);
             WriteExplorerUiEventsSystem.InjectToWorld(ref builder, sharedDependencies.ExplorerUiEvents, sharedDependencies.EcsToCRDTWriter, sharedDependencies.SceneStateProvider);
 
             ClearEntityEventsSystem.InjectToWorld(ref builder, sharedDependencies.EntityEventsBuilder);

--- a/Explorer/Assets/DCL/PluginSystem/World/Dependencies/SystemsDependencies.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/Dependencies/SystemsDependencies.cs
@@ -1,5 +1,6 @@
 using DCL.Interaction.Utility;
 using DCL.Multiplayer.Connections.RoomHubs;
+using DCL.RealmNavigation;
 
 namespace DCL.PluginSystem.World.Dependencies
 {
@@ -12,11 +13,13 @@ namespace DCL.PluginSystem.World.Dependencies
     {
         public readonly IRoomHub RoomHub;
         public readonly IEntityCollidersGlobalCache EntityCollidersGlobalCache;
+        public readonly IReadOnlyLoadingStatus LoadingStatus;
 
-        public SystemsDependencies(IRoomHub roomHub, IEntityCollidersGlobalCache entityCollidersGlobalCache)
+        public SystemsDependencies(IRoomHub roomHub, IEntityCollidersGlobalCache entityCollidersGlobalCache, IReadOnlyLoadingStatus loadingStatus)
         {
             RoomHub = roomHub;
             EntityCollidersGlobalCache = entityCollidersGlobalCache;
+            LoadingStatus = loadingStatus;
         }
     }
 }

--- a/Explorer/Assets/Protocol/DecentralandProtocol/EngineInfo.gen.cs
+++ b/Explorer/Assets/Protocol/DecentralandProtocol/EngineInfo.gen.cs
@@ -25,14 +25,14 @@ namespace DCL.ECSComponents {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "Ci1kZWNlbnRyYWxhbmQvc2RrL2NvbXBvbmVudHMvZW5naW5lX2luZm8ucHJv",
-            "dG8SG2RlY2VudHJhbGFuZC5zZGsuY29tcG9uZW50cyJQCgxQQkVuZ2luZUlu",
+            "dG8SG2RlY2VudHJhbGFuZC5zZGsuY29tcG9uZW50cyJmCgxQQkVuZ2luZUlu",
             "Zm8SFAoMZnJhbWVfbnVtYmVyGAEgASgNEhUKDXRvdGFsX3J1bnRpbWUYAiAB",
-            "KAISEwoLdGlja19udW1iZXIYAyABKA1CFKoCEURDTC5FQ1NDb21wb25lbnRz",
-            "YgZwcm90bzM="));
+            "KAISEwoLdGlja19udW1iZXIYAyABKA0SFAoMc2NlbmVfaGlkZGVuGAQgASgI",
+            "QhSqAhFEQ0wuRUNTQ29tcG9uZW50c2IGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::DCL.ECSComponents.PBEngineInfo), global::DCL.ECSComponents.PBEngineInfo.Parser, new[]{ "FrameNumber", "TotalRuntime", "TickNumber" }, null, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::DCL.ECSComponents.PBEngineInfo), global::DCL.ECSComponents.PBEngineInfo.Parser, new[]{ "FrameNumber", "TotalRuntime", "TickNumber", "SceneHidden" }, null, null, null, null)
           }));
     }
     #endregion
@@ -83,6 +83,7 @@ namespace DCL.ECSComponents {
       frameNumber_ = other.frameNumber_;
       totalRuntime_ = other.totalRuntime_;
       tickNumber_ = other.tickNumber_;
+      sceneHidden_ = other.sceneHidden_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -137,6 +138,21 @@ namespace DCL.ECSComponents {
       }
     }
 
+    /// <summary>Field number for the "scene_hidden" field.</summary>
+    public const int SceneHiddenFieldNumber = 4;
+    private bool sceneHidden_;
+    /// <summary>
+    /// visibility state of the scene regarding Explorer fullscreen UI
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool SceneHidden {
+      get { return sceneHidden_; }
+      set {
+        sceneHidden_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -155,6 +171,7 @@ namespace DCL.ECSComponents {
       if (FrameNumber != other.FrameNumber) return false;
       if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(TotalRuntime, other.TotalRuntime)) return false;
       if (TickNumber != other.TickNumber) return false;
+      if (SceneHidden != other.SceneHidden) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -165,6 +182,7 @@ namespace DCL.ECSComponents {
       if (FrameNumber != 0) hash ^= FrameNumber.GetHashCode();
       if (TotalRuntime != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(TotalRuntime);
       if (TickNumber != 0) hash ^= TickNumber.GetHashCode();
+      if (SceneHidden != false) hash ^= SceneHidden.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -195,6 +213,10 @@ namespace DCL.ECSComponents {
         output.WriteRawTag(24);
         output.WriteUInt32(TickNumber);
       }
+      if (SceneHidden != false) {
+        output.WriteRawTag(32);
+        output.WriteBool(SceneHidden);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -217,6 +239,10 @@ namespace DCL.ECSComponents {
         output.WriteRawTag(24);
         output.WriteUInt32(TickNumber);
       }
+      if (SceneHidden != false) {
+        output.WriteRawTag(32);
+        output.WriteBool(SceneHidden);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -235,6 +261,9 @@ namespace DCL.ECSComponents {
       }
       if (TickNumber != 0) {
         size += 1 + pb::CodedOutputStream.ComputeUInt32Size(TickNumber);
+      }
+      if (SceneHidden != false) {
+        size += 1 + 1;
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -256,6 +285,9 @@ namespace DCL.ECSComponents {
       }
       if (other.TickNumber != 0) {
         TickNumber = other.TickNumber;
+      }
+      if (other.SceneHidden != false) {
+        SceneHidden = other.SceneHidden;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -288,6 +320,10 @@ namespace DCL.ECSComponents {
             TickNumber = input.ReadUInt32();
             break;
           }
+          case 32: {
+            SceneHidden = input.ReadBool();
+            break;
+          }
         }
       }
     #endif
@@ -317,6 +353,10 @@ namespace DCL.ECSComponents {
           }
           case 24: {
             TickNumber = input.ReadUInt32();
+            break;
+          }
+          case 32: {
+            SceneHidden = input.ReadBool();
             break;
           }
         }

--- a/Explorer/Assets/Protocol/DecentralandProtocol/PulseClient.gen.cs
+++ b/Explorer/Assets/Protocol/DecentralandProtocol/PulseClient.gen.cs
@@ -47,17 +47,23 @@ namespace Decentraland.Pulse {
             "ZVN0b3AimQEKD1RlbGVwb3J0UmVxdWVzdBIUCgxwYXJjZWxfaW5kZXgYASAB",
             "KAUSHwoKcG9zaXRpb25feBgCIAEoDUILirUYBxUAAIBBGAgSHwoKcG9zaXRp",
             "b25feRgDIAEoDUILirUYBxUAAEhDGA0SHwoKcG9zaXRpb25fehgEIAEoDUIL",
-            "irUYBxUAAIBBGAgSDQoFcmVhbG0YBSABKAkitgMKDUNsaWVudE1lc3NhZ2US",
-            "OQoJaGFuZHNoYWtlGAEgASgLMiQuZGVjZW50cmFsYW5kLnB1bHNlLkhhbmRz",
-            "aGFrZVJlcXVlc3RIABI1CgVpbnB1dBgCIAEoCzIkLmRlY2VudHJhbGFuZC5w",
-            "dWxzZS5QbGF5ZXJTdGF0ZUlucHV0SAASMwoGcmVzeW5jGAMgASgLMiEuZGVj",
-            "ZW50cmFsYW5kLnB1bHNlLlJlc3luY1JlcXVlc3RIABJOChRwcm9maWxlX2Fu",
-            "bm91bmNlbWVudBgEIAEoCzIuLmRlY2VudHJhbGFuZC5wdWxzZS5Qcm9maWxl",
-            "VmVyc2lvbkFubm91bmNlbWVudEgAEjUKC2Vtb3RlX3N0YXJ0GAUgASgLMh4u",
-            "ZGVjZW50cmFsYW5kLnB1bHNlLkVtb3RlU3RhcnRIABIzCgplbW90ZV9zdG9w",
-            "GAYgASgLMh0uZGVjZW50cmFsYW5kLnB1bHNlLkVtb3RlU3RvcEgAEjcKCHRl",
-            "bGVwb3J0GAcgASgLMiMuZGVjZW50cmFsYW5kLnB1bHNlLlRlbGVwb3J0UmVx",
-            "dWVzdEgAQgkKB21lc3NhZ2ViBnByb3RvMw=="));
+            "irUYBxUAAIBBGAgSDQoFcmVhbG0YBSABKAkiSAoKUGFyY2VsUmVjdBINCgVt",
+            "aW5feBgBIAEoERINCgVtaW5fehgCIAEoERINCgVtYXhfeBgDIAEoERINCgVt",
+            "YXhfehgEIAEoESJ4Ch1TY2VuZUxpc3RlbmVySGFuZHNoYWtlUmVxdWVzdBIS",
+            "CgphdXRoX2NoYWluGAEgASgMEg0KBXJlYWxtGAIgASgJEjQKDHBhcmNlbF9y",
+            "ZWN0cxgDIAMoCzIeLmRlY2VudHJhbGFuZC5wdWxzZS5QYXJjZWxSZWN0Io0E",
+            "Cg1DbGllbnRNZXNzYWdlEjkKCWhhbmRzaGFrZRgBIAEoCzIkLmRlY2VudHJh",
+            "bGFuZC5wdWxzZS5IYW5kc2hha2VSZXF1ZXN0SAASNQoFaW5wdXQYAiABKAsy",
+            "JC5kZWNlbnRyYWxhbmQucHVsc2UuUGxheWVyU3RhdGVJbnB1dEgAEjMKBnJl",
+            "c3luYxgDIAEoCzIhLmRlY2VudHJhbGFuZC5wdWxzZS5SZXN5bmNSZXF1ZXN0",
+            "SAASTgoUcHJvZmlsZV9hbm5vdW5jZW1lbnQYBCABKAsyLi5kZWNlbnRyYWxh",
+            "bmQucHVsc2UuUHJvZmlsZVZlcnNpb25Bbm5vdW5jZW1lbnRIABI1CgtlbW90",
+            "ZV9zdGFydBgFIAEoCzIeLmRlY2VudHJhbGFuZC5wdWxzZS5FbW90ZVN0YXJ0",
+            "SAASMwoKZW1vdGVfc3RvcBgGIAEoCzIdLmRlY2VudHJhbGFuZC5wdWxzZS5F",
+            "bW90ZVN0b3BIABI3Cgh0ZWxlcG9ydBgHIAEoCzIjLmRlY2VudHJhbGFuZC5w",
+            "dWxzZS5UZWxlcG9ydFJlcXVlc3RIABJVChhzY2VuZV9saXN0ZW5lcl9oYW5k",
+            "c2hha2UYCCABKAsyMS5kZWNlbnRyYWxhbmQucHVsc2UuU2NlbmVMaXN0ZW5l",
+            "ckhhbmRzaGFrZVJlcXVlc3RIAEIJCgdtZXNzYWdlYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Decentraland.Pulse.PulseSharedReflection.Descriptor, global::Decentraland.Common.OptionsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -69,7 +75,9 @@ namespace Decentraland.Pulse {
             new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Pulse.EmoteStart), global::Decentraland.Pulse.EmoteStart.Parser, new[]{ "EmoteId", "DurationMs", "PlayerState", "Mask" }, new[]{ "DurationMs", "Mask" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Pulse.EmoteStop), global::Decentraland.Pulse.EmoteStop.Parser, null, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Pulse.TeleportRequest), global::Decentraland.Pulse.TeleportRequest.Parser, new[]{ "ParcelIndex", "PositionX", "PositionY", "PositionZ", "Realm" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Pulse.ClientMessage), global::Decentraland.Pulse.ClientMessage.Parser, new[]{ "Handshake", "Input", "Resync", "ProfileAnnouncement", "EmoteStart", "EmoteStop", "Teleport" }, new[]{ "Message" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Pulse.ParcelRect), global::Decentraland.Pulse.ParcelRect.Parser, new[]{ "MinX", "MinZ", "MaxX", "MaxZ" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Pulse.SceneListenerHandshakeRequest), global::Decentraland.Pulse.SceneListenerHandshakeRequest.Parser, new[]{ "AuthChain", "Realm", "ParcelRects" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Pulse.ClientMessage), global::Decentraland.Pulse.ClientMessage.Parser, new[]{ "Handshake", "Input", "Resync", "ProfileAnnouncement", "EmoteStart", "EmoteStop", "Teleport", "SceneListenerHandshake" }, new[]{ "Message" }, null, null, null)
           }));
     }
     #endregion
@@ -2344,6 +2352,594 @@ namespace Decentraland.Pulse {
 
   }
 
+  /// <summary>
+  /// Inclusive rectangle in parcel coordinates. A single parcel is min == max.
+  /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class ParcelRect : pb::IMessage<ParcelRect>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<ParcelRect> _parser = new pb::MessageParser<ParcelRect>(() => new ParcelRect());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<ParcelRect> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Decentraland.Pulse.PulseClientReflection.Descriptor.MessageTypes[8]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ParcelRect() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ParcelRect(ParcelRect other) : this() {
+      minX_ = other.minX_;
+      minZ_ = other.minZ_;
+      maxX_ = other.maxX_;
+      maxZ_ = other.maxZ_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ParcelRect Clone() {
+      return new ParcelRect(this);
+    }
+
+    /// <summary>Field number for the "min_x" field.</summary>
+    public const int MinXFieldNumber = 1;
+    private int minX_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int MinX {
+      get { return minX_; }
+      set {
+        minX_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "min_z" field.</summary>
+    public const int MinZFieldNumber = 2;
+    private int minZ_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int MinZ {
+      get { return minZ_; }
+      set {
+        minZ_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "max_x" field.</summary>
+    public const int MaxXFieldNumber = 3;
+    private int maxX_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int MaxX {
+      get { return maxX_; }
+      set {
+        maxX_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "max_z" field.</summary>
+    public const int MaxZFieldNumber = 4;
+    private int maxZ_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int MaxZ {
+      get { return maxZ_; }
+      set {
+        maxZ_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as ParcelRect);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(ParcelRect other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (MinX != other.MinX) return false;
+      if (MinZ != other.MinZ) return false;
+      if (MaxX != other.MaxX) return false;
+      if (MaxZ != other.MaxZ) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (MinX != 0) hash ^= MinX.GetHashCode();
+      if (MinZ != 0) hash ^= MinZ.GetHashCode();
+      if (MaxX != 0) hash ^= MaxX.GetHashCode();
+      if (MaxZ != 0) hash ^= MaxZ.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (MinX != 0) {
+        output.WriteRawTag(8);
+        output.WriteSInt32(MinX);
+      }
+      if (MinZ != 0) {
+        output.WriteRawTag(16);
+        output.WriteSInt32(MinZ);
+      }
+      if (MaxX != 0) {
+        output.WriteRawTag(24);
+        output.WriteSInt32(MaxX);
+      }
+      if (MaxZ != 0) {
+        output.WriteRawTag(32);
+        output.WriteSInt32(MaxZ);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (MinX != 0) {
+        output.WriteRawTag(8);
+        output.WriteSInt32(MinX);
+      }
+      if (MinZ != 0) {
+        output.WriteRawTag(16);
+        output.WriteSInt32(MinZ);
+      }
+      if (MaxX != 0) {
+        output.WriteRawTag(24);
+        output.WriteSInt32(MaxX);
+      }
+      if (MaxZ != 0) {
+        output.WriteRawTag(32);
+        output.WriteSInt32(MaxZ);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (MinX != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt32Size(MinX);
+      }
+      if (MinZ != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt32Size(MinZ);
+      }
+      if (MaxX != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt32Size(MaxX);
+      }
+      if (MaxZ != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt32Size(MaxZ);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(ParcelRect other) {
+      if (other == null) {
+        return;
+      }
+      if (other.MinX != 0) {
+        MinX = other.MinX;
+      }
+      if (other.MinZ != 0) {
+        MinZ = other.MinZ;
+      }
+      if (other.MaxX != 0) {
+        MaxX = other.MaxX;
+      }
+      if (other.MaxZ != 0) {
+        MaxZ = other.MaxZ;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            MinX = input.ReadSInt32();
+            break;
+          }
+          case 16: {
+            MinZ = input.ReadSInt32();
+            break;
+          }
+          case 24: {
+            MaxX = input.ReadSInt32();
+            break;
+          }
+          case 32: {
+            MaxZ = input.ReadSInt32();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            MinX = input.ReadSInt32();
+            break;
+          }
+          case 16: {
+            MinZ = input.ReadSInt32();
+            break;
+          }
+          case 24: {
+            MaxX = input.ReadSInt32();
+            break;
+          }
+          case 32: {
+            MaxZ = input.ReadSInt32();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  /// <summary>
+  /// Scene-listener connect: same signed-fetch auth chain as HandshakeRequest, plus an
+  /// immutable parcel-set area of interest. No initial state — a listener is never a subject.
+  /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class SceneListenerHandshakeRequest : pb::IMessage<SceneListenerHandshakeRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<SceneListenerHandshakeRequest> _parser = new pb::MessageParser<SceneListenerHandshakeRequest>(() => new SceneListenerHandshakeRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<SceneListenerHandshakeRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Decentraland.Pulse.PulseClientReflection.Descriptor.MessageTypes[9]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public SceneListenerHandshakeRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public SceneListenerHandshakeRequest(SceneListenerHandshakeRequest other) : this() {
+      authChain_ = other.authChain_;
+      realm_ = other.realm_;
+      parcelRects_ = other.parcelRects_.Clone();
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public SceneListenerHandshakeRequest Clone() {
+      return new SceneListenerHandshakeRequest(this);
+    }
+
+    /// <summary>Field number for the "auth_chain" field.</summary>
+    public const int AuthChainFieldNumber = 1;
+    private pb::ByteString authChain_ = pb::ByteString.Empty;
+    /// <summary>
+    /// Signed-fetch headers JSON — identical shape to HandshakeRequest.auth_chain.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString AuthChain {
+      get { return authChain_; }
+      set {
+        authChain_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "realm" field.</summary>
+    public const int RealmFieldNumber = 2;
+    private string realm_ = "";
+    /// <summary>
+    /// AoI realm partition — same rules as TeleportRequest.realm.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Realm {
+      get { return realm_; }
+      set {
+        realm_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "parcel_rects" field.</summary>
+    public const int ParcelRectsFieldNumber = 3;
+    private static readonly pb::FieldCodec<global::Decentraland.Pulse.ParcelRect> _repeated_parcelRects_codec
+        = pb::FieldCodec.ForMessage(26, global::Decentraland.Pulse.ParcelRect.Parser);
+    private readonly pbc::RepeatedField<global::Decentraland.Pulse.ParcelRect> parcelRects_ = new pbc::RepeatedField<global::Decentraland.Pulse.ParcelRect>();
+    /// <summary>
+    /// Announced AoI as inclusive parcel-coordinate rects; fixed for the connection
+    /// lifetime. The sum of rect areas is capped server-side (SceneListener:MaxParcels) —
+    /// overlaps count per rect, so announce disjoint rects.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pbc::RepeatedField<global::Decentraland.Pulse.ParcelRect> ParcelRects {
+      get { return parcelRects_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as SceneListenerHandshakeRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(SceneListenerHandshakeRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (AuthChain != other.AuthChain) return false;
+      if (Realm != other.Realm) return false;
+      if(!parcelRects_.Equals(other.parcelRects_)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (AuthChain.Length != 0) hash ^= AuthChain.GetHashCode();
+      if (Realm.Length != 0) hash ^= Realm.GetHashCode();
+      hash ^= parcelRects_.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (AuthChain.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteBytes(AuthChain);
+      }
+      if (Realm.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Realm);
+      }
+      parcelRects_.WriteTo(output, _repeated_parcelRects_codec);
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (AuthChain.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteBytes(AuthChain);
+      }
+      if (Realm.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Realm);
+      }
+      parcelRects_.WriteTo(ref output, _repeated_parcelRects_codec);
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (AuthChain.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(AuthChain);
+      }
+      if (Realm.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Realm);
+      }
+      size += parcelRects_.CalculateSize(_repeated_parcelRects_codec);
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(SceneListenerHandshakeRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.AuthChain.Length != 0) {
+        AuthChain = other.AuthChain;
+      }
+      if (other.Realm.Length != 0) {
+        Realm = other.Realm;
+      }
+      parcelRects_.Add(other.parcelRects_);
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            AuthChain = input.ReadBytes();
+            break;
+          }
+          case 18: {
+            Realm = input.ReadString();
+            break;
+          }
+          case 26: {
+            parcelRects_.AddEntriesFrom(input, _repeated_parcelRects_codec);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            AuthChain = input.ReadBytes();
+            break;
+          }
+          case 18: {
+            Realm = input.ReadString();
+            break;
+          }
+          case 26: {
+            parcelRects_.AddEntriesFrom(ref input, _repeated_parcelRects_codec);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ClientMessage : pb::IMessage<ClientMessage>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
@@ -2359,7 +2955,7 @@ namespace Decentraland.Pulse {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Decentraland.Pulse.PulseClientReflection.Descriptor.MessageTypes[8]; }
+      get { return global::Decentraland.Pulse.PulseClientReflection.Descriptor.MessageTypes[10]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2400,6 +2996,9 @@ namespace Decentraland.Pulse {
           break;
         case MessageOneofCase.Teleport:
           Teleport = other.Teleport.Clone();
+          break;
+        case MessageOneofCase.SceneListenerHandshake:
+          SceneListenerHandshake = other.SceneListenerHandshake.Clone();
           break;
       }
 
@@ -2496,6 +3095,18 @@ namespace Decentraland.Pulse {
       }
     }
 
+    /// <summary>Field number for the "scene_listener_handshake" field.</summary>
+    public const int SceneListenerHandshakeFieldNumber = 8;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Decentraland.Pulse.SceneListenerHandshakeRequest SceneListenerHandshake {
+      get { return messageCase_ == MessageOneofCase.SceneListenerHandshake ? (global::Decentraland.Pulse.SceneListenerHandshakeRequest) message_ : null; }
+      set {
+        message_ = value;
+        messageCase_ = value == null ? MessageOneofCase.None : MessageOneofCase.SceneListenerHandshake;
+      }
+    }
+
     private object message_;
     /// <summary>Enum of possible cases for the "message" oneof.</summary>
     public enum MessageOneofCase {
@@ -2507,6 +3118,7 @@ namespace Decentraland.Pulse {
       EmoteStart = 5,
       EmoteStop = 6,
       Teleport = 7,
+      SceneListenerHandshake = 8,
     }
     private MessageOneofCase messageCase_ = MessageOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2544,6 +3156,7 @@ namespace Decentraland.Pulse {
       if (!object.Equals(EmoteStart, other.EmoteStart)) return false;
       if (!object.Equals(EmoteStop, other.EmoteStop)) return false;
       if (!object.Equals(Teleport, other.Teleport)) return false;
+      if (!object.Equals(SceneListenerHandshake, other.SceneListenerHandshake)) return false;
       if (MessageCase != other.MessageCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -2559,6 +3172,7 @@ namespace Decentraland.Pulse {
       if (messageCase_ == MessageOneofCase.EmoteStart) hash ^= EmoteStart.GetHashCode();
       if (messageCase_ == MessageOneofCase.EmoteStop) hash ^= EmoteStop.GetHashCode();
       if (messageCase_ == MessageOneofCase.Teleport) hash ^= Teleport.GetHashCode();
+      if (messageCase_ == MessageOneofCase.SceneListenerHandshake) hash ^= SceneListenerHandshake.GetHashCode();
       hash ^= (int) messageCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -2606,6 +3220,10 @@ namespace Decentraland.Pulse {
         output.WriteRawTag(58);
         output.WriteMessage(Teleport);
       }
+      if (messageCase_ == MessageOneofCase.SceneListenerHandshake) {
+        output.WriteRawTag(66);
+        output.WriteMessage(SceneListenerHandshake);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -2644,6 +3262,10 @@ namespace Decentraland.Pulse {
         output.WriteRawTag(58);
         output.WriteMessage(Teleport);
       }
+      if (messageCase_ == MessageOneofCase.SceneListenerHandshake) {
+        output.WriteRawTag(66);
+        output.WriteMessage(SceneListenerHandshake);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -2674,6 +3296,9 @@ namespace Decentraland.Pulse {
       }
       if (messageCase_ == MessageOneofCase.Teleport) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Teleport);
+      }
+      if (messageCase_ == MessageOneofCase.SceneListenerHandshake) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(SceneListenerHandshake);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -2729,6 +3354,12 @@ namespace Decentraland.Pulse {
             Teleport = new global::Decentraland.Pulse.TeleportRequest();
           }
           Teleport.MergeFrom(other.Teleport);
+          break;
+        case MessageOneofCase.SceneListenerHandshake:
+          if (SceneListenerHandshake == null) {
+            SceneListenerHandshake = new global::Decentraland.Pulse.SceneListenerHandshakeRequest();
+          }
+          SceneListenerHandshake.MergeFrom(other.SceneListenerHandshake);
           break;
       }
 
@@ -2814,6 +3445,15 @@ namespace Decentraland.Pulse {
             Teleport = subBuilder;
             break;
           }
+          case 66: {
+            global::Decentraland.Pulse.SceneListenerHandshakeRequest subBuilder = new global::Decentraland.Pulse.SceneListenerHandshakeRequest();
+            if (messageCase_ == MessageOneofCase.SceneListenerHandshake) {
+              subBuilder.MergeFrom(SceneListenerHandshake);
+            }
+            input.ReadMessage(subBuilder);
+            SceneListenerHandshake = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -2894,6 +3534,15 @@ namespace Decentraland.Pulse {
             }
             input.ReadMessage(subBuilder);
             Teleport = subBuilder;
+            break;
+          }
+          case 66: {
+            global::Decentraland.Pulse.SceneListenerHandshakeRequest subBuilder = new global::Decentraland.Pulse.SceneListenerHandshakeRequest();
+            if (messageCase_ == MessageOneofCase.SceneListenerHandshake) {
+              subBuilder.MergeFrom(SceneListenerHandshake);
+            }
+            input.ReadMessage(subBuilder);
+            SceneListenerHandshake = subBuilder;
             break;
           }
         }

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/protocol": "^1.0.0-31621059011.commit-6c148c3",
+        "@dcl/protocol": "^1.0.0-32905037810.commit-4ed8d74",
         "@protobuf-ts/protoc": "^2.11.0",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.0.1",
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-31621059011.commit-6c148c3",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-31621059011.commit-6c148c3.tgz",
-      "integrity": "sha512-d+hLScmPOFjjR2m6bsOGeDv34Ab2wILnW/st5eWlEhua5EG9cBJKU4Ka0lPu+urE87G1W3fPxHhUBcSxhukOFA==",
+      "version": "1.0.0-32905037810.commit-4ed8d74",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-32905037810.commit-4ed8d74.tgz",
+      "integrity": "sha512-PNmVcgBF6xiZDUurqyAGIEjy2ZYL35eufrrQzLDo8ylW+qAhAoPVwDYUeYb4iHj0zz6AZXBbD6Ui9eZjSbclHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -608,9 +608,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-31621059011.commit-6c148c3",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-31621059011.commit-6c148c3.tgz",
-      "integrity": "sha512-d+hLScmPOFjjR2m6bsOGeDv34Ab2wILnW/st5eWlEhua5EG9cBJKU4Ka0lPu+urE87G1W3fPxHhUBcSxhukOFA==",
+      "version": "1.0.0-32905037810.commit-4ed8d74",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-32905037810.commit-4ed8d74.tgz",
+      "integrity": "sha512-PNmVcgBF6xiZDUurqyAGIEjy2ZYL35eufrrQzLDo8ylW+qAhAoPVwDYUeYb4iHj0zz6AZXBbD6Ui9eZjSbclHQ==",
       "requires": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@dcl/protocol": "^1.0.0-31621059011.commit-6c148c3",
+    "@dcl/protocol": "^1.0.0-32905037810.commit-4ed8d74",
     "@protobuf-ts/protoc": "^2.11.0",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.0.1",


### PR DESCRIPTION
### WHY

Scenes cannot know when the loading screen gets disabled. This was originally requested by the Content Team.

### WHAT

Inject the `IReadOnlyLoadingStatus` loading screen bool into the new `hiddenScene` field of the `EngineInfo` component.

### QA TEST STEPS

Use the build from this PR to load locally the following small test scene: 
[95,-8-engine-info-scene-hidden.zip](https://github.com/user-attachments/files/31472046/95.-8-engine-info-scene-hidden.zip)

Once inside confirm:
- You see the cube as Green and not Red.
- Check the scene console and confirm you see the log "sceneHidden changed to true at tick 0" and "sceneHidden changed to false at tick [ANYTHING NOT 0 HERE]"

<img width="982" height="667" alt="Screenshot 2026-08-26 at 12 20 30 PM" src="https://github.com/user-attachments/assets/cbc7a931-f04e-4847-a281-da03e0c87394" />
