### PR TITLE
fix(network): route fixture services through gateway

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsExtensions.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsExtensions.cs
@@ -15,16 +15,24 @@ namespace Global.AppArgs
 
         //This method resolves a feature flag considering an eventual app argument override, allowing to set
         //the value to both true or false
-        public static bool ResolveFeatureFlagArg(this IAppArgs args, string appArgFlag, bool fallback, bool requireDebug = true)
+        public static bool ResolveFeatureFlagArg(this IAppArgs args, string appArgFlag, bool fallback, bool requireDebug = true) =>
+            args.ResolveFeatureFlagOverride(appArgFlag, requireDebug) ?? fallback;
+
+        /// <summary>
+        ///     The override <paramref name="appArgFlag" /> declares — true, false, or null when it declares none and
+        ///     the remote flag decides. For a consumer that cannot resolve the flag at parse time because it reads it
+        ///     later than launch; when the fallback is available, use <see cref="ResolveFeatureFlagArg" />.
+        /// </summary>
+        public static bool? ResolveFeatureFlagOverride(this IAppArgs args, string appArgFlag, bool requireDebug = true)
         {
             if (!args.HasFlag(appArgFlag))
-                return fallback;
+                return null;
 
             if (args.HasFlagWithValueFalse(appArgFlag))
                 return false;
 
             if (requireDebug && !args.HasDebugFlag())
-                return fallback;
+                return null;
 
             return true;
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -22,6 +22,13 @@ namespace Global.AppArgs
         public const string REALM = "realm";
         public const string COMMS_ADAPTER = "comms-adapter";
         public const string GATEKEEPER_URL = "gatekeeper-url";
+
+        /// <summary>
+        ///     Forces gateway routing on (<c>--gateway</c>, <c>--gateway true</c>) or off (<c>--gateway false</c>),
+        ///     overriding the <c>use-gateway</c> feature flag. Command line only: it reroutes every supported backend
+        ///     url for the whole session, so it must never be settable from a deep link.
+        /// </summary>
+        public const string GATEWAY = "gateway";
         public const string LOCAL_SCENE = "local-scene";
         public const string POSITION = "position";
         public const string SPAWN_POINT = "spawnpoint";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -24,9 +24,10 @@ namespace Global.AppArgs
         public const string GATEKEEPER_URL = "gatekeeper-url";
 
         /// <summary>
-        ///     Forces gateway routing on (<c>--gateway</c>, <c>--gateway true</c>) or off (<c>--gateway false</c>),
-        ///     overriding the <c>use-gateway</c> feature flag. Command line only: it reroutes every supported backend
-        ///     url for the whole session, so it must never be settable from a deep link.
+        ///     Routes every supported backend url through this gateway base instead of
+        ///     <c>gateway.decentraland.{env}</c>, and forces routing on: naming a gateway is the opt-in the
+        ///     <c>use-gateway</c> feature flag would otherwise carry, so the flag is ignored. Command line only —
+        ///     it aims the session's whole backend traffic at the named host, so a deep link must never set it.
         /// </summary>
         public const string GATEWAY = "gateway";
         public const string LOCAL_SCENE = "local-scene";

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -40,9 +40,10 @@ namespace Global.AppArgs
     ///         <item>
     ///             <b>Never permitted</b> — everything else, in particular params that launch code
     ///             (<c>creator-hub-bin-path</c>, <c>launch-cdp-monitor-on-start</c> — SEC-005); point the client at
-    ///             attacker infrastructure (<c>comms-adapter</c>, <c>gatekeeper-url</c>, <c>friends-api-url</c> —
-    ///             SEC-052, <c>feature-flags-url</c>/<c>-hostname</c>, <c>optimized-assets-url</c>,
-    ///             <c>lsd-remote-ab-server</c>/<c>-world</c>, <c>pulse</c>); bypass a version/specs screen
+    ///             attacker infrastructure, or reroute its traffic (<c>comms-adapter</c>, <c>gatekeeper-url</c>,
+    ///             <c>friends-api-url</c> — SEC-052, <c>feature-flags-url</c>/<c>-hostname</c>,
+    ///             <c>optimized-assets-url</c>, <c>lsd-remote-ab-server</c>/<c>-world</c>, <c>pulse</c>,
+    ///             <c>gateway</c>); bypass a version/specs screen
     ///             (<c>skip-version-check</c>, <c>skip-minimum-specs-screen</c>); or enable the remaining dev/test
     ///             modes (<c>debug</c>, <c>autopilot</c>, <c>alttester</c>, <c>simulate*</c>). A whitelisted realm
     ///             does not unlock these: unlike the tier above, a key that is in neither set is dropped for every

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkAllowlist.cs
@@ -40,10 +40,10 @@ namespace Global.AppArgs
     ///         <item>
     ///             <b>Never permitted</b> — everything else, in particular params that launch code
     ///             (<c>creator-hub-bin-path</c>, <c>launch-cdp-monitor-on-start</c> — SEC-005); point the client at
-    ///             attacker infrastructure, or reroute its traffic (<c>comms-adapter</c>, <c>gatekeeper-url</c>,
-    ///             <c>friends-api-url</c> — SEC-052, <c>feature-flags-url</c>/<c>-hostname</c>,
-    ///             <c>optimized-assets-url</c>, <c>lsd-remote-ab-server</c>/<c>-world</c>, <c>pulse</c>,
-    ///             <c>gateway</c>); bypass a version/specs screen
+    ///             attacker infrastructure (<c>comms-adapter</c>, <c>gatekeeper-url</c>, <c>friends-api-url</c> —
+    ///             SEC-052, <c>feature-flags-url</c>/<c>-hostname</c>, <c>optimized-assets-url</c>,
+    ///             <c>lsd-remote-ab-server</c>/<c>-world</c>, <c>pulse</c>, <c>gateway</c>); bypass a
+    ///             version/specs screen
     ///             (<c>skip-version-check</c>, <c>skip-minimum-specs-screen</c>); or enable the remaining dev/test
     ///             modes (<c>debug</c>, <c>autopilot</c>, <c>alttester</c>, <c>simulate*</c>). A whitelisted realm
     ///             does not unlock these: unlike the tier above, a key that is in neither set is dropped for every

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkParamDescriptions.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkParamDescriptions.cs
@@ -29,6 +29,7 @@ namespace Global.AppArgs
             [AppArgsFlags.LSD_REMOTE_AB_SERVER] = "Changes the server scene asset bundles are downloaded from.",
             [AppArgsFlags.LSD_REMOTE_AB_WORLD] = "Loads scene content from a world chosen by the link.",
             [AppArgsFlags.PULSE_MULTIPLAYER] = "Changes how this session connects to other players.",
+            [AppArgsFlags.GATEWAY] = "Changes which Decentraland endpoint this session's traffic is routed through.",
 
             // Skips a protective screen.
             [AppArgsFlags.SKIP_VERSION_CHECK] = "Skips the check for an outdated Explorer version.",

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkParamDescriptions.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/DeepLinkParamDescriptions.cs
@@ -29,7 +29,7 @@ namespace Global.AppArgs
             [AppArgsFlags.LSD_REMOTE_AB_SERVER] = "Changes the server scene asset bundles are downloaded from.",
             [AppArgsFlags.LSD_REMOTE_AB_WORLD] = "Loads scene content from a world chosen by the link.",
             [AppArgsFlags.PULSE_MULTIPLAYER] = "Changes how this session connects to other players.",
-            [AppArgsFlags.GATEWAY] = "Changes which Decentraland endpoint this session's traffic is routed through.",
+            [AppArgsFlags.GATEWAY] = "Routes all Decentraland traffic through a server chosen by the link.",
 
             // Skips a protective screen.
             [AppArgsFlags.SKIP_VERSION_CHECK] = "Skips the check for an outdated Explorer version.",

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -160,12 +160,33 @@ namespace Global.AppArgs.Tests
         public void DeepLinkDropsExecAndInfraParamsEvenForLoopbackRealm()
         {
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=http://127.0.0.1:8000&creator-hub-bin-path=x&launch-cdp-monitor-on-start=true&comms-adapter=y&optimized-assets-url=https://evil.example");
+                "decentraland://?realm=http://127.0.0.1:8000&creator-hub-bin-path=x&launch-cdp-monitor-on-start=true&comms-adapter=y&optimized-assets-url=https://evil.example&gateway=true");
 
             Assert.IsFalse(output.ContainsKey("creator-hub-bin-path"), "creator-hub-bin-path must never be permitted (SEC-005), even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must never be permitted, even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must never be permitted, even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.OPTIMIZED_ASSETS_URL), "optimized-assets-url must never be permitted, even for a loopback realm — it points the AB/LOD/registry endpoints at arbitrary infrastructure for the whole session; local-ab derives the base from the realm instead");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.GATEWAY), "gateway must never be permitted, even for a loopback realm — it reroutes every supported backend url for the whole session");
+        }
+
+        [Test]
+        public void GatewayArgIsUnsetWithoutTheFlag()
+        {
+            IAppArgs args = new ApplicationParametersParser(false);
+
+            Assert.IsNull(args.ResolveFeatureFlagOverride(AppArgsFlags.GATEWAY, requireDebug: false));
+        }
+
+        [TestCase("--gateway", null, true, TestName = "gateway bare")]
+        [TestCase("--gateway", "true", true, TestName = "gateway true")]
+        [TestCase("--gateway", "false", false, TestName = "gateway false")]
+        public void GatewayArgOverridesTheFeatureFlagInBothDirections(string flag, string? value, bool expected)
+        {
+            IAppArgs args = value == null
+                ? new ApplicationParametersParser(false, flag)
+                : new ApplicationParametersParser(false, flag, value);
+
+            Assert.AreEqual(expected, args.ResolveFeatureFlagOverride(AppArgsFlags.GATEWAY, requireDebug: false));
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -160,33 +160,13 @@ namespace Global.AppArgs.Tests
         public void DeepLinkDropsExecAndInfraParamsEvenForLoopbackRealm()
         {
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?realm=http://127.0.0.1:8000&creator-hub-bin-path=x&launch-cdp-monitor-on-start=true&comms-adapter=y&optimized-assets-url=https://evil.example&gateway=true");
+                "decentraland://?realm=http://127.0.0.1:8000&creator-hub-bin-path=x&launch-cdp-monitor-on-start=true&comms-adapter=y&optimized-assets-url=https://evil.example&gateway=https://evil.example");
 
             Assert.IsFalse(output.ContainsKey("creator-hub-bin-path"), "creator-hub-bin-path must never be permitted (SEC-005), even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must never be permitted, even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must never be permitted, even for a loopback realm");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.OPTIMIZED_ASSETS_URL), "optimized-assets-url must never be permitted, even for a loopback realm — it points the AB/LOD/registry endpoints at arbitrary infrastructure for the whole session; local-ab derives the base from the realm instead");
-            Assert.IsFalse(output.ContainsKey(AppArgsFlags.GATEWAY), "gateway must never be permitted, even for a loopback realm — it reroutes every supported backend url for the whole session");
-        }
-
-        [Test]
-        public void GatewayArgIsUnsetWithoutTheFlag()
-        {
-            IAppArgs args = new ApplicationParametersParser(false);
-
-            Assert.IsNull(args.ResolveFeatureFlagOverride(AppArgsFlags.GATEWAY, requireDebug: false));
-        }
-
-        [TestCase("--gateway", null, true, TestName = "gateway bare")]
-        [TestCase("--gateway", "true", true, TestName = "gateway true")]
-        [TestCase("--gateway", "false", false, TestName = "gateway false")]
-        public void GatewayArgOverridesTheFeatureFlagInBothDirections(string flag, string? value, bool expected)
-        {
-            IAppArgs args = value == null
-                ? new ApplicationParametersParser(false, flag)
-                : new ApplicationParametersParser(false, flag, value);
-
-            Assert.AreEqual(expected, args.ResolveFeatureFlagOverride(AppArgsFlags.GATEWAY, requireDebug: false));
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.GATEWAY), "gateway must never be permitted, even for a loopback realm — it aims every supported backend url at a host of the link's choosing for the whole session");
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -839,14 +839,8 @@ namespace Global.Dynamic
             if (string.IsNullOrEmpty(realm)) return true;
 
             var uri = new Uri(realm);
-            if (uri.Host == "127.0.0.1") return true;
-            if (uri.Host == "localhost") return true;
-            if (uri.Host == "sdk-team-cdn." + IDecentralandUrlsSource.ORG_DOMAIN) return true;
-            if (uri.Host == "sdk-test-scenes." + IDecentralandUrlsSource.ZONE_DOMAIN) return true;
-            if (uri.Host == "realm-provider-ea." + IDecentralandUrlsSource.ORG_DOMAIN) return true;
-            if (uri.Host == "realm-provider-ea." + IDecentralandUrlsSource.ZONE_DOMAIN) return true;
-            if (uri.Host == "worlds-content-server." + IDecentralandUrlsSource.ORG_DOMAIN) return true;
-            if (uri.Host == "worlds-content-server." + IDecentralandUrlsSource.ZONE_DOMAIN) return true;
+            // Hosts we control outright skip both the consent prompt and the contracts/servers lookup below.
+            if (TrustedRealms.IsTrusted(uri)) return true;
 
             IWebRequestController webRequestController = staticContainer!.WebRequestsContainer.WebRequestController;
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -839,7 +839,7 @@ namespace Global.Dynamic
             if (string.IsNullOrEmpty(realm)) return true;
 
             var uri = new Uri(realm);
-            // Hosts we control outright skip both the consent prompt and the contracts/servers lookup below.
+            // A controlled host skips the consent prompt and the contracts/servers lookup below.
             if (TrustedRealms.IsTrusted(uri)) return true;
 
             IWebRequestController webRequestController = staticContainer!.WebRequestsContainer.WebRequestController;

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -258,9 +258,7 @@ namespace Global.Dynamic
             applicationParametersParser.TryGetValue(AppArgsFlags.GATEKEEPER_URL, out string? cliGatekeeperUrl);
             applicationParametersParser.TryGetValue(AppArgsFlags.OPTIMIZED_ASSETS_URL, out string? cliOptimizedAssetsUrl);
 
-            // No --debug required: an e2e fixture run has no feature-flags backend to enable the flag with, and the
-            // arg only picks between Decentraland's own gateway and its own service hosts.
-            bool? cliUseGateway = applicationParametersParser.ResolveFeatureFlagOverride(AppArgsFlags.GATEWAY, requireDebug: false);
+            applicationParametersParser.TryGetValue(AppArgsFlags.GATEWAY, out string? cliGatewayUrl);
 
             // local-ab only: the embedded abgen JIT server reads the scene through the preview server's own
             // content endpoints — no SDK-side sidecar or proxy involved. Its base URL becomes the
@@ -282,7 +280,7 @@ namespace Global.Dynamic
                 debugSettings.CustomGatekeeperUrl,
                 cliGatekeeperUrl,
                 cliOptimizedAssetsUrl,
-                cliUseGateway);
+                cliGatewayUrl);
             DiagnosticInfoUtils.LogEnvironment(decentralandUrlsSource);
 
             splashScreen = await assetsProvisioner.ProvideInstanceAsync(splashScreenRef, ct: ct);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -258,6 +258,10 @@ namespace Global.Dynamic
             applicationParametersParser.TryGetValue(AppArgsFlags.GATEKEEPER_URL, out string? cliGatekeeperUrl);
             applicationParametersParser.TryGetValue(AppArgsFlags.OPTIMIZED_ASSETS_URL, out string? cliOptimizedAssetsUrl);
 
+            // No --debug required: an e2e fixture run has no feature-flags backend to enable the flag with, and the
+            // arg only picks between Decentraland's own gateway and its own service hosts.
+            bool? cliUseGateway = applicationParametersParser.ResolveFeatureFlagOverride(AppArgsFlags.GATEWAY, requireDebug: false);
+
             // local-ab only: the embedded abgen JIT server reads the scene through the preview server's own
             // content endpoints — no SDK-side sidecar or proxy involved. Its base URL becomes the
             // optimized-assets source; requests it doesn't build (wearables, emotes, LODs, registry)
@@ -277,7 +281,8 @@ namespace Global.Dynamic
                 debugSettings.GatekeeperMode,
                 debugSettings.CustomGatekeeperUrl,
                 cliGatekeeperUrl,
-                cliOptimizedAssetsUrl);
+                cliOptimizedAssetsUrl,
+                cliUseGateway);
             DiagnosticInfoUtils.LogEnvironment(decentralandUrlsSource);
 
             splashScreen = await assetsProvisioner.ProvideInstanceAsync(splashScreenRef, ct: ct);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -73,7 +73,8 @@ namespace Global.Dynamic
 
         // Non-null only for DecentralandEnvironment.Custom; set from the command line by ApplyBaseDomainArg.
         private string? customBaseDomain;
-        private string? cliGatewayUrl;
+        private string? cliGatewayArg;
+        private string? cliGatewayPrefix;
 
         // The validated --eth-network value, or null when it was not passed on the command line. Captured by
         // CaptureEthNetworkArg and turned into a network by ResolveEthereumNetwork once the environment is settled.
@@ -261,8 +262,11 @@ namespace Global.Dynamic
             // Read while the deep link is still deferred, for the same reason as the two above: where a session's
             // supported-service traffic goes is not something a link may pick, not even through the denied-params
             // dialog.
-            if (applicationParametersParser.TryGetValue(AppArgsFlags.GATEWAY, out string? gatewayArg) && !string.IsNullOrWhiteSpace(gatewayArg))
-                cliGatewayUrl = gatewayArg.Trim();
+            if (!CaptureGatewayArg(applicationParametersParser))
+            {
+                ExitUtils.Exit();
+                return;
+            }
 
             if (applicationParametersParser.HasPendingDeepLink)
                 await InitializeDeepLinkWorldWhitelistAsync(applicationParametersParser, ct);
@@ -283,7 +287,7 @@ namespace Global.Dynamic
 
             WarnIfCommandLineOnlyArgCameFromTheDeepLink(applicationParametersParser, AppArgsFlags.BASE_DOMAIN, customBaseDomain);
             WarnIfCommandLineOnlyArgCameFromTheDeepLink(applicationParametersParser, AppArgsFlags.ETH_NETWORK, ethNetworkArg);
-            WarnIfCommandLineOnlyArgCameFromTheDeepLink(applicationParametersParser, AppArgsFlags.GATEWAY, cliGatewayUrl);
+            WarnIfCommandLineOnlyArgCameFromTheDeepLink(applicationParametersParser, AppArgsFlags.GATEWAY, cliGatewayArg);
 
             FeatureFlagsConfiguration.Initialize(new FeatureFlagsConfiguration(FeatureFlagsResultDto.Empty));
 
@@ -337,7 +341,7 @@ namespace Global.Dynamic
                 cliGatekeeperUrl,
                 cliOptimizedAssetsUrl,
                 customBaseDomain,
-                cliGatewayUrl);
+                cliGatewayPrefix);
             DiagnosticInfoUtils.LogEnvironment(decentralandUrlsSource);
 
             splashScreen = await assetsProvisioner.ProvideInstanceAsync(splashScreenRef, ct: ct);
@@ -652,6 +656,31 @@ namespace Global.Dynamic
             }
 
             ethNetworkArg = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+            return true;
