### PR TITLE
fix: deploy avatar-preview-renderer to vercel production on merges to dev

### DIFF
--- a/.github/workflows/avatar-preview-renderer-build.yml
+++ b/.github/workflows/avatar-preview-renderer-build.yml
@@ -225,8 +225,14 @@ jobs:
       - name: Install Vercel CLI
         run: npm i -g vercel@latest
 
-      - name: Pull Vercel environment (preview)
-        run: vercel pull --yes --environment=preview
+      # Merges to dev deploy to production so unity-explorer-aang-renderer.vercel.app tracks the latest dev build.
+      - name: Pull Vercel environment
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            vercel pull --yes --environment=production
+          else
+            vercel pull --yes --environment=preview
+          fi
 
       - name: Download built artifact
         uses: actions/download-artifact@v7
@@ -259,17 +265,16 @@ jobs:
           echo "Using vercel.json:"
           cat .vercel/output/static/vercel.json
 
-      - name: Deploy static folder to Vercel (Preview)
+      - name: Deploy static folder to Vercel
         id: vercel_deploy
         run: |
-          url=$(vercel deploy .vercel/output/static --yes)
+          if [ "${{ github.event_name }}" = "push" ]; then
+            url=$(vercel deploy .vercel/output/static --prod --yes)
+          else
+            url=$(vercel deploy .vercel/output/static --yes)
+          fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
-          echo "Preview URL: $url"
-
-      # Stable URL that always points at the latest dev build.
-      - name: Alias dev deployment (merges to dev only)
-        if: ${{ github.event_name == 'push' }}
-        run: vercel alias set "${{ steps.vercel_deploy.outputs.url }}" unity-explorer-aang-renderer.vercel.app
+          echo "Deployment URL: $url"
 
       - name: Write job summary
         run: |


### PR DESCRIPTION
Merges to dev now deploy with `--prod` so `unity-explorer-aang-renderer.vercel.app` (project production domain) always serves the latest dev build. Replaces the `vercel alias` step, which cannot run with a team-scoped token (bare .vercel.app aliases are an account-level resource). PR deploys remain previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)