### PR TITLE
fix: stuck looping emote on failed emote load

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteIntent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteIntent.cs
@@ -19,6 +19,9 @@ namespace DCL.AvatarRendering.Emotes
         public TriggerSource TriggerSource;
         public AvatarEmoteMask Mask;
 
+        // One-shot latch for the missing-asset re-request: retrying every frame would flood the world with load promises.
+        public bool AssetReloadRequested;
+
         private LoadTimeout? playTimeout;
 
         public void UpdateRemoteId(URN emoteId)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteIntent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Components/CharacterEmoteIntent.cs
@@ -19,7 +19,6 @@ namespace DCL.AvatarRendering.Emotes
         public TriggerSource TriggerSource;
         public AvatarEmoteMask Mask;
 
-        // One-shot latch for the missing-asset re-request: retrying every frame would flood the world with load promises.
         public bool AssetReloadRequested;
 
         private LoadTimeout? playTimeout;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
@@ -84,8 +84,7 @@ namespace DCL.AvatarRendering.Emotes
                     if (!emotes.TryGetValue(urn, out IEmote emote))
                         continue;
 
-                    // An in-flight load owns the asset slots: stripping or evicting the emote now orphans the
-                    // pending promise and strands any play intent waiting on it (#9485).
+                    // Evicting mid-load orphans the pending promise and strands any play intent waiting on it (#9485).
                     if (emote.IsLoading)
                         continue;
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Helpers/MemoryEmotesStorage.cs
@@ -84,6 +84,11 @@ namespace DCL.AvatarRendering.Emotes
                     if (!emotes.TryGetValue(urn, out IEmote emote))
                         continue;
 
+                    // An in-flight load owns the asset slots: stripping or evicting the emote now orphans the
+                    // pending promise and strands any play intent waiting on it (#9485).
+                    if (emote.IsLoading)
+                        continue;
+
                     if (!TryUnloadAllWearableAssets(emote)) continue;
 
                     DisposeThumbnail(emote);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -106,8 +106,7 @@ namespace DCL.AvatarRendering.Emotes.Load
             GetEmotesByPointersIntention intention,
             RepoolableList<IEmote> resolvedEmotesTmp)
         {
-            // Abandoned mid-DTO emotes must drop IsLoading: requests skip loading emotes, so a kept flag
-            // makes them permanently unloadable and parks any play intent on them forever (#9485).
+            // A kept IsLoading makes an abandoned emote permanently unloadable: requests skip loading emotes (#9485).
             foreach (URN pointer in intention.Pointers)
                 if (emoteStorage.TryGetElement(pointer.Shorten(), out IEmote emote) && emote.IsLoading && !emote.Model.IsInitialized)
                     emote.UpdateLoadingStatus(false);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Load/LoadEmotesByPointersSystem.cs
@@ -106,6 +106,12 @@ namespace DCL.AvatarRendering.Emotes.Load
             GetEmotesByPointersIntention intention,
             RepoolableList<IEmote> resolvedEmotesTmp)
         {
+            // Abandoned mid-DTO emotes must drop IsLoading: requests skip loading emotes, so a kept flag
+            // makes them permanently unloadable and parks any play intent on them forever (#9485).
+            foreach (URN pointer in intention.Pointers)
+                if (emoteStorage.TryGetElement(pointer.Shorten(), out IEmote emote) && emote.IsLoading && !emote.Model.IsInitialized)
+                    emote.UpdateLoadingStatus(false);
+
             HashSet<URN> successfulPointers = intention.SuccessfulPointers;
             // Keep only successful emotes in the result list (also remove emotes with unresolved DTO)
             resolvedEmotesTmp.List.RemoveAll(emote => emote.DTO?.Metadata == null || !successfulPointers.Contains(emote.GetUrn()));

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -223,9 +223,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             StopEmote(entity, ref emoteComponent, avatarView, EmoteState.EsInterrupted);
         }
 
-        // User input wins over a scene emote that never started: a parked intent disables every cancel query,
-        // leaving a looping emote holding the CharacterController off with no escape (#9485).
-        // Scene full-body only: user-queued emotes may legitimately wait out movement, masked ones don't lock it.
+        // A parked intent disables every cancel query, so a looping emote soft-locks the player until it consumes (#9485).
         [Query]
         [None(typeof(DeleteEntityIntention), typeof(PlayerTeleportIntent.JustTeleported))]
         private void CancelParkedSceneEmoteIntentByMovementInput(
@@ -320,9 +318,7 @@ namespace DCL.AvatarRendering.Emotes.Play
                      avatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND) > 0.1f))
                     return;
 