+        }
+
+        /// <summary>
+        ///     Captures <see cref="AppArgsFlags.GATEWAY" /> into <see cref="cliGatewayArg" /> and its normalized form
+        ///     into <see cref="cliGatewayPrefix" />. Returns false when the launch must be abandoned; the reason is
+        ///     already reported.
+        ///     <para>
+        ///         Rejecting rather than ignoring: naming a gateway forces routing on, so a value that cannot be read
+        ///         as an origin would otherwise send every supported service to a host nobody named.
+        ///     </para>
+        /// </summary>
+        private bool CaptureGatewayArg(IAppArgs appArgs)
+        {
+            if (!appArgs.TryGetValue(AppArgsFlags.GATEWAY, out string? value) || string.IsNullOrWhiteSpace(value))
+                return true;
+
+            if (!GatewayUrlsSource.TryNormalizeGatewayPrefix(value, out string prefix))
+            {
+                ReportHub.LogError(ReportCategory.STARTUP, $"--{AppArgsFlags.GATEWAY} '{value}' is not a gateway origin. Expected an absolute http or https url with a host and no query or fragment");
+                return false;
+            }
+
+            cliGatewayArg = value.Trim();
+            cliGatewayPrefix = prefix;
             return true;
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/TrustedRealms.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/TrustedRealms.cs
@@ -4,29 +4,16 @@ using System;
 namespace Global.Dynamic
 {
     /// <summary>
-    ///     Host policy for the startup trusted-realm gate: which realm hosts may be entered without the
-    ///     untrusted-realm consent prompt. Consulted by <c>MainSceneLoader.IsTrustedRealmAsync</c> before it falls
-    ///     back to the catalyst <c>lambdas/contracts/servers</c> lookup, so a match here also spares that request.
-    ///     <para>
-    ///         A realm reaching this policy is attacker-influenced by design: <c>realm</c> is one of the query params
-    ///         a <c>decentraland://</c> deep link may inject, and it sits on <c>DeepLinkAllowlist</c>'s
-    ///         always-permitted tier *because* this gate exists to catch it. Trusting a host here therefore removes a
-    ///         consent prompt for every user, not only for automation, so an entry must name infrastructure
-    ///         Decentraland controls end to end.
-    ///     </para>
+    ///     Realm hosts that may be entered without the untrusted-realm consent prompt. <c>realm</c> is
+    ///     deep-link injectable, so an entry here drops that prompt for every user, not only for automation:
+    ///     it must name infrastructure Decentraland controls end to end.
     /// </summary>
     public static class TrustedRealms
     {
         /// <summary>
-        ///     Hosts trusted verbatim, scheme-agnostic. Only two kinds of host belong here: loopback, which sits
-        ///     under no Decentraland domain and is served over plain http by local scene development and by a locally
-        ///     hosted E2E fixture; and individual production hosts, which have to be named one by one because
-        ///     <see cref="IDecentralandUrlsSource.ORG_DOMAIN" /> is intentionally not in <see cref="TRUSTED_DOMAINS" />.
-        ///     <para>
-        ///         A <see cref="IDecentralandUrlsSource.ZONE_DOMAIN" /> host never belongs here — the whole domain is
-        ///         already trusted below, so naming one of its hosts would only be dead weight that reads as if the
-        ///         rest of the domain were untrusted.
-        ///     </para>
+        ///     Trusted verbatim, any scheme. Loopback only, plus production hosts one by one —
+        ///     <see cref="IDecentralandUrlsSource.ORG_DOMAIN" /> must never join <see cref="TRUSTED_DOMAINS" />.
+        ///     Never add a <see cref="IDecentralandUrlsSource.ZONE_DOMAIN" /> host: the domain already covers it.
         /// </summary>
         private static readonly string[] TRUSTED_HOSTS =
         {
@@ -38,27 +25,17 @@ namespace Global.Dynamic
         };
 
         /// <summary>
-        ///     Domains whose every subdomain is Decentraland-controlled, and so are trusted without being named.
-        ///     <para>
-        ///         <see cref="IDecentralandUrlsSource.ZONE_DOMAIN" /> is the non-production environment. It hosts the
-        ///         ephemeral E2E Catalyst fixtures at <c>f-{id}.e2e-fixtures.decentraland.zone</c>, whose hostname is
-        ///         minted per run and therefore cannot be enumerated in <see cref="TRUSTED_HOSTS" />.
-        ///     </para>
-        ///     <para>
-        ///         <see cref="IDecentralandUrlsSource.ORG_DOMAIN" /> is deliberately absent. Production keeps
-        ///         per-host entries so that one production subdomain — or one dangling DNS record under it — cannot
-        ///         become a silent realm switch for every user.
-        ///     </para>
+        ///     Domains trusted down to every subdomain. <see cref="IDecentralandUrlsSource.ZONE_DOMAIN" /> covers
+        ///     the E2E fixtures at <c>f-{id}.e2e-fixtures.decentraland.zone</c>, minted per run and so impossible
+        ///     to enumerate. Production stays per-host: one subdomain of it — or one dangling DNS record under it
+        ///     — would otherwise be a silent realm switch for every user.
         /// </summary>
         private static readonly string[] TRUSTED_DOMAINS =
         {
             IDecentralandUrlsSource.ZONE_DOMAIN,
         };
 
-        /// <summary>
-        ///     True when <paramref name="realm" /> may be entered without asking the user to confirm it.
-        ///     Callers pass an already-parsed absolute uri, so malformed-realm handling stays with the caller.
-        /// </summary>
+        /// <summary>True when <paramref name="realm" />, an absolute uri, needs no consent prompt.</summary>
         public static bool IsTrusted(Uri realm)
         {
             string host = realm.Host;
@@ -67,9 +44,8 @@ namespace Global.Dynamic
                 if (string.Equals(host, trustedHost, StringComparison.OrdinalIgnoreCase))
                     return true;
 
-            // Domain-level trust is https-only: a remote realm reached over cleartext can be answered by a network
-            // attacker, so inheriting the domain's trust would hand out that trust to anyone on the path. The exact
-            // hosts above opt out of this because loopback has no meaningful network to attack.
+            // Domain trust is https-only: over cleartext a network attacker answers as any host under the
+            // domain. The exact hosts opt out — loopback has no meaningful network to attack.
             if (!string.Equals(realm.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                 return false;
 
@@ -81,9 +57,8 @@ namespace Global.Dynamic
         }
 
         /// <summary>
-        ///     Suffix match anchored to a label boundary: the domain itself, or any host strictly below it. Requiring
-        ///     the dot is what keeps a look-alike registration such as <c>evildecentraland.zone</c> out, and requiring
-        ///     the suffix to be terminal is what keeps <c>decentraland.zone.example.com</c> out.
+        ///     The domain itself, or any host strictly below it. The dot rejects <c>evildecentraland.zone</c>;
+        ///     anchoring the suffix to the end rejects <c>decentraland.zone.example.com</c>.
         /// </summary>
         private static bool IsWithinDomain(string host, string domain) =>
             string.Equals(host, domain, StringComparison.OrdinalIgnoreCase)

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/TrustedRealms.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/TrustedRealms.cs
@@ -1,0 +1,94 @@
+using DCL.Multiplayer.Connections.DecentralandUrls;
+using System;
+
+namespace Global.Dynamic
+{
+    /// <summary>
+    ///     Host policy for the startup trusted-realm gate: which realm hosts may be entered without the
+    ///     untrusted-realm consent prompt. Consulted by <c>MainSceneLoader.IsTrustedRealmAsync</c> before it falls
+    ///     back to the catalyst <c>lambdas/contracts/servers</c> lookup, so a match here also spares that request.
+    ///     <para>
+    ///         A realm reaching this policy is attacker-influenced by design: <c>realm</c> is one of the query params
+    ///         a <c>decentraland://</c> deep link may inject, and it sits on <c>DeepLinkAllowlist</c>'s
+    ///         always-permitted tier *because* this gate exists to catch it. Trusting a host here therefore removes a
+    ///         consent prompt for every user, not only for automation, so an entry must name infrastructure
+    ///         Decentraland controls end to end.
+    ///     </para>
+    /// </summary>
+    public static class TrustedRealms
+    {
+        /// <summary>
+        ///     Hosts trusted verbatim, scheme-agnostic. Only two kinds of host belong here: loopback, which sits
+        ///     under no Decentraland domain and is served over plain http by local scene development and by a locally
+        ///     hosted E2E fixture; and individual production hosts, which have to be named one by one because
+        ///     <see cref="IDecentralandUrlsSource.ORG_DOMAIN" /> is intentionally not in <see cref="TRUSTED_DOMAINS" />.
+        ///     <para>
+        ///         A <see cref="IDecentralandUrlsSource.ZONE_DOMAIN" /> host never belongs here — the whole domain is
+        ///         already trusted below, so naming one of its hosts would only be dead weight that reads as if the
+        ///         rest of the domain were untrusted.
+        ///     </para>
+        /// </summary>
+        private static readonly string[] TRUSTED_HOSTS =
+        {
+            "127.0.0.1",
+            "localhost",
+            "sdk-team-cdn." + IDecentralandUrlsSource.ORG_DOMAIN,
+            "realm-provider-ea." + IDecentralandUrlsSource.ORG_DOMAIN,
+            "worlds-content-server." + IDecentralandUrlsSource.ORG_DOMAIN,
+        };
+
+        /// <summary>
+        ///     Domains whose every subdomain is Decentraland-controlled, and so are trusted without being named.
+        ///     <para>
+        ///         <see cref="IDecentralandUrlsSource.ZONE_DOMAIN" /> is the non-production environment. It hosts the
+        ///         ephemeral E2E Catalyst fixtures at <c>f-{id}.e2e-fixtures.decentraland.zone</c>, whose hostname is
+        ///         minted per run and therefore cannot be enumerated in <see cref="TRUSTED_HOSTS" />.
+        ///     </para>
+        ///     <para>
+        ///         <see cref="IDecentralandUrlsSource.ORG_DOMAIN" /> is deliberately absent. Production keeps
+        ///         per-host entries so that one production subdomain — or one dangling DNS record under it — cannot
+        ///         become a silent realm switch for every user.
+        ///     </para>
+        /// </summary>
+        private static readonly string[] TRUSTED_DOMAINS =
+        {
+            IDecentralandUrlsSource.ZONE_DOMAIN,
+        };
+
+        /// <summary>
+        ///     True when <paramref name="realm" /> may be entered without asking the user to confirm it.
+        ///     Callers pass an already-parsed absolute uri, so malformed-realm handling stays with the caller.
+        /// </summary>
+        public static bool IsTrusted(Uri realm)
+        {
+            string host = realm.Host;
+
+            foreach (string trustedHost in TRUSTED_HOSTS)
+                if (string.Equals(host, trustedHost, StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+            // Domain-level trust is https-only: a remote realm reached over cleartext can be answered by a network
+            // attacker, so inheriting the domain's trust would hand out that trust to anyone on the path. The exact
+            // hosts above opt out of this because loopback has no meaningful network to attack.
+            if (!string.Equals(realm.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            foreach (string domain in TRUSTED_DOMAINS)
+                if (IsWithinDomain(host, domain))
+                    return true;
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Suffix match anchored to a label boundary: the domain itself, or any host strictly below it. Requiring
+        ///     the dot is what keeps a look-alike registration such as <c>evildecentraland.zone</c> out, and requiring
+        ///     the suffix to be terminal is what keeps <c>decentraland.zone.example.com</c> out.
+        /// </summary>
+        private static bool IsWithinDomain(string host, string domain) =>
+            string.Equals(host, domain, StringComparison.OrdinalIgnoreCase)
+            || (host.Length > domain.Length + 1
+                && host[host.Length - domain.Length - 1] == '.'
+                && host.EndsWith(domain, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/TrustedRealms.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/TrustedRealms.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0945879a8a537452df33d9c434c8f9cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/TrustedRealmsShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/TrustedRealmsShould.cs
@@ -1,0 +1,78 @@
+using Global.Dynamic;
+using NUnit.Framework;
+using System;
+
+namespace Global.Tests.EditMode
+{
+    /// <summary>
+    ///     Pins the realm host policy that decides whether the untrusted-realm consent prompt is shown. The negative
+    ///     cases matter more than the positive ones: each one is a host an attacker can register or reach, and a
+    ///     regression there turns a deep link into a silent realm switch.
+    /// </summary>
+    public class TrustedRealmsShould
+    {
+        // The E2E fixture pool. The subdomain is minted per run, so the policy has to cover it by domain.
+        [TestCase("https://f-9c24e0fe1464661d.e2e-fixtures.decentraland.zone")]
+        [TestCase("https://f-0000000000000000.e2e-fixtures.decentraland.zone/")]
+        [TestCase("https://f-9c24e0fe1464661d.e2e-fixtures.decentraland.zone:8443")]
+        [TestCase("https://F-9C24E0FE1464661D.E2E-FIXTURES.DECENTRALAND.ZONE")]
+        // Any depth under the controlled non-production domain, including the apex.
+        [TestCase("https://decentraland.zone")]
+        [TestCase("https://anything.decentraland.zone")]
+        [TestCase("https://a.b.c.decentraland.zone")]
+        public void TrustControlledZoneHosts(string realm) =>
+            Assert.IsTrue(TrustedRealms.IsTrusted(new Uri(realm)), realm);
+
+        // Domain-level trust is https-only, so a cleartext realm inside the domain still needs consent.
+        [TestCase("http://f-9c24e0fe1464661d.e2e-fixtures.decentraland.zone")]
+        [TestCase("http://decentraland.zone")]
+        public void NotTrustCleartextInsideAControlledDomain(string realm) =>
+            Assert.IsFalse(TrustedRealms.IsTrusted(new Uri(realm)), realm);
+
+        // Suffix matching must be anchored to a label boundary at the end of the host.
+        [TestCase("https://evildecentraland.zone")]
+        [TestCase("https://xdecentraland.zone")]
+        [TestCase("https://decentraland.zone.example.com")]
+        [TestCase("https://f-1.e2e-fixtures.decentraland.zone.example.com")]
+        [TestCase("https://decentraland.zonely.io")]
+        public void NotTrustLookAlikeDomains(string realm) =>
+            Assert.IsFalse(TrustedRealms.IsTrusted(new Uri(realm)), realm);
+
+        // Production and 'today' are not generalised to whole domains: only the named hosts below are trusted.
+        [TestCase("https://anything.decentraland.org")]
+        [TestCase("https://e2e-fixtures.decentraland.org")]
+        [TestCase("https://decentraland.org")]
+        [TestCase("https://anything.decentraland.today")]
+        public void NotTrustWholeProductionOrTodayDomains(string realm) =>
+            Assert.IsFalse(TrustedRealms.IsTrusted(new Uri(realm)), realm);
+
+        // The exact hosts that were trusted before the domain tier existed, including scheme-agnostic loopback.
+        [TestCase("http://127.0.0.1:8000")]
+        [TestCase("http://localhost:8000")]
+        [TestCase("https://localhost")]
+        [TestCase("https://sdk-team-cdn.decentraland.org")]
+        [TestCase("https://sdk-test-scenes.decentraland.zone")]
+        [TestCase("https://realm-provider-ea.decentraland.org/main")]
+        [TestCase("https://realm-provider-ea.decentraland.zone/main")]
+        [TestCase("https://worlds-content-server.decentraland.org")]
+        [TestCase("https://worlds-content-server.decentraland.zone")]
+        public void KeepTrustingTheNamedHosts(string realm) =>
+            Assert.IsTrue(TrustedRealms.IsTrusted(new Uri(realm)), realm);
+
+        // Uri.Host is the only input to the decision. A trusted-looking string anywhere else in the url --
+        // userinfo, query, fragment -- must not leak trust to the host that actually gets contacted.
+        [TestCase("https://f-9c24e0fe1464661d.e2e-fixtures.decentraland.zone@evil.example.com")]
+        [TestCase("https://evil.example.com#f-1.e2e-fixtures.decentraland.zone")]
+        [TestCase("https://evil.example.com/?realm=f-1.e2e-fixtures.decentraland.zone")]
+        // The fully qualified form fails closed: cheaper to ask for consent than to assume the trailing dot is safe.
+        [TestCase("https://f-1.e2e-fixtures.decentraland.zone.")]
+        public void NotBeSpoofedByOtherUriParts(string realm) =>
+            Assert.IsFalse(TrustedRealms.IsTrusted(new Uri(realm)), realm);
+
+        [TestCase("https://example.com")]
+        [TestCase("https://catalyst.example.org")]
+        [TestCase("http://192.168.1.10:8000")]
+        public void NotTrustUnrelatedHosts(string realm) =>
+            Assert.IsFalse(TrustedRealms.IsTrusted(new Uri(realm)), realm);
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/TrustedRealmsShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/TrustedRealmsShould.cs
@@ -5,31 +5,30 @@ using System;
 namespace Global.Tests.EditMode
 {
     /// <summary>
-    ///     Pins the realm host policy that decides whether the untrusted-realm consent prompt is shown. The negative
-    ///     cases matter more than the positive ones: each one is a host an attacker can register or reach, and a
-    ///     regression there turns a deep link into a silent realm switch.
+    ///     Pins the host policy behind the untrusted-realm consent prompt. A regression in the negative
+    ///     cases turns a deep link into a silent realm switch.
     /// </summary>
     public class TrustedRealmsShould
     {
-        // The E2E fixture pool. The subdomain is minted per run, so the policy has to cover it by domain.
+        // Fixture hosts are minted per run; only the domain tier covers them.
         [TestCase("https://f-9c24e0fe1464661d.e2e-fixtures.decentraland.zone")]
         [TestCase("https://f-0000000000000000.e2e-fixtures.decentraland.zone/")]
         [TestCase("https://f-9c24e0fe1464661d.e2e-fixtures.decentraland.zone:8443")]
         [TestCase("https://F-9C24E0FE1464661D.E2E-FIXTURES.DECENTRALAND.ZONE")]
-        // Any depth under the controlled non-production domain, including the apex.
+        // Any depth, apex included.
         [TestCase("https://decentraland.zone")]
         [TestCase("https://anything.decentraland.zone")]
         [TestCase("https://a.b.c.decentraland.zone")]
         public void TrustControlledZoneHosts(string realm) =>
             Assert.IsTrue(TrustedRealms.IsTrusted(new Uri(realm)), realm);
 
-        // Domain-level trust is https-only, so a cleartext realm inside the domain still needs consent.
+        // Domain trust is https-only.
         [TestCase("http://f-9c24e0fe1464661d.e2e-fixtures.decentraland.zone")]
         [TestCase("http://decentraland.zone")]
         public void NotTrustCleartextInsideAControlledDomain(string realm) =>
             Assert.IsFalse(TrustedRealms.IsTrusted(new Uri(realm)), realm);
 
-        // Suffix matching must be anchored to a label boundary at the end of the host.
+        // The suffix must end the host, on a label boundary.
         [TestCase("https://evildecentraland.zone")]
         [TestCase("https://xdecentraland.zone")]
         [TestCase("https://decentraland.zone.example.com")]
@@ -38,7 +37,7 @@ namespace Global.Tests.EditMode
         public void NotTrustLookAlikeDomains(string realm) =>
             Assert.IsFalse(TrustedRealms.IsTrusted(new Uri(realm)), realm);
 
-        // Production and 'today' are not generalised to whole domains: only the named hosts below are trusted.
+        // Never whole domains, only the named hosts below.
         [TestCase("https://anything.decentraland.org")]
         [TestCase("https://e2e-fixtures.decentraland.org")]
         [TestCase("https://decentraland.org")]
@@ -46,7 +45,7 @@ namespace Global.Tests.EditMode
         public void NotTrustWholeProductionOrTodayDomains(string realm) =>
             Assert.IsFalse(TrustedRealms.IsTrusted(new Uri(realm)), realm);
 
-        // The exact hosts that were trusted before the domain tier existed, including scheme-agnostic loopback.
+        // Pre-existing exact hosts; loopback is scheme-agnostic.
         [TestCase("http://127.0.0.1:8000")]
         [TestCase("http://localhost:8000")]
         [TestCase("https://localhost")]
@@ -59,12 +58,11 @@ namespace Global.Tests.EditMode
         public void KeepTrustingTheNamedHosts(string realm) =>
             Assert.IsTrue(TrustedRealms.IsTrusted(new Uri(realm)), realm);
 
-        // Uri.Host is the only input to the decision. A trusted-looking string anywhere else in the url --
-        // userinfo, query, fragment -- must not leak trust to the host that actually gets contacted.
+        // Only Uri.Host decides; userinfo, query and fragment must not leak trust.
         [TestCase("https://f-9c24e0fe1464661d.e2e-fixtures.decentraland.zone@evil.example.com")]
         [TestCase("https://evil.example.com#f-1.e2e-fixtures.decentraland.zone")]
         [TestCase("https://evil.example.com/?realm=f-1.e2e-fixtures.decentraland.zone")]
-        // The fully qualified form fails closed: cheaper to ask for consent than to assume the trailing dot is safe.
+        // Trailing dot fails closed.
         [TestCase("https://f-1.e2e-fixtures.decentraland.zone.")]
         public void NotBeSpoofedByOtherUriParts(string realm) =>
             Assert.IsFalse(TrustedRealms.IsTrusted(new Uri(realm)), realm);

--- a/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/TrustedRealmsShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Tests/EditMode/TrustedRealmsShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a0de15e82be064c82170c2f71a9133e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
@@ -82,11 +82,14 @@ namespace DCL.Browser
         };
 
         private readonly bool envSupported;
+
+        // What --gateway declared: true and false both outrank the flag, null leaves the decision to it.
+        private readonly bool? cliUseGateway;
         private readonly List<string>? resolvedNonClientHosts;
         private readonly string? gatewayPrefix;
         private readonly string? domainSuffix;
 
-        private bool enabled => envSupported && FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.USE_GATEWAY);
+        private bool enabled => envSupported && (cliUseGateway ?? FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.USE_GATEWAY));
 
         public GatewayUrlsSource(
             DecentralandEnvironment environment,
@@ -95,9 +98,11 @@ namespace DCL.Browser
             GatekeeperMode gatekeeperMode = GatekeeperMode.Org,
             string customGatekeeperUrl = "",
             string? cliGatekeeperUrl = null,
-            string? cliOptimizedAssetsUrl = null)
+            string? cliOptimizedAssetsUrl = null,
+            bool? cliUseGateway = null)
             : base(environment, realmData, launchMode, gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, cliOptimizedAssetsUrl)
         {
+            this.cliUseGateway = cliUseGateway;
             envSupported = SUPPORTED_ENVS.Contains(environment);
 
             if (envSupported)

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
@@ -83,13 +83,14 @@ namespace DCL.Browser
 
         private readonly bool envSupported;
 
-        // What --gateway declared: true and false both outrank the flag, null leaves the decision to it.
-        private readonly bool? cliUseGateway;
+        // The base --gateway named, trailing slash trimmed, or null to use gateway.decentraland.{env}. Naming
+        // one is itself the opt-in, so it also stands in for the flag.
+        private readonly string? cliGatewayBase;
         private readonly List<string>? resolvedNonClientHosts;
         private readonly string? gatewayPrefix;
         private readonly string? domainSuffix;
 
-        private bool enabled => envSupported && (cliUseGateway ?? FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.USE_GATEWAY));
+        private bool enabled => envSupported && (cliGatewayBase != null || FeatureFlagsConfiguration.Instance.IsEnabled(FeatureFlagsStrings.USE_GATEWAY));
 
         public GatewayUrlsSource(
             DecentralandEnvironment environment,
@@ -99,10 +100,10 @@ namespace DCL.Browser
             string customGatekeeperUrl = "",
             string? cliGatekeeperUrl = null,
             string? cliOptimizedAssetsUrl = null,
-            bool? cliUseGateway = null)
+            string? cliGatewayUrl = null)
             : base(environment, realmData, launchMode, gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, cliOptimizedAssetsUrl)
         {
-            this.cliUseGateway = cliUseGateway;
+            cliGatewayBase = cliGatewayUrl is { Length: > 0 } ? cliGatewayUrl.TrimEnd('/') : null;
             envSupported = SUPPORTED_ENVS.Contains(environment);
 
             if (envSupported)
@@ -113,7 +114,7 @@ namespace DCL.Browser
                 foreach (string pattern in SUPPORTED_URLS_OF_NON_CLIENT_ORIGIN)
                     resolvedNonClientHosts.Add(pattern.Replace(ENV, envDomain));
 
-                gatewayPrefix = $"https://{GATEWAY_SUBDOMAIN}.decentraland.{envDomain}/";
+                gatewayPrefix = cliGatewayBase != null ? $"{cliGatewayBase}/" : $"https://{GATEWAY_SUBDOMAIN}.decentraland.{envDomain}/";
                 domainSuffix = $".decentraland.{envDomain}";
             }
         }
@@ -230,9 +231,10 @@ namespace DCL.Browser
 
         /// <summary>
         ///     Transform: https://{subdomain}.{domain}/{path}
-        ///     to: https://gateway.{domain}/{subdomain}/{path}
+        ///     to: https://gateway.{domain}/{subdomain}/{path}, or to {--gateway base}/{subdomain}/{path} when one
+        ///     was named.
         /// </summary>
-        private static string TransformToGateway(string url)
+        private string TransformToGateway(string url)
         {
             int firstDot = url.IndexOf('.', HTTPS_PREFIX_LENGTH);
 
@@ -248,6 +250,9 @@ namespace DCL.Browser
             int domainEnd = pathStart >= 0 ? pathStart : url.Length;
             int domainLength = domainEnd - firstDot;
             int pathLength = url.Length - domainEnd;
+
+            if (cliGatewayBase != null)
+                return string.Concat(cliGatewayBase, "/", url.Substring(HTTPS_PREFIX_LENGTH, subdomainLength), url.Substring(domainEnd, pathLength));
 
             int resultLength = HTTPS_PREFIX_LENGTH + GATEWAY_SUBDOMAIN.Length + domainLength + 1 + subdomainLength + pathLength;
 

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
@@ -27,6 +27,8 @@ namespace DCL.Browser
             DecentralandUrl.ApiPlaces,
             DecentralandUrl.ApiWorlds,
             DecentralandUrl.ApiDestinations,
+            DecentralandUrl.ApiEvents,
+            DecentralandUrl.POI,
             DecentralandUrl.Map,
             DecentralandUrl.ContentModerationReport,
 
@@ -46,7 +48,11 @@ namespace DCL.Browser
 
             // Content Servers
             DecentralandUrl.AssetBundlesCDN,
+            DecentralandUrl.WorldServer,
             DecentralandUrl.WorldContentServer,
+            DecentralandUrl.WorldPermissions,
+            DecentralandUrl.WorldComms,
+            DecentralandUrl.WorldCommsAdapter,
 
             DecentralandUrl.Genesis,
             DecentralandUrl.Badges,

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
@@ -86,8 +86,8 @@ namespace DCL.Browser
 
         private readonly bool envSupported;
 
-        // The origin --gateway named, normalized to a trailing slash, or null to use gateway.{BaseDomain}.
-        // Naming one is itself the opt-in, so it also stands in for the flag.
+        // The origin --gateway named, already normalized by TryNormalizeGatewayPrefix, or null to use
+        // gateway.{BaseDomain}. Naming one is itself the opt-in, so it also stands in for the flag.
         private readonly string? cliGatewayPrefix;
         private readonly List<string>? resolvedNonClientHosts;
         private readonly string? gatewayPrefix;
@@ -104,10 +104,10 @@ namespace DCL.Browser
             string? cliGatekeeperUrl = null,
             string? cliOptimizedAssetsUrl = null,
             string? customBaseDomain = null,
-            string? cliGatewayUrl = null)
+            string? cliGatewayPrefix = null)
             : base(environment, realmData, launchMode, gatekeeperMode, customGatekeeperUrl, cliGatekeeperUrl, cliOptimizedAssetsUrl, customBaseDomain)
         {
-            cliGatewayPrefix = NormalizeGatewayPrefix(cliGatewayUrl);
+            this.cliGatewayPrefix = cliGatewayPrefix;
             envSupported = SUPPORTED_ENVS.Contains(environment);
 
             if (envSupported)
@@ -129,24 +129,24 @@ namespace DCL.Browser
             new (DecentralandEnvironment.Custom, new IRealmData.Fake(), launchMode, customBaseDomain: customBaseDomain);
 
         /// <summary>
-        ///     <paramref name="gatewayUrl" /> as a prefix ending in '/', or null when no gateway was named. A value
-        ///     that is not an absolute http(s) url with a host, and without query or fragment, ends the launch
-        ///     instead of being coerced: a mistyped gateway silently routes every supported service somewhere
-        ///     unintended.
+        ///     <paramref name="gatewayUrl" /> reduced to the prefix every gatewayed url is built from, or false when
+        ///     it is not an absolute http(s) url with a host and without query or fragment. The caller reports and
+        ///     abandons the launch rather than coercing a value into something plausible: this arg forces routing on,
+        ///     so a misread one sends every supported service to a host nobody named.
         /// </summary>
-        private static string? NormalizeGatewayPrefix(string? gatewayUrl)
+        public static bool TryNormalizeGatewayPrefix(string gatewayUrl, out string prefix)
         {
-            if (string.IsNullOrWhiteSpace(gatewayUrl))
-                return null;
+            prefix = string.Empty;
 
             if (!Uri.TryCreate(gatewayUrl.Trim(), UriKind.Absolute, out Uri? uri)
                 || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
                 || string.IsNullOrEmpty(uri.Host)
                 || !string.IsNullOrEmpty(uri.Query)
                 || !string.IsNullOrEmpty(uri.Fragment))
-                throw new ArgumentException($"'{gatewayUrl}' is not a valid gateway URL", nameof(gatewayUrl));
+                return false;
 
-            return uri.ToString().TrimEnd('/') + "/";
+            prefix = uri.ToString().TrimEnd('/') + "/";
+            return true;
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
@@ -79,6 +79,8 @@ namespace DCL.Browser
             DecentralandUrl.Members,
             DecentralandUrl.MembersV2,
             DecentralandUrl.ActiveCommunityVoiceChats,
+            DecentralandUrl.ApiFriends,
+            DecentralandUrl.SocialServiceMutes,
         };
 
         /// <summary>
@@ -203,11 +205,11 @@ namespace DCL.Browser
         /// </summary>
         private bool IsGatewayTransformable(string url)
         {
-            if (domainSuffix == null || !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            if (domainSuffix == null || !TryGetSchemePrefixLength(url, out int schemeLength))
                 return false;
 
-            int hostEnd = url.IndexOf('/', HTTPS_PREFIX_LENGTH);
-            ReadOnlySpan<char> authority = url.AsSpan(HTTPS_PREFIX_LENGTH, (hostEnd < 0 ? url.Length : hostEnd) - HTTPS_PREFIX_LENGTH);
+            int hostEnd = url.IndexOf('/', schemeLength);
+            ReadOnlySpan<char> authority = url.AsSpan(schemeLength, (hostEnd < 0 ? url.Length : hostEnd) - schemeLength);
 
             if (authority.IndexOfAny(':', '@') >= 0)
                 return false;
@@ -274,9 +276,12 @@ namespace DCL.Browser
             if (gatewayPrefix == null)
                 return url;
 
-            string prefix = gatewayPrefix;
+            if (!TryGetSchemePrefixLength(url, out int schemeLength))
+                return url;
 
-            int firstDot = url.IndexOf('.', HTTPS_PREFIX_LENGTH);
+            string prefix = GatewayPrefixForScheme(gatewayPrefix, schemeLength);
+
+            int firstDot = url.IndexOf('.', schemeLength);
 
             if (firstDot < 0)
                 return url;
@@ -307,6 +312,46 @@ namespace DCL.Browser
                 if (state.pathLength > 0)
                     src.Slice(state.pathStart, state.pathLength).CopyTo(span.Slice(pos));
             });
+        }
+
+        private static bool TryGetSchemePrefixLength(string url, out int length)
+        {
+            if (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                length = 8;
+                return true;
+            }
+
+            if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            {
+                length = 7;
+                return true;
+            }
+
+            if (url.StartsWith("wss://", StringComparison.OrdinalIgnoreCase))
+            {
+                length = 6;
+                return true;
+            }
+
+            if (url.StartsWith("ws://", StringComparison.OrdinalIgnoreCase))
+            {
+                length = 5;
+                return true;
+            }
+
+            length = 0;
+            return false;
+        }
+
+        private static string GatewayPrefixForScheme(string prefix, int schemeLength)
+        {
+            bool websocket = schemeLength is 5 or 6;
+            if (!websocket)
+                return prefix;
+
+            string websocketScheme = prefix.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ? "wss://" : "ws://";
+            return websocketScheme + prefix[(prefix.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ? 8 : 7)..];
         }
     }
 }

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/GatewayUrlsSource.cs
@@ -290,14 +290,14 @@ namespace DCL.Browser
             if (url.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 return url;
 
-            int subdomainLength = firstDot - HTTPS_PREFIX_LENGTH;
+            int subdomainLength = firstDot - schemeLength;
             int pathStart = url.IndexOf('/', firstDot);
             int domainEnd = pathStart >= 0 ? pathStart : url.Length;
             int pathLength = url.Length - domainEnd;
 
             int resultLength = prefix.Length + subdomainLength + pathLength;
 
-            return string.Create(resultLength, (url, prefix, subdomainLength, pathStart, pathLength), static (span, state) =>
+            return string.Create(resultLength, (url, prefix, schemeLength, subdomainLength, pathStart, pathLength), static (span, state) =>
             {
                 ReadOnlySpan<char> src = state.url.AsSpan();
 
@@ -306,7 +306,7 @@ namespace DCL.Browser
                 state.prefix.AsSpan().CopyTo(span);
                 pos += state.prefix.Length;
 
-                src.Slice(HTTPS_PREFIX_LENGTH, state.subdomainLength).CopyTo(span.Slice(pos));
+                src.Slice(state.schemeLength, state.subdomainLength).CopyTo(span.Slice(pos));
                 pos += state.subdomainLength;
 
                 if (state.pathLength > 0)

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -203,6 +203,34 @@ namespace DCL.Browser.DecentralandUrls.Tests
         }
 
         [Test]
+        public void RouteThroughTheGatewayWhenTheArgForcesItOn()
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: false);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliUseGateway: true);
+
+            Assert.AreEqual("https://gateway.decentraland.org/places/api/places", urlsSource.Url(DecentralandUrl.ApiPlaces));
+        }
+
+        [Test]
+        public void KeepUrlsOffTheGatewayWhenTheArgForcesItOff()
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: true);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliUseGateway: false);
+
+            Assert.AreEqual("https://places.decentraland.org/api/places", urlsSource.Url(DecentralandUrl.ApiPlaces));
+        }
+
+        // The arg overrides the flag, never the environment: today has no gateway to route to.
+        [Test]
+        public void KeepTodayOffTheGatewayWhenTheArgForcesItOn()
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: false);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Today, new IRealmData.Fake(), ILaunchMode.PLAY, cliUseGateway: true);
+
+            Assert.AreEqual("https://places.decentraland.org/api/places", urlsSource.Url(DecentralandUrl.ApiPlaces));
+        }
+
+        [Test]
         public void KeepGatewayRoutingWhenOptimizedAssetsDisabled()
         {
             InitializeFeatureFlags(optimizedAssets: false, useGateway: true);

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -202,30 +202,34 @@ namespace DCL.Browser.DecentralandUrls.Tests
             Assert.AreEqual("https://gateway.decentraland.org/auth-api", urlsSource.Url(DecentralandUrl.ApiAuth));
         }
 
-        [Test]
-        public void RouteThroughTheGatewayWhenTheArgForcesItOn()
+        // Naming a base forces routing on, so the flag has no say either way, and a trailing slash is trimmed.
+        [TestCase(true, "https://gateway.localhost")]
+        [TestCase(false, "https://gateway.localhost")]
+        [TestCase(false, "https://gateway.localhost/")]
+        public void RouteThroughTheGatewayBaseTheArgNames(bool useGateway, string gatewayUrl)
         {
-            InitializeFeatureFlags(optimizedAssets: false, useGateway: false);
-            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliUseGateway: true);
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: useGateway);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayUrl: gatewayUrl);
 
-            Assert.AreEqual("https://gateway.decentraland.org/places/api/places", urlsSource.Url(DecentralandUrl.ApiPlaces));
+            Assert.AreEqual("https://gateway.localhost/places/api/places", urlsSource.Url(DecentralandUrl.ApiPlaces));
         }
 
+        // Signed fetch signs the un-gatewayed url, so the custom base has to reverse as cleanly as the default one.
         [Test]
-        public void KeepUrlsOffTheGatewayWhenTheArgForcesItOff()
-        {
-            InitializeFeatureFlags(optimizedAssets: false, useGateway: true);
-            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliUseGateway: false);
-
-            Assert.AreEqual("https://places.decentraland.org/api/places", urlsSource.Url(DecentralandUrl.ApiPlaces));
-        }
-
-        // The arg overrides the flag, never the environment: today has no gateway to route to.
-        [Test]
-        public void KeepTodayOffTheGatewayWhenTheArgForcesItOn()
+        public void ReverseTheGatewayBaseForSignedFetch()
         {
             InitializeFeatureFlags(optimizedAssets: false, useGateway: false);
-            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Today, new IRealmData.Fake(), ILaunchMode.PLAY, cliUseGateway: true);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayUrl: "https://gateway.localhost");
+
+            Assert.AreEqual("https://places.decentraland.org/api/places", urlsSource.GetOriginalUrl(urlsSource.Url(DecentralandUrl.ApiPlaces)));
+        }
+
+        // The arg replaces the host and outranks the flag, never the environment: today is not gateway-routed.
+        [Test]
+        public void KeepTodayOffTheGatewayEvenWithAGatewayBase()
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: false);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Today, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayUrl: "https://gateway.localhost");
 
             Assert.AreEqual("https://places.decentraland.org/api/places", urlsSource.Url(DecentralandUrl.ApiPlaces));
         }

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -216,6 +216,20 @@ namespace DCL.Browser.DecentralandUrls.Tests
             Assert.AreEqual(expected, urlsSource.Url(DecentralandUrl.ApiPlaces));
         }
 