-                // Bounds every load-related park (IsLoading, unresolved asset slot, promise never created):
-                // a stranded intent disables all cancel queries and soft-locks the player (#6531, #9485).
-                // Below the settle guard on purpose — that wait is user-driven and unbounded (#9626 review).
+                // Bounds every load-related park; deliberately below the settle guard, whose wait is user-driven and unbounded (#6531, #9485, #9626 review).
                 if (emoteIntent.UpdatePlayTimeout(dt))
                 {
                     ReportHub.LogError(GetReportData(), $"Cant play emote {emoteId} timeout reached.");
@@ -356,8 +352,7 @@ namespace DCL.AvatarRendering.Emotes.Play
 
                     if (assetResult == null)
                     {
-                        // The memory sweep strips unreferenced asset slots and nothing restores them on its own —
-                        // without a re-request the intent parks here forever (#6531, #9485).
+                        // Nothing restores an asset slot stripped by the memory sweep — without a re-request the intent parks forever (#6531, #9485).
                         if (!emoteIntent.AssetReloadRequested)
                         {
                             emoteIntent.AssetReloadRequested = true;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -359,9 +359,18 @@ namespace DCL.AvatarRendering.Emotes.Play
                     BodyShape bodyShape = avatarShapeComponent.BodyShape;
                     StreamableLoadingResult<AttachmentRegularAsset>? assetResult = emote.AssetResults[bodyShape];
 
-                    // Loading not complete
                     if (assetResult == null)
+                    {
+                        // The memory sweep strips unreferenced asset slots and nothing restores them on its own —
+                        // without a re-request the intent parks here forever (#6531, #9485).
+                        if (!emoteIntent.AssetReloadRequested)
+                        {
+                            emoteIntent.AssetReloadRequested = true;
+                            CreateEmotePromise(emoteId, bodyShape, emoteIntent.Mask);
+                        }
+
                         return;
+                    }
 
                     StreamableLoadingResult<AttachmentRegularAsset> streamableAssetValue = assetResult.Value;
                     GameObject? mainAsset;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -45,6 +45,8 @@ namespace DCL.AvatarRendering.Emotes.Play
     [UpdateBefore(typeof(ChangeCharacterPositionGroup))]
     public partial class CharacterEmoteSystem : BaseUnityLoopSystem
     {
+        private const float HORIZONTAL_THRESHOLD_SQ = 0.1f * 0.1f;
+
         private static readonly string SCENE_EMOTE_PREFIX_WITH_COLON = GetSceneEmoteFromRealmIntention.SCENE_EMOTE_PREFIX + ":";
 
         // todo: use this to add nice Debug UI to trigger any emote?
@@ -82,6 +84,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             CancelEmotesByTeleportIntentionQuery(World);
             CancelEmotesByMoveToWithDurationQuery(World);
             CancelEmotesByMovementInputQuery(World);
+            CancelParkedSceneEmoteIntentByMovementInputQuery(World);
             ReplicateLoopingEmotesQuery(World);
             ConsumeEmoteIntentQuery(World, t);
             BroadcastEmoteOnLocalPlayerQuery(World);
@@ -215,8 +218,6 @@ namespace DCL.AvatarRendering.Emotes.Play
         {
             if (!emoteComponent.IsPlayingEmote) return;
 
-            const float HORIZONTAL_THRESHOLD_SQ = 0.1f * 0.1f;
-
             float horizontalSpeedSq = movementInputComponent.Axes.sqrMagnitude;
             bool shouldCancelEmote = horizontalSpeedSq > HORIZONTAL_THRESHOLD_SQ || jumpInputComponent.IsPressed;
 
@@ -225,6 +226,29 @@ namespace DCL.AvatarRendering.Emotes.Play
             ReportHub.Log(ReportCategory.EMOTE, $"CancelEmotesByMovementInput() {profile.UserId} Stopping emote");
 
             StopEmote(entity, ref emoteComponent, avatarView, EmoteState.EsInterrupted);
+        }
+
+        // User input wins over a scene emote that never started: a parked intent disables every cancel query,
+        // leaving a looping emote holding the CharacterController off with no escape (#9485).
+        // Scene full-body only: user-queued emotes may legitimately wait out movement, masked ones don't lock it.
+        [Query]
+        [None(typeof(DeleteEntityIntention), typeof(PlayerTeleportIntent.JustTeleported))]
+        private void CancelParkedSceneEmoteIntentByMovementInput(
+            Entity entity,
+            ref CharacterEmoteComponent emoteComponent,
+            ref CharacterEmoteIntent emoteIntent,
+            in IAvatarView avatarView,
+            ref JumpInputComponent jumpInputComponent,
+            ref MovementInputComponent movementInputComponent)
+        {
+            if (emoteIntent.TriggerSource != TriggerSource.Scene || emoteIntent.Mask != AvatarEmoteMask.AemFullBody) return;
+
+            bool wantsToMove = movementInputComponent.Axes.sqrMagnitude > HORIZONTAL_THRESHOLD_SQ || jumpInputComponent.IsPressed;
+            if (!wantsToMove) return;
+
+            // Ref writes before the structural change that invalidates them.
+            StopEmote(entity, ref emoteComponent, avatarView, EmoteState.EsInterrupted);
+            World.Remove<CharacterEmoteIntent>(entity);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -301,6 +325,16 @@ namespace DCL.AvatarRendering.Emotes.Play
                      avatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND) > 0.1f))
                     return;
 
+                // Bounds every load-related park (IsLoading, unresolved asset slot, promise never created):
+                // a stranded intent disables all cancel queries and soft-locks the player (#6531, #9485).
+                // Below the settle guard on purpose — that wait is user-driven and unbounded (#9626 review).
+                if (emoteIntent.UpdatePlayTimeout(dt))
+                {
+                    ReportHub.LogError(GetReportData(), $"Cant play emote {emoteId} timeout reached.");
+                    World.Remove<CharacterEmoteIntent>(entity);
+                    return;
+                }
+
                 if (emoteStorage.TryGetElement(emoteId.Shorten(), out IEmote emote))
                 {
                     if (emote.IsLoading)
@@ -318,17 +352,6 @@ namespace DCL.AvatarRendering.Emotes.Play
                     if (emote.DTO is { assetBundleManifestVersion: { assetBundleManifestRequestFailed: true, IsLSDAsset: false } })
                     {
                         ReportHub.LogError(GetReportData(), $"Cant play emote {emoteId} since it failed loading the manifest");
-                        World.Remove<CharacterEmoteIntent>(entity);
-                        return;
-                    }
-
-                    // Fixes https://github.com/decentraland/unity-explorer/issues/6531
-                    // Rarely happens for an unknown reason that emote.AssetResults[bodyShape] is null, provoking the emote intent to never finish,
-                    // thus props of the previous emote cannot be disposed either.
-                    // By setting a timeout we force unstuck the process
-                    if (emoteIntent.UpdatePlayTimeout(dt))
-                    {
-                        ReportHub.LogError(GetReportData(), $"Cant play emote {emoteId} timeout reached.");
                         World.Remove<CharacterEmoteIntent>(entity);
                         return;
                     }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -14,7 +14,6 @@ using DCL.Character.Components;
 using DCL.CharacterMotion.Components;
 using DCL.CharacterMotion.Systems;
 using DCL.Multiplayer.Movement;
-using DCL.DebugUtilities;
 using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.Multiplayer.Emotes;
@@ -49,8 +48,6 @@ namespace DCL.AvatarRendering.Emotes.Play
 
         private static readonly string SCENE_EMOTE_PREFIX_WITH_COLON = GetSceneEmoteFromRealmIntention.SCENE_EMOTE_PREFIX + ":";
 
-        // todo: use this to add nice Debug UI to trigger any emote?
-        private readonly IDebugContainerBuilder debugContainerBuilder;
         private readonly IScenesCache scenesCache;
 
         private readonly IEmoteStorage emoteStorage;
@@ -64,14 +61,12 @@ namespace DCL.AvatarRendering.Emotes.Play
             IEmoteStorage emoteStorage,
             IEmotesMessageBus messageBus,
             EmotePlayer emotePlayer,
-            IDebugContainerBuilder debugContainerBuilder,
             bool localSceneDevelopment,
             IScenesCache scenesCache) : base(world)
         {
             this.messageBus = messageBus;
             this.emoteStorage = emoteStorage;
             this.emotePlayer = emotePlayer;
-            this.debugContainerBuilder = debugContainerBuilder;
             this.scenesCache = scenesCache;
             this.localSceneDevelopment = localSceneDevelopment;
         }
@@ -493,7 +488,7 @@ namespace DCL.AvatarRendering.Emotes.Play
             in CharacterAnimationComponent animation,
             in StunComponent stun,
             in MovementInputComponent input,
-            in HeadIKComponent headIK,
+            in HeadIKComponent headIk,
             in HandPointAtComponent pointAt)
         {
             var playerState = new NetworkMovementMessage
@@ -509,9 +504,9 @@ namespace DCL.AvatarRendering.Emotes.Play
                 isSliding = animation.States.IsSliding,
                 isPointingAt = pointAt.IsPointing,
                 pointAtWorldHitPoint = pointAt.WorldHitPoint,
-                headIKYawEnabled = headIK.YawEnabled,
-                headIKPitchEnabled = headIK.PitchEnabled,
-                headYawAndPitch = headIK.GetHeadYawAndPitch(),
+                headIKYawEnabled = headIk.YawEnabled,
+                headIKPitchEnabled = headIk.PitchEnabled,
+                headYawAndPitch = headIk.GetHeadYawAndPitch(),
                 movementKind = input.Kind,
                 animState = new AnimationStates
                 {
@@ -571,7 +566,7 @@ namespace DCL.AvatarRendering.Emotes.Play
         private void CleanUp(Profile profile, in DeleteEntityIntention deleteEntityIntention)
         {
             if (!deleteEntityIntention.DeferDeletion)
-                messageBus.OnPlayerRemoved(profile.UserId);
+                messageBus.OnPlayerRemoved(profile.UserId.Value);
         }
 
         private void CreateEmotePromise(URN urn, BodyShape bodyShape, AvatarEmoteMask mask)

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -239,7 +239,6 @@ namespace DCL.AvatarRendering.Emotes.Play
             bool wantsToMove = movementInputComponent.Axes.sqrMagnitude > HORIZONTAL_THRESHOLD_SQ || jumpInputComponent.IsPressed;
             if (!wantsToMove) return;
 
-            // Ref writes before the structural change that invalidates them.
             StopEmote(entity, ref emoteComponent, avatarView, EmoteState.EsInterrupted);
             World.Remove<CharacterEmoteIntent>(entity);
         }
@@ -318,7 +317,6 @@ namespace DCL.AvatarRendering.Emotes.Play
                      avatarView.GetAnimatorFloat(AnimationHashes.MOVEMENT_BLEND) > 0.1f))
                     return;
 