+        [Test]
+        public void RouteEventsPoiAndWorldServerThroughTheGatewayOrigin()
+        {
+            InitializeFeatureFlags(optimizedAssets: false, useGateway: false);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayPrefix: "http://127.0.0.1:8080/");
+
+            Assert.AreEqual("http://127.0.0.1:8080/events/api/events", urlsSource.Url(DecentralandUrl.ApiEvents));
+            Assert.AreEqual("http://127.0.0.1:8080/dcl-lists/pois", urlsSource.Url(DecentralandUrl.POI));
+            Assert.AreEqual("http://127.0.0.1:8080/worlds-content-server/world", urlsSource.Url(DecentralandUrl.WorldServer));
+            Assert.AreEqual("http://127.0.0.1:8080/worlds-content-server/world/{0}/permissions", urlsSource.Url(DecentralandUrl.WorldPermissions));
+            Assert.AreEqual("http://127.0.0.1:8080/worlds-content-server/worlds/{0}/comms", urlsSource.Url(DecentralandUrl.WorldComms));
+            Assert.AreEqual("http://127.0.0.1:8080/worlds-content-server/worlds/{0}/scenes/{1}/comms", urlsSource.Url(DecentralandUrl.WorldCommsAdapter));
+        }
+
         [TestCase("https://gateway.localhost", "https://gateway.localhost/")]
         [TestCase("https://gateway.localhost/", "https://gateway.localhost/")]
         [TestCase("  https://gateway.localhost  ", "https://gateway.localhost/")]

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -228,6 +228,8 @@ namespace DCL.Browser.DecentralandUrls.Tests
             Assert.AreEqual("http://127.0.0.1:8080/worlds-content-server/world/{0}/permissions", urlsSource.Url(DecentralandUrl.WorldPermissions));
             Assert.AreEqual("http://127.0.0.1:8080/worlds-content-server/worlds/{0}/comms", urlsSource.Url(DecentralandUrl.WorldComms));
             Assert.AreEqual("http://127.0.0.1:8080/worlds-content-server/worlds/{0}/scenes/{1}/comms", urlsSource.Url(DecentralandUrl.WorldCommsAdapter));
+            Assert.AreEqual("ws://127.0.0.1:8080/rpc-social-service-ea", urlsSource.Url(DecentralandUrl.ApiFriends));
+            Assert.AreEqual("http://127.0.0.1:8080/social-api/v1/mutes", urlsSource.Url(DecentralandUrl.SocialServiceMutes));
         }
 
         [TestCase("https://gateway.localhost", "https://gateway.localhost/")]

--- a/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
+++ b/Explorer/Assets/DCL/NetworkDefinitions/Browser/Tests/DecentralandUrlsSourceShould.cs
@@ -204,23 +204,31 @@ namespace DCL.Browser.DecentralandUrls.Tests
             Assert.AreEqual("https://gateway.decentraland.org/auth-api", urlsSource.Url(DecentralandUrl.ApiAuth));
         }
 
-        // Naming a gateway forces routing on, so the flag has no say either way, and the origin is normalized.
-        [TestCase(true, "https://gateway.localhost", "https://gateway.localhost/places/api/places")]
-        [TestCase(false, "https://gateway.localhost", "https://gateway.localhost/places/api/places")]
+        // Naming a gateway forces routing on, so the flag has no say either way.
+        [TestCase(true, "https://gateway.localhost/", "https://gateway.localhost/places/api/places")]
         [TestCase(false, "https://gateway.localhost/", "https://gateway.localhost/places/api/places")]