-                // Bounds every load-related park; deliberately below the settle guard, whose wait is user-driven and unbounded (#6531, #9485, #9626 review).
                 if (emoteIntent.UpdatePlayTimeout(dt))
                 {
                     ReportHub.LogError(GetReportData(), $"Cant play emote {emoteId} timeout reached.");
@@ -352,7 +350,7 @@ namespace DCL.AvatarRendering.Emotes.Play
 
                     if (assetResult == null)
                     {
-                        // Nothing restores an asset slot stripped by the memory sweep — without a re-request the intent parks forever (#6531, #9485).
+                        // Nothing restores an asset slot stripped by the memory sweep — without a re-request the intent parks forever
                         if (!emoteIntent.AssetReloadRequested)
                         {
                             emoteIntent.AssetReloadRequested = true;

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/SceneMaskedEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/SceneMaskedEmoteSystem.cs
@@ -119,7 +119,6 @@ namespace DCL.AvatarRendering.Emotes.Play
         {
             URN emoteId = emoteIntent.EmoteId;
 
-            // Above every early return so any park is bounded — a stranded intent blocks masked emotes forever (#9485).
             if (emoteIntent.UpdatePlayTimeout(dt))
             {
                 ReportHub.LogError(GetReportData(), $"Cant play masked emote {emoteId} timeout reached.");

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/SceneMaskedEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/SceneMaskedEmoteSystem.cs
@@ -119,6 +119,14 @@ namespace DCL.AvatarRendering.Emotes.Play
         {
             URN emoteId = emoteIntent.EmoteId;
 
+            // Above every early return so any park is bounded — a stranded intent blocks masked emotes forever (#9485).
+            if (emoteIntent.UpdatePlayTimeout(dt))
+            {
+                ReportHub.LogError(GetReportData(), $"Cant play masked emote {emoteId} timeout reached.");
+                World.Remove<CharacterEmoteIntent>(entity);
+                return;
+            }
+
             if (!emoteStorage.TryGetElement(emoteId.Shorten(), out IEmote emote)) return;
 
             if (emote.IsLoading)
@@ -126,13 +134,6 @@ namespace DCL.AvatarRendering.Emotes.Play
 
             if (emote.Model is { IsInitialized: true, Succeeded: false })
             {
-                World.Remove<CharacterEmoteIntent>(entity);
-                return;
-            }
-
-            if (emoteIntent.UpdatePlayTimeout(dt))
-            {
-                ReportHub.LogError(GetReportData(), $"Cant play masked emote {emoteId} timeout reached.");
                 World.Remove<CharacterEmoteIntent>(entity);
                 return;
             }

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
@@ -5,7 +5,9 @@ using DCL.AvatarRendering.AvatarShape.UnityInterface;
 using DCL.AvatarRendering.Emotes.Play;
 using DCL.AvatarRendering.Loading.Assets;
 using DCL.AvatarRendering.Loading.Components;
+using DCL.Character.CharacterMotion.Components;
 using DCL.Character.Components;
+using DCL.CharacterMotion.Components;
 using DCL.DebugUtilities;
 using DCL.Diagnostics;
 using DCL.ECSComponents;
@@ -176,6 +178,158 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 "An intent held back by the movement gate must survive: the avatar is moving, which is not a stuck state.");
 
             emoteStorage.DidNotReceive().TryGetElement(Arg.Any<URN>(), out Arg.Any<IEmote>());
+        }
+
+        /// <summary>
+        /// Regression for https://github.com/decentraland/unity-explorer/issues/9485: an emote stuck in
+        /// IsLoading must be released by the play timeout instead of parking the intent forever.
+        /// </summary>
+        [Test]
+        public void RemoveIntentAfterTimeoutWhenEmoteNeverFinishesLoading()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("Cant play emote .* timeout reached"));
+
+            IAvatarView strandedAvatarView = Substitute.For<IAvatarView>();
+            strandedAvatarView.GetAnimatorBool(AnimationHashes.GROUNDED).Returns(true);
+
+            IEmote emote = Substitute.For<IEmote>();
+            emote.IsLoading.Returns(true);
+
+            emoteStorage.TryGetElement(Arg.Any<URN>(), out Arg.Any<IEmote>())
+                        .Returns(call =>
+                         {
+                             call[1] = emote;
+                             return true;
+                         });
+
+            Entity strandedEntity = world.Create(
+                new CharacterEmoteComponent(),
+                new CharacterEmoteIntent
+                {
+                    EmoteId = new URN(SCENE_EMOTE_URN),
+                    Mask = AvatarEmoteMask.AemFullBody,
+                },
+                strandedAvatarView,
+                new AvatarShapeComponent { BodyShape = BodyShape.MALE });
+
+            for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
+                system!.Update(1f);
+
+            Assert.IsFalse(world.Has<CharacterEmoteIntent>(strandedEntity),
+                "A CharacterEmoteIntent whose emote never finishes loading must expire after StreamableLoadingDefaults.TIMEOUT seconds.");
+        }
+
+        /// <summary>
+        /// The exact https://github.com/decentraland/unity-explorer/issues/9485 shape: the emote never lands in
+        /// storage and its promise can silently never be created (scene gone), so only the timeout can unpark.
+        /// </summary>
+        [Test]
+        public void RemoveIntentAfterTimeoutWhenEmoteNeverArrivesInStorage()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("Cant play emote .* timeout reached"));
+
+            IAvatarView strandedAvatarView = Substitute.For<IAvatarView>();
+            strandedAvatarView.GetAnimatorBool(AnimationHashes.GROUNDED).Returns(true);
+
+            Entity strandedEntity = world.Create(
+                new CharacterEmoteComponent(),
+                new CharacterEmoteIntent
+                {
+                    EmoteId = new URN(SCENE_EMOTE_URN),
+                    Mask = AvatarEmoteMask.AemFullBody,
+                },
+                strandedAvatarView,
+                new AvatarShapeComponent { BodyShape = BodyShape.MALE });
+
+            for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
+                system!.Update(1f);
+
+            Assert.IsFalse(world.Has<CharacterEmoteIntent>(strandedEntity),
+                "A CharacterEmoteIntent whose emote never arrives in storage must expire after StreamableLoadingDefaults.TIMEOUT seconds.");
+        }
+
+        [Test]
+        public void CancelParkedSceneEmoteIntentOnMovementInput()
+        {
+            //Arrange
+            Entity parkedEntity = NewParkedIntentEntity(TriggerSource.Scene, AvatarEmoteMask.AemFullBody,
+                new MovementInputComponent { Axes = Vector2.up }, new JumpInputComponent());
+
+            //Act
+            system!.Update(0);
+
+            //Assert: user input discards the not-yet-started scene emote and stops the playing loop.
+            Assert.IsFalse(world.Has<CharacterEmoteIntent>(parkedEntity));
+            CharacterEmoteComponent emoteComponent = world.Get<CharacterEmoteComponent>(parkedEntity);
+            Assert.IsNull(emoteComponent.CurrentEmoteReference);
+            Assert.IsTrue(emoteComponent.PendingStop.IsSet);
+            Assert.AreEqual(EmoteState.EsInterrupted, emoteComponent.PendingStop.Reason);
+        }
+
+        [Test]
+        public void CancelParkedSceneEmoteIntentOnJumpInput()
+        {
+            //Arrange
+            Entity parkedEntity = NewParkedIntentEntity(TriggerSource.Scene, AvatarEmoteMask.AemFullBody,
+                new MovementInputComponent(), new JumpInputComponent { IsPressed = true });
+
+            //Act
+            system!.Update(0);
+
+            //Assert
+            Assert.IsFalse(world.Has<CharacterEmoteIntent>(parkedEntity));
+            Assert.IsNull(world.Get<CharacterEmoteComponent>(parkedEntity).CurrentEmoteReference);
+        }
+
+        [Test]
+        public void KeepParkedSelfEmoteIntentOnMovementInput()
+        {
+            //Arrange: a user-queued emote must survive movement — queue-while-moving is a supported UX.
+            Entity parkedEntity = NewParkedIntentEntity(TriggerSource.Self, AvatarEmoteMask.AemFullBody,
+                new MovementInputComponent { Axes = Vector2.up }, new JumpInputComponent());
+
+            //Act
+            system!.Update(0);
+
+            //Assert
+            Assert.IsTrue(world.Has<CharacterEmoteIntent>(parkedEntity));
+            Assert.IsNotNull(world.Get<CharacterEmoteComponent>(parkedEntity).CurrentEmoteReference);
+        }
+
+        [Test]
+        public void KeepParkedMaskedSceneEmoteIntentOnMovementInput()
+        {
+            //Arrange: masked emotes never lock movement, so movement must not discard them.
+            Entity parkedEntity = NewParkedIntentEntity(TriggerSource.Scene, AvatarEmoteMask.AemUpperBody,
+                new MovementInputComponent { Axes = Vector2.up }, new JumpInputComponent());
+
+            //Act
+            system!.Update(0);
+
+            //Assert
+            Assert.IsTrue(world.Has<CharacterEmoteIntent>(parkedEntity));
+        }
+
+        private Entity NewParkedIntentEntity(TriggerSource triggerSource, AvatarEmoteMask mask, MovementInputComponent movementInput, JumpInputComponent jumpInput)
+        {
+            var playingEmoteComponent = new CharacterEmoteComponent
+            {
+                EmoteUrn = "urn:decentraland:off-chain:base-emotes:dance",
+                CurrentEmoteReference = emoteReferences,
+            };
+
+            return world.Create(
+                playingEmoteComponent,
+                new CharacterEmoteIntent
+                {
+                    EmoteId = new URN(SCENE_EMOTE_URN),
+                    TriggerSource = triggerSource,
+                    Mask = mask,
+                },
+                Substitute.For<IAvatarView>(),
+                new AvatarShapeComponent { BodyShape = BodyShape.MALE },
+                movementInput,
+                jumpInput);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
@@ -85,7 +85,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             scenesCache.AddPortableExperienceScene(portableExperienceScene, SMART_WEARABLE_ENTITY_ID);
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             Assert.IsNotNull(world.Get<CharacterEmoteComponent>(playerEntity).CurrentEmoteReference);
@@ -96,7 +96,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         public void StopSceneEmoteWhenItsSceneIsNoLongerLoaded()
         {
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             Assert.IsNull(world.Get<CharacterEmoteComponent>(playerEntity).CurrentEmoteReference);
@@ -142,7 +142,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new AvatarShapeComponent { BodyShape = BodyShape.MALE });
 
             for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
-                system!.Update(1f);
+                system.Update(1f);
 
             Assert.IsFalse(world.Has<CharacterEmoteIntent>(strandedEntity),
                 "A CharacterEmoteIntent whose asset never resolves must expire after StreamableLoadingDefaults.TIMEOUT seconds of elapsed play time.");
@@ -170,7 +170,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new AvatarShapeComponent { BodyShape = BodyShape.MALE });
 
             for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
-                system!.Update(1f);
+                system.Update(1f);
 
             Assert.IsTrue(world.Has<CharacterEmoteIntent>(movingEntity),
                 "An intent held back by the movement gate must survive: the avatar is moving, which is not a stuck state.");
@@ -211,7 +211,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new AvatarShapeComponent { BodyShape = BodyShape.MALE });
 
             for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
-                system!.Update(1f);
+                system.Update(1f);
 
             Assert.IsFalse(world.Has<CharacterEmoteIntent>(strandedEntity),
                 "A CharacterEmoteIntent whose emote never finishes loading must expire after StreamableLoadingDefaults.TIMEOUT seconds.");
@@ -240,7 +240,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new AvatarShapeComponent { BodyShape = BodyShape.MALE });
 
             for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
-                system!.Update(1f);
+                system.Update(1f);
 
             Assert.IsFalse(world.Has<CharacterEmoteIntent>(strandedEntity),
                 "A CharacterEmoteIntent whose emote never arrives in storage must expire after StreamableLoadingDefaults.TIMEOUT seconds.");
@@ -278,7 +278,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new AvatarShapeComponent { BodyShape = BodyShape.MALE });
 
             for (var i = 0; i < 3; i++)
-                system!.Update(0.1f);
+                system.Update(0.1f);
 
             Assert.IsTrue(world.Has<CharacterEmoteIntent>(parkedEntity),
                 "The intent must stay parked while the asset reload is pending.");
@@ -296,7 +296,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new MovementInputComponent { Axes = Vector2.up }, new JumpInputComponent());
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             Assert.IsFalse(world.Has<CharacterEmoteIntent>(parkedEntity));
@@ -314,7 +314,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new MovementInputComponent(), new JumpInputComponent { IsPressed = true });
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             Assert.IsFalse(world.Has<CharacterEmoteIntent>(parkedEntity));
@@ -329,7 +329,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new MovementInputComponent { Axes = Vector2.up }, new JumpInputComponent());
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             Assert.IsTrue(world.Has<CharacterEmoteIntent>(parkedEntity));
@@ -344,7 +344,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 new MovementInputComponent { Axes = Vector2.up }, new JumpInputComponent());
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             Assert.IsTrue(world.Has<CharacterEmoteIntent>(parkedEntity));
@@ -379,7 +379,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             URN emoteUrn = world.Get<CharacterEmoteComponent>(playerEntity).EmoteUrn;
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert: a scene-change cancellation is an interruption, and it survives Reset().
             CharacterEmoteComponent emoteComponent = world.Get<CharacterEmoteComponent>(playerEntity);
@@ -399,7 +399,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             avatarView.IsLegacyAnimationPlaying.Returns(false);
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             CharacterEmoteComponent updated = world.Get<CharacterEmoteComponent>(playerEntity);
@@ -420,7 +420,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             emoteComponent.StopEmote = true;
 
             //Act
-            system!.Update(0);
+            system.Update(0);
 
             //Assert
             CharacterEmoteComponent updated = world.Get<CharacterEmoteComponent>(playerEntity);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
@@ -248,6 +248,48 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 "A CharacterEmoteIntent whose emote never arrives in storage must expire after StreamableLoadingDefaults.TIMEOUT seconds.");
         }
 
+        /// <summary>
+        /// Regression for https://github.com/decentraland/unity-explorer/issues/9485: the memory sweep can strip
+        /// a stored emote's asset slot; the intent must re-request the asset instead of parking forever.
+        /// </summary>
+        [Test]
+        public void RequestAssetReloadOnceWhenStoredEmoteAssetIsMissing()
+        {
+            IAvatarView parkedAvatarView = Substitute.For<IAvatarView>();
+            parkedAvatarView.GetAnimatorBool(AnimationHashes.GROUNDED).Returns(true);
+
+            IEmote emote = Substitute.For<IEmote>();
+            emote.IsLoading.Returns(false);
+            emote.AssetResults.Returns(new StreamableLoadingResult<AttachmentRegularAsset>?[BodyShape.COUNT]);
+
+            emoteStorage.TryGetElement(Arg.Any<URN>(), out Arg.Any<IEmote>())
+                        .Returns(call =>
+                         {
+                             call[1] = emote;
+                             return true;
+                         });
+
+            Entity parkedEntity = world.Create(
+                new CharacterEmoteComponent(),
+                new CharacterEmoteIntent
+                {
+                    EmoteId = new URN("urn:decentraland:off-chain:base-emotes:dance"),
+                    Mask = AvatarEmoteMask.AemFullBody,
+                },
+                parkedAvatarView,
+                new AvatarShapeComponent { BodyShape = BodyShape.MALE });
+
+            for (var i = 0; i < 3; i++)
+                system!.Update(0.1f);
+
+            Assert.IsTrue(world.Has<CharacterEmoteIntent>(parkedEntity),
+                "The intent must stay parked while the asset reload is pending.");
+
+            var reloadPromises = new QueryDescription().WithAll<GetEmotesByPointersIntention>();
+            Assert.AreEqual(1, world.CountEntities(in reloadPromises),
+                "The missing-asset reload must be requested exactly once per intent.");
+        }
+
         [Test]
         public void CancelParkedSceneEmoteIntentOnMovementInput()
         {

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
@@ -298,7 +298,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             //Act
             system!.Update(0);
 
-            //Assert: user input discards the not-yet-started scene emote and stops the playing loop.
+            //Assert
             Assert.IsFalse(world.Has<CharacterEmoteIntent>(parkedEntity));
             CharacterEmoteComponent emoteComponent = world.Get<CharacterEmoteComponent>(parkedEntity);
             Assert.IsNull(emoteComponent.CurrentEmoteReference);
@@ -324,7 +324,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         [Test]
         public void KeepParkedSelfEmoteIntentOnMovementInput()
         {
-            //Arrange: a user-queued emote must survive movement — queue-while-moving is a supported UX.
+            //Arrange
             Entity parkedEntity = NewParkedIntentEntity(TriggerSource.Self, AvatarEmoteMask.AemFullBody,
                 new MovementInputComponent { Axes = Vector2.up }, new JumpInputComponent());
 
@@ -339,7 +339,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         [Test]
         public void KeepParkedMaskedSceneEmoteIntentOnMovementInput()
         {
-            //Arrange: masked emotes never lock movement, so movement must not discard them.
+            //Arrange
             Entity parkedEntity = NewParkedIntentEntity(TriggerSource.Scene, AvatarEmoteMask.AemUpperBody,
                 new MovementInputComponent { Axes = Vector2.up }, new JumpInputComponent());
 

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
@@ -8,7 +8,6 @@ using DCL.AvatarRendering.Loading.Components;
 using DCL.Character.CharacterMotion.Components;
 using DCL.Character.Components;
 using DCL.CharacterMotion.Components;
-using DCL.DebugUtilities;
 using DCL.Diagnostics;
 using DCL.ECSComponents;
 using DCL.Multiplayer.Emotes;
@@ -54,8 +53,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
             messageBus = Substitute.For<IEmotesMessageBus>();
             emoteStorage = Substitute.For<IEmoteStorage>();
 
-            system = new CharacterEmoteSystem(world, emoteStorage, messageBus, emotePlayer,
-                Substitute.For<IDebugContainerBuilder>(), localSceneDevelopment: false, scenesCache);
+            system = new CharacterEmoteSystem(world, emoteStorage, messageBus, emotePlayer, localSceneDevelopment: false, scenesCache);
 
             avatarView = Substitute.For<IAvatarView>();
             avatarView.IsLegacyAnimationPlaying.Returns(true);

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/MemoryEmotesStorageShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/MemoryEmotesStorageShould.cs
@@ -1,0 +1,56 @@
+using CommunicationData.URLHelpers;
+using DCL.Optimization.PerformanceBudgeting;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DCL.AvatarRendering.Emotes.Tests
+{
+    public class MemoryEmotesStorageShould
+    {
+        private const string EMOTE_URN = "urn:decentraland:off-chain:base-emotes:dance";
+
+        private MemoryEmotesStorage storage = null!;
+        private IPerformanceBudget budget = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            storage = new MemoryEmotesStorage();
+            budget = Substitute.For<IPerformanceBudget>();
+            budget.TrySpendBudget().Returns(true);
+        }
+
+        /// <summary>
+        /// Regression for https://github.com/decentraland/unity-explorer/issues/9485: evicting an emote whose
+        /// load is in flight orphans the pending promise and strands the play intent waiting on it.
+        /// </summary>
+        [Test]
+        public void KeepLoadingEmoteResidentDuringUnload()
+        {
+            IEmote emote = storage.GetOrAddByDTO(NewDto());
+            emote.UpdateLoadingStatus(true);
+
+            storage.Unload(budget);
+
+            Assert.IsTrue(storage.TryGetElement(new URN(EMOTE_URN), out _),
+                "An emote with a load in flight must survive the memory sweep.");
+        }
+
+        [Test]
+        public void EvictIdleEmoteWithoutAssetsDuringUnload()
+        {
+            storage.GetOrAddByDTO(NewDto());
+
+            storage.Unload(budget);
+
+            Assert.IsFalse(storage.TryGetElement(new URN(EMOTE_URN), out _),
+                "An idle emote holding no assets is reclaimable by the memory sweep.");
+        }
+
+        private static EmoteDTO NewDto() =>
+            new ()
+            {
+                metadata = new EmoteDTO.EmoteMetadataDto { id = EMOTE_URN },
+            };
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/MemoryEmotesStorageShould.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/MemoryEmotesStorageShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d645296de09b41ef999867b6576c0e2e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/SceneMaskedEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/SceneMaskedEmoteSystemShould.cs
@@ -76,7 +76,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         {
             Entity entity = CreateSuspendedMaskedEmote(loop: false);
 
-            system!.Update(0);
+            system.Update(0);
 
             CharacterMaskedEmoteComponent masked = world.Get<CharacterMaskedEmoteComponent>(entity);
 
@@ -92,7 +92,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
         {
             Entity entity = CreateSuspendedMaskedEmote(loop: true);
 
-            system!.Update(0);
+            system.Update(0);
 
             CharacterMaskedEmoteComponent masked = world.Get<CharacterMaskedEmoteComponent>(entity);
 
@@ -118,7 +118,7 @@ namespace DCL.AvatarRendering.Emotes.Tests
                 });
 
             for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
-                system!.Update(1f);
+                system.Update(1f);
 
             Assert.IsFalse(world.Has<CharacterEmoteIntent>(strandedEntity),
                 "A masked CharacterEmoteIntent whose emote never arrives in storage must expire after StreamableLoadingDefaults.TIMEOUT seconds.");

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/SceneMaskedEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/SceneMaskedEmoteSystemShould.cs
@@ -8,12 +8,15 @@ using DCL.AvatarRendering.Loading.Components;
 using DCL.ECSComponents;
 using DCL.Multiplayer.Emotes;
 using DCL.Utilities;
+using ECS.StreamableLoading;
 using ECS.StreamableLoading.Common.Components;
 using ECS.TestSuite;
 using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Scene;
+using System.Text.RegularExpressions;
 using UnityEngine;
+using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
 namespace DCL.AvatarRendering.Emotes.Tests
@@ -95,6 +98,30 @@ namespace DCL.AvatarRendering.Emotes.Tests
 
             Assert.IsFalse(masked.EmoteUrn.IsNullOrEmpty(),
                 "A looping masked emote is resumed once the play conditions are met again, so its urn must survive being suspended.");
+        }
+
+        /// <summary>
+        /// The masked counterpart of the https://github.com/decentraland/unity-explorer/issues/9485 class of
+        /// bug: an emote that never lands in storage must not park its intent forever.
+        /// </summary>
+        [Test]
+        public void RemoveMaskedIntentAfterTimeoutWhenEmoteNeverArrivesInStorage()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("Cant play masked emote .* timeout reached"));
+
+            Entity strandedEntity = world.Create(
+                new CharacterMaskedEmoteComponent { Mask = AvatarEmoteMask.AemUpperBody },
+                new CharacterEmoteIntent
+                {
+                    EmoteId = new URN(string.Format(EMOTE_URN_FORMAT, "false")),
+                    Mask = AvatarEmoteMask.AemUpperBody,
+                });
+
+            for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
+                system!.Update(1f);
+
+            Assert.IsFalse(world.Has<CharacterEmoteIntent>(strandedEntity),
+                "A masked CharacterEmoteIntent whose emote never arrives in storage must expire after StreamableLoadingDefaults.TIMEOUT seconds.");
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -532,7 +532,7 @@ namespace Global.Dynamic
                 new GlobalInteractionPlugin(assetsProvisioner, staticContainer.EntityCollidersGlobalCache, exposedGlobalDataContainer.GlobalInputEvents, uiShellContainer.EventSystem, staticContainer.ScenesCache, uiShellContainer.MvcManager, menusAccessFacade, exposedGlobalDataContainer.ExposedCameraData.CameraEntityProxy),
                 new CharacterCameraPlugin(assetsProvisioner, realmSamplingData, exposedGlobalDataContainer.ExposedCameraData, debugBuilder, dynamicWorldDependencies.CommandLineArgs),
                 wearableContainer.CreateWearablePlugin(staticContainer, bootstrapContainer),
-                wearableContainer.CreateEmotePlugin(staticContainer, bootstrapContainer, assetsProvisioner, debugBuilder, uiShellContainer, profileContainer, commsContainer,
+                wearableContainer.CreateEmotePlugin(staticContainer, bootstrapContainer, assetsProvisioner, uiShellContainer, profileContainer, commsContainer,
                     multiplayerEmotesMessageBus, globalWorld, playerEntity),
                 new ProfilingPlugin(staticContainer.Profiler, staticContainer.RealmData,
                     staticContainer.SingletonSharedDependencies.MemoryBudget, debugBuilder,

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/DynamicWorldContainer.cs
@@ -894,7 +894,7 @@ namespace Global.Dynamic
                     localSceneDevelopment));
 
             if (FeaturesRegistry.Instance.IsEnabled(FeatureId.LocalSceneDevelopment) || FeaturesRegistry.Instance.IsEnabled(FeatureId.SelfPreviewBuilderCollections))
-                globalPlugins.Add(new GlobalGLTFLoadingPlugin(staticContainer.WebRequestsContainer.WebRequestController, staticContainer.RealmData, wearableContainer.BuilderContentURL.Value, localSceneDevelopment, staticContainer.ComponentsContainer.ComponentPoolsRegistry.RootContainerTransform()));
+                globalPlugins.Add(new GlobalGLTFLoadingPlugin(staticContainer.WebRequestsContainer.WebRequestController, staticContainer.RealmData, wearableContainer.BuilderContentUrl.Value, localSceneDevelopment, staticContainer.ComponentsContainer.ComponentPoolsRegistry.RootContainerTransform()));
 
             globalPlugins.AddRange(staticContainer.SharedPlugins);
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WearableContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WearableContainer.cs
@@ -6,7 +6,6 @@ using DCL.AvatarRendering.Wearables;
 using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.AvatarRendering.Wearables.ThirdParty;
 using DCL.Backpack.BackpackBus;
-using DCL.DebugUtilities;
 using DCL.PerformanceAndDiagnostics.Analytics;
 using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.Multiplayer.Emotes;
@@ -132,7 +131,6 @@ namespace Global.Dynamic
             StaticContainer staticContainer,
             BootstrapContainer bootstrapContainer,
             IAssetsProvisioner assetsProvisioner,
-            IDebugContainerBuilder debugBuilder,
             UIShellContainer uiShellContainer,
             ProfileContainer profileContainer,
             CommsContainer commsContainer,
@@ -144,7 +142,6 @@ namespace Global.Dynamic
                 staticContainer.EmoteStorage,
                 staticContainer.RealmData,
                 emotesMessageBus,
-                debugBuilder,
                 assetsProvisioner,
                 profileContainer.SelfProfile,
                 uiShellContainer.MvcManager,

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WearableContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WearableContainer.cs
@@ -33,7 +33,7 @@ namespace Global.Dynamic
 
         public IThirdPartyNftProviderSource ThirdPartyNftProviderSource { get; }
 
-        public URLDomain BuilderContentURL { get; }
+        public URLDomain BuilderContentUrl { get; }
 
         public IEventBus EmotesEventBus { get; }
 
@@ -50,7 +50,7 @@ namespace Global.Dynamic
             IEmoteProvider emoteProvider,
             ApplicationParametersWearablesProvider wearablesProvider,
             IThirdPartyNftProviderSource thirdPartyNftProviderSource,
-            URLDomain builderContentURL,
+            URLDomain builderContentUrl,
             IEventBus emotesEventBus,
             EmoteWheelShortcutHandler emoteWheelShortcutHandler,
             IBackpackEventBus backpackEventBus,
@@ -62,7 +62,7 @@ namespace Global.Dynamic
             EmoteProvider = emoteProvider;
             WearablesProvider = wearablesProvider;
             ThirdPartyNftProviderSource = thirdPartyNftProviderSource;
-            BuilderContentURL = builderContentURL;
+            BuilderContentUrl = builderContentUrl;
             EmotesEventBus = emotesEventBus;
             EmoteWheelShortcutHandler = emoteWheelShortcutHandler;
             BackpackEventBus = backpackEventBus;
@@ -85,8 +85,8 @@ namespace Global.Dynamic
                 ? new BackpackEventBusAnalyticsDecorator(coreBackpackEventBus, bootstrapContainer.Analytics.Controller)
                 : coreBackpackEventBus;
 
-            var builderDTOsURL = URLDomain.FromString(bootstrapContainer.DecentralandUrlsSource.Url(DecentralandUrl.BuilderApiDtos));
-            var builderContentURL = URLDomain.FromString(bootstrapContainer.DecentralandUrlsSource.Url(DecentralandUrl.BuilderApiContent));
+            var builderDtosUrl = URLDomain.FromString(bootstrapContainer.DecentralandUrlsSource.Url(DecentralandUrl.BuilderApiDtos));
+            var builderContentUrl = URLDomain.FromString(bootstrapContainer.DecentralandUrlsSource.Url(DecentralandUrl.BuilderApiContent));
 
             // If we have many undesired delays when using the third-party providers, it might be useful to cache it at app's bootstrap
             // So far, the chance of using it is quite low, so it's preferable to do it lazy avoiding extra requests & memory allocations
@@ -97,10 +97,10 @@ namespace Global.Dynamic
             staticContainer.CacheCleaner.Register(trimmedEmoteCatalog);
 
             IEmoteProvider emoteProvider = new ApplicationParamsEmoteProvider(appArgs,
-                new EcsEmoteProvider(globalWorld, identityCache), builderDTOsURL.Value);
+                new EcsEmoteProvider(globalWorld, identityCache), builderDtosUrl.Value);
 
             var wearablesProvider = new ApplicationParametersWearablesProvider(appArgs,
-                new ECSWearablesProvider(identityCache, globalWorld), builderDTOsURL.Value);
+                new ECSWearablesProvider(identityCache, globalWorld), builderDtosUrl.Value);
 
             return new WearableContainer(
                 new WearableStorage(),
@@ -109,7 +109,7 @@ namespace Global.Dynamic
                 emoteProvider,
                 wearablesProvider,
                 thirdPartyNftProviderSource,
-                builderContentURL,
+                builderContentUrl,
                 emotesEventBus,
                 new EmoteWheelShortcutHandler(emotesEventBus),
                 backpackEventBus,
@@ -125,7 +125,7 @@ namespace Global.Dynamic
                 WearableCatalog,
                 trimmedWearableCatalog,
                 bootstrapContainer.Analytics.EntitiesAnalytics,
-                BuilderContentURL.Value);
+                BuilderContentUrl.Value);
 
         public EmotePlugin CreateEmotePlugin(
             StaticContainer staticContainer,
@@ -151,7 +151,7 @@ namespace Global.Dynamic
                 staticContainer.InputBlock,
                 globalWorld,
                 playerEntity,
-                BuilderContentURL.Value,
+                BuilderContentUrl.Value,
                 ThumbnailProvider,
                 staticContainer.ScenesCache,
                 bootstrapContainer.DecentralandUrlsSource,

--- a/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
@@ -51,7 +51,7 @@ namespace DCL.PluginSystem.Global
         private readonly IMVCManager mvcManager;
         private readonly IReadOnlyEntityParticipantTable entityParticipantTable;
         private readonly AudioClipsCache audioClipsCache;
-        private readonly string builderContentURL;
+        private readonly string builderContentUrl;
         private readonly ICursor cursor;
         private readonly IInputBlock inputBlock;
         private readonly Arch.Core.World world;
@@ -86,7 +86,7 @@ namespace DCL.PluginSystem.Global
             IInputBlock inputBlock,
             Arch.Core.World world,
             Entity playerEntity,
-            string builderContentURL,
+            string builderContentUrl,
             IThumbnailProvider thumbnailProvider,
             IScenesCache scenesCache,
             IDecentralandUrlsSource decentralandUrlsSource,
@@ -101,7 +101,7 @@ namespace DCL.PluginSystem.Global
             this.selfProfile = selfProfile;
             this.mvcManager = mvcManager;
             this.entityParticipantTable = entityParticipantTable;
-            this.builderContentURL = builderContentURL;
+            this.builderContentUrl = builderContentUrl;
             this.webRequestController = webRequestController;
             this.emoteStorage = emoteStorage;
             this.realmData = realmData;
@@ -140,7 +140,7 @@ namespace DCL.PluginSystem.Global
             LoadTrimmedEmotesByParamSystem.InjectToWorld(ref builder, realmData, webRequestController,
                 new NoCache<TrimmedEmotesResponse, GetTrimmedEmotesByParamIntention>(false, false),
                 emoteStorage, trimmedEmoteStorage, EMOTES_COMPLEMENT_URL,
-                decentralandUrlsSource, builderContentURL);
+                decentralandUrlsSource, builderContentUrl);
 
             CharacterEmoteSystem.InjectToWorld(ref builder, emoteStorage, messageBus, emotePlayer, localSceneDevelopment, scenesCache);
 
@@ -213,7 +213,7 @@ namespace DCL.PluginSystem.Global
             /// Ordered list of base emote URNs.
             /// The order defines the default emote order for users with no equipped emotes.
             /// </summary>
-            [field: SerializeField] public string[] BaseEmotes { get; private set; }
+            [field: SerializeField] public string[] BaseEmotes { get; private set; } = null!;
 
             public IReadOnlyCollection<URN> BaseEmotesAsURN() => BaseEmotes.Select(s => new URN(s)).ToArray();
         }

--- a/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/EmotePlugin.cs
@@ -7,7 +7,6 @@ using DCL.AvatarRendering.Emotes;
 using DCL.AvatarRendering.Emotes.Load;
 using DCL.AvatarRendering.Wearables;
 using DCL.Backpack;
-using DCL.DebugUtilities;
 using DCL.EmotesWheel;
 using DCL.FeatureFlags;
 using DCL.Input;
@@ -21,7 +20,6 @@ using DCL.WebRequests;
 using ECS;
 using ECS.StreamableLoading.AudioClips;
 using ECS.StreamableLoading.Cache;
-using Global.AppArgs;
 using MVC;
 using System;
 using System.Collections.Generic;
@@ -48,7 +46,6 @@ namespace DCL.PluginSystem.Global
         private readonly IEmoteStorage emoteStorage;
         private readonly IRealmData realmData;
         private readonly IEmotesMessageBus messageBus;
-        private readonly IDebugContainerBuilder debugBuilder;
         private readonly IAssetsProvisioner assetsProvisioner;
         private readonly SelfProfile selfProfile;
         private readonly IMVCManager mvcManager;
@@ -80,7 +77,6 @@ namespace DCL.PluginSystem.Global
             IEmoteStorage emoteStorage,
             IRealmData realmData,
             IEmotesMessageBus messageBus,
-            IDebugContainerBuilder debugBuilder,
             IAssetsProvisioner assetsProvisioner,
             SelfProfile selfProfile,
             IMVCManager mvcManager,
@@ -101,7 +97,6 @@ namespace DCL.PluginSystem.Global
         {
             this.emotePlayer = emotePlayer;
             this.messageBus = messageBus;
-            this.debugBuilder = debugBuilder;
             this.assetsProvisioner = assetsProvisioner;
             this.selfProfile = selfProfile;
             this.mvcManager = mvcManager;
@@ -147,7 +142,7 @@ namespace DCL.PluginSystem.Global
                 emoteStorage, trimmedEmoteStorage, EMOTES_COMPLEMENT_URL,
                 decentralandUrlsSource, builderContentURL);
 
-            CharacterEmoteSystem.InjectToWorld(ref builder, emoteStorage, messageBus, emotePlayer, debugBuilder, localSceneDevelopment, scenesCache);
+            CharacterEmoteSystem.InjectToWorld(ref builder, emoteStorage, messageBus, emotePlayer, localSceneDevelopment, scenesCache);
 
             LoadAudioClipGlobalSystem.InjectToWorld(ref builder, audioClipsCache, webRequestController);
 


### PR DESCRIPTION
# Pull Request Description
Fixes #9485

After catching a fish in the Genesis Plaza pond, the player is left frozen in the looping "show fish" scene emote, and no other emote can be played until restart. The scene ends that loop by triggering fistpump, but fistpump is not an embedded emote — it loads on demand, and the memory-pressure sweep (frequent on Mac) can strip a stored emote's asset slots or evict it mid-load, leaving states the play path could never recover from. The parked `CharacterEmoteIntent` then disables every cancel query and TriggerEmote (`[None(CharacterEmoteIntent)]`), so the loop holds the `CharacterController` off with no escape.

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

- `CharacterEmoteSystem.ConsumeEmoteIntent`: re-requests the emote (one-shot, latched by `CharacterEmoteIntent.AssetReloadRequested`) when it's in storage but its asset slot is null — previously nothing ever reloaded a stripped asset, parking the intent forever.
- `MemoryEmotesStorage.Unload`: never strips/evicts an emote whose load is in flight (`IsLoading`) — evicting mid-load orphaned the pending promise.
- `LoadEmotesByPointersSystem`: the request-timeout path now resets `IsLoading` on abandoned DTO-less emotes, so they stay loadable by future requests.
- `ConsumeEmoteIntent` play-timeout watchdog moved to cover all loading parks (`IsLoading`, not-in-storage, null asset) — deliberately below the settle guard, which is user-driven and must never expire an intent. Same hoist in `SceneMaskedEmoteSystem`.
- New `CancelParkedSceneEmoteIntentByMovementInput` query: movement/jump input discards a parked full-body scene-sourced intent and stops the current emote — user input always wins; the player can never be held frozen while a scene emote loads.
- Tests: park-path timeouts, one-shot asset reload, input-cancel (+ Self/masked survival fences), sweep keeps loading emotes resident.


### Test Steps
1. Use repro steps in the linked issue
2. Full test about emotes


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