-        [TestCase(false, "  https://gateway.localhost  ", "https://gateway.localhost/places/api/places")]
-        [TestCase(false, "http://127.0.0.1:8080", "http://127.0.0.1:8080/places/api/places")]
-        [TestCase(false, "https://edge.localhost/gw", "https://edge.localhost/gw/places/api/places")]
-        public void RouteThroughTheGatewayOriginTheArgNames(bool useGateway, string gatewayUrl, string expected)
+        [TestCase(false, "https://edge.localhost/gw/", "https://edge.localhost/gw/places/api/places")]
+        public void RouteThroughTheGatewayOriginTheArgNames(bool useGateway, string gatewayPrefix, string expected)
         {
             InitializeFeatureFlags(optimizedAssets: false, useGateway: useGateway);
-            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayUrl: gatewayUrl);
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayPrefix: gatewayPrefix);
 
             Assert.AreEqual(expected, urlsSource.Url(DecentralandUrl.ApiPlaces));
         }
 
-        // A mistyped gateway would route every supported service somewhere unintended, so it ends the launch
-        // instead of being coerced into something plausible.
+        [TestCase("https://gateway.localhost", "https://gateway.localhost/")]
+        [TestCase("https://gateway.localhost/", "https://gateway.localhost/")]
+        [TestCase("  https://gateway.localhost  ", "https://gateway.localhost/")]
+        [TestCase("http://127.0.0.1:8080", "http://127.0.0.1:8080/")]
+        [TestCase("https://edge.localhost/gw", "https://edge.localhost/gw/")]
+        public void NormalizeAGatewayOrigin(string gatewayUrl, string expected)
+        {
+            Assert.IsTrue(GatewayUrlsSource.TryNormalizeGatewayPrefix(gatewayUrl, out string prefix), gatewayUrl);
+            Assert.AreEqual(expected, prefix);
+        }
+
+        // A mistyped gateway would send every supported service somewhere unintended, so MainSceneLoader reports and
+        // ends the launch instead of coercing it into something plausible.
         [TestCase("not-a-url")]
         [TestCase("gateway.localhost")]
         [TestCase("ftp://gateway.localhost")]
@@ -228,9 +236,7 @@ namespace DCL.Browser.DecentralandUrls.Tests
         [TestCase("https://gateway.localhost#fragment")]
         public void RejectAGatewayUrlThatIsNotAnOrigin(string gatewayUrl)
         {
-            InitializeFeatureFlags(optimizedAssets: false, useGateway: false);
-
-            Assert.Throws<ArgumentException>(() => _ = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayUrl: gatewayUrl));
+            Assert.IsFalse(GatewayUrlsSource.TryNormalizeGatewayPrefix(gatewayUrl, out _), gatewayUrl);
         }
 
         // Signed fetch signs the un-gatewayed url, so the custom base has to reverse as cleanly as the default one.
@@ -238,7 +244,7 @@ namespace DCL.Browser.DecentralandUrls.Tests
         public void ReverseTheGatewayBaseForSignedFetch()
         {
             InitializeFeatureFlags(optimizedAssets: false, useGateway: false);
-            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayUrl: "https://gateway.localhost");
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Org, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayPrefix: "https://gateway.localhost/");
 
             Assert.AreEqual("https://places.decentraland.org/api/places", urlsSource.GetOriginalUrl(urlsSource.Url(DecentralandUrl.ApiPlaces)));
         }
@@ -248,7 +254,7 @@ namespace DCL.Browser.DecentralandUrls.Tests
         public void KeepTodayOffTheGatewayEvenWithAGatewayOrigin()
         {
             InitializeFeatureFlags(optimizedAssets: false, useGateway: false);
-            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Today, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayUrl: "https://gateway.localhost");
+            var urlsSource = new GatewayUrlsSource(DecentralandEnvironment.Today, new IRealmData.Fake(), ILaunchMode.PLAY, cliGatewayPrefix: "https://gateway.localhost/");
 
             Assert.AreEqual("https://places.decentraland.org/api/places", urlsSource.Url(DecentralandUrl.ApiPlaces));
         }

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -106,6 +106,18 @@ For embedded links you will need to place value after `=` sign, instead of space
 
 ---
 
+### `gateway`
+**Type:** Bool (`true` / `false`)
+**Description:** Routes every supported backend url through `gateway.decentraland.{env}/{subdomain}/…` instead of calling each service host directly, overriding the `use-gateway` remote feature flag. When **specified**, the value wins over the remote flag: `--gateway` and `--gateway true` force routing on, `--gateway false` forces it off. When **not specified**, the remote flag decides. Only `org` and `zone` are ever routed — `today` has no gateway, and the arg does not change that. Command line only: it is never accepted from a deep link.
+
+**Usage:**
+```bash
+--gateway true
+--gateway false
+```
+
+---
+
 ### `realm`
 **Type:** String (URL)
 **Description:** Specifies a custom realm server URL to connect to. Used for connecting to local or custom Decentraland servers. The URL should include the protocol (http:// or https://).

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -107,13 +107,12 @@ For embedded links you will need to place value after `=` sign, instead of space
 ---
 
 ### `gateway`
-**Type:** Bool (`true` / `false`)
-**Description:** Routes every supported backend url through `gateway.decentraland.{env}/{subdomain}/…` instead of calling each service host directly, overriding the `use-gateway` remote feature flag. When **specified**, the value wins over the remote flag: `--gateway` and `--gateway true` force routing on, `--gateway false` forces it off. When **not specified**, the remote flag decides. Only `org` and `zone` are ever routed — `today` has no gateway, and the arg does not change that. Command line only: it is never accepted from a deep link.
+**Type:** String (URL)
+**Description:** Routes every supported backend url through this gateway base — `https://{subdomain}.decentraland.{env}/{path}` becomes `<gateway>/{subdomain}/{path}` — instead of the default `gateway.decentraland.{env}`. Specifying it also **forces routing on**: naming a gateway is the opt-in the `use-gateway` remote feature flag would otherwise carry, so the flag is ignored. Without it, the flag decides and the default host is used. Only `org` and `zone` are ever routed — `today` has no gateway, and this arg does not change that. Command line only: never accepted from a deep link, since it aims the session's whole backend traffic at the named host.
 
 **Usage:**
 ```bash
---gateway true
---gateway false
+--gateway https://gateway.localhost
 ```
 
 ---


### PR DESCRIPTION
## Summary
- route Events and POI through the custom `--gateway` origin
- route Worlds metadata, permissions, and comms through the same gateway
- add coverage for all fixture-facing gateway paths

The fixture was serving these endpoints correctly, but Unity still resolved them to `events.decentraland.org`, `dcl-lists.decentraland.org`, and `worlds-content-server.decentraland.org`. This is stacked on #9822.