### PR TITLE
fix: allow explicitly opted-in local HTTP comms adapters

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/AppArgsFlags.cs
@@ -24,6 +24,12 @@ namespace Global.AppArgs
         public const string GATEKEEPER_URL = "gatekeeper-url";
 
         /// <summary>
+        ///     Explicit command-line opt-in for local fixture realms whose signed comms adapter uses HTTP.
+        ///     This flag is intentionally not included in the deep-link allowlist.
+        /// </summary>
+        public const string ACCEPT_UNTRUSTED_REALM = "accept-untrusted-realm";
+
+        /// <summary>
         ///     Points every backend host at a deployment served under this base domain instead of
         ///     decentraland.{org,zone,today}, selecting <c>DecentralandEnvironment.Custom</c>. Applied from the
         ///     command line only: it gates which realm hosts are trusted, so it has to be read before a pending deep

--- a/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/AppArgs/Tests/AppArgsTests.cs
@@ -62,12 +62,13 @@ namespace Global.AppArgs.Tests
         public void DeepLinkDropsInternalFlags()
         {
             Dictionary<string, string> output = ApplicationParametersParser.ProcessDeepLinkParameters(
-                "decentraland://?creator-hub-bin-path=%5C%5Cattacker%5Cshare%5Cp.exe&launch-cdp-monitor-on-start&local-scene=true&comms-adapter=x&skip-auth-screen=true");
+                "decentraland://?creator-hub-bin-path=%5C%5Cattacker%5Cshare%5Cp.exe&launch-cdp-monitor-on-start&local-scene=true&comms-adapter=x&accept-untrusted-realm=true&skip-auth-screen=true");
 
             Assert.IsFalse(output.ContainsKey("creator-hub-bin-path"), "creator-hub-bin-path must be dropped from deep links (not an app-arg; the Creator Hub path is resolved at runtime)");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START), "launch-cdp-monitor-on-start must be dropped");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.LOCAL_SCENE), "local-scene must be dropped");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.COMMS_ADAPTER), "comms-adapter must be dropped");
+            Assert.IsFalse(output.ContainsKey(AppArgsFlags.ACCEPT_UNTRUSTED_REALM), "accept-untrusted-realm must be dropped");
             Assert.IsFalse(output.ContainsKey(AppArgsFlags.SKIP_AUTH_SCREEN), "skip-auth-screen must be dropped");
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/CommsContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/CommsContainer.cs
@@ -145,7 +145,8 @@ namespace Global.Dynamic
                 staticContainer.CharacterContainer.CharacterObject,
                 currentAdapterAddress,
                 staticContainer.WebRequestsContainer.WebRequestController,
-                staticContainer.RealmData
+                staticContainer.RealmData,
+                appArgs
             );
 
             var chatRoom = new ChatConnectiveRoom(staticContainer.WebRequestsContainer.WebRequestController, URLAddress.FromString(bootstrapContainer.DecentralandUrlsSource.Url(DecentralandUrl.ChatAdapter)), hardwareFingerprintProvider);

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ForkGlobalRealmRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/ForkGlobalRealmRoom.cs
@@ -15,13 +15,19 @@ namespace DCL.Multiplayer.Connections.Archipelago.Rooms
 
         private readonly ICurrentAdapterAddress currentAdapterAddress;
         private readonly Func<ArchipelagoIslandRoom> wssRoomFactory;
-        private readonly Func<FixedConnectiveRoom> httpsRoomFactory;
+        private readonly Func<FixedConnectiveRoom> fixedRoomFactory;
+        private readonly bool allowInsecureLocalHttp;
 
-        public ForkGlobalRealmRoom(ICurrentAdapterAddress currentAdapterAddress, Func<ArchipelagoIslandRoom> wssRoomFactory, Func<FixedConnectiveRoom> httpsRoomFactory)
+        public ForkGlobalRealmRoom(
+            ICurrentAdapterAddress currentAdapterAddress,
+            Func<ArchipelagoIslandRoom> wssRoomFactory,
+            Func<FixedConnectiveRoom> fixedRoomFactory,
+            bool allowInsecureLocalHttp = false)
         {
             this.currentAdapterAddress = currentAdapterAddress;
             this.wssRoomFactory = wssRoomFactory;
-            this.httpsRoomFactory = httpsRoomFactory;
+            this.fixedRoomFactory = fixedRoomFactory;
+            this.allowInsecureLocalHttp = allowInsecureLocalHttp;
         }
 
         public IArchipelagoIslandRoom AsActivatable() =>
@@ -34,16 +40,34 @@ namespace DCL.Multiplayer.Connections.Archipelago.Rooms
         {
             string adapterUrl = currentAdapterAddress.AdapterUrl();
 
-            if (adapterUrl.Contains("wss://"))
+            if (adapterUrl.Contains("wss://", StringComparison.OrdinalIgnoreCase))
                 return wssRoomFactory();
 
-            if (adapterUrl.Contains("https://"))
-                return httpsRoomFactory();
+            if (adapterUrl.Contains("https://", StringComparison.OrdinalIgnoreCase))
+                return fixedRoomFactory();
 
-            if (adapterUrl.Contains("offline:offline"))
+            if (IsLoopbackHttpAdapter(adapterUrl, allowInsecureLocalHttp))
+                return fixedRoomFactory();
+
+            if (adapterUrl.Contains("offline:offline", StringComparison.OrdinalIgnoreCase))
                 return IConnectiveRoom.Null.INSTANCE;
 
             throw new InvalidOperationException($"Cannot determine the protocol from the about url: {adapterUrl}");
+        }
+
+        internal static bool IsLoopbackHttpAdapter(string adapterUrl, bool allowInsecureLocalHttp)
+        {
+            if (!allowInsecureLocalHttp)
+                return false;
+
+            int schemeIndex = adapterUrl.IndexOf("http://", StringComparison.OrdinalIgnoreCase);
+            if (schemeIndex < 0)
+                return false;
+
+            string httpUrl = adapterUrl.Substring(schemeIndex);
+            return Uri.TryCreate(httpUrl, UriKind.Absolute, out Uri? uri)
+                   && uri.Scheme == Uri.UriSchemeHttp
+                   && uri.IsLoopback;
         }
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/IArchipelagoIslandRoom.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Rooms/IArchipelagoIslandRoom.cs
@@ -5,6 +5,7 @@ using DCL.Multiplayer.Connections.Rooms.Connective;
 using DCL.Web3.Identities;
 using DCL.WebRequests;
 using ECS;
+using Global.AppArgs;
 using LiveKit.Internal.FFIClients.Pools;
 using LiveKit.Internal.FFIClients.Pools.Memory;
 
@@ -19,7 +20,8 @@ namespace DCL.Multiplayer.Connections.Archipelago.Rooms
             ICharacterObject characterObject,
             ICurrentAdapterAddress currentAdapterAddress,
             IWebRequestController webRequestController,
-            IRealmData realmData
+            IRealmData realmData,
+            IAppArgs? appArgs = null
         ) =>
             new ForkGlobalRealmRoom(
                 currentAdapterAddress,
@@ -35,6 +37,8 @@ namespace DCL.Multiplayer.Connections.Archipelago.Rooms
                     currentAdapterAddress,
                     identityCache,
                     realmData
-                )).AsActivatable();
+                ),
+                allowInsecureLocalHttp: appArgs?.HasFlag(AppArgsFlags.ACCEPT_UNTRUSTED_REALM) == true
+            ).AsActivatable();
     }
 }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Tests/ArchipelagoProtocolSelectionShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Tests/ArchipelagoProtocolSelectionShould.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+
+namespace DCL.Multiplayer.Connections.Archipelago.Tests
+{
+    public class ArchipelagoProtocolSelectionShould
+    {
+        [TestCase("fixed-adapter:signed-login:http://127.0.0.1:8080/comms", true, true)]
+        [TestCase("fixed-adapter:signed-login:http://localhost:8080/comms", true, true)]
+        [TestCase("fixed-adapter:signed-login:http://[::1]:8080/comms", true, true)]
+        [TestCase("fixed-adapter:signed-login:http://127.0.0.1:8080/comms", false, false)]
+        [TestCase("fixed-adapter:signed-login:http://127.0.0.1.attacker.example/comms", true, false)]
+        [TestCase("fixed-adapter:signed-login:http://127.0.0.1@attacker.example/comms", true, false)]
+        [TestCase("fixed-adapter:signed-login:https://127.0.0.1:8080/comms", true, false)]
+        public void AllowInsecureHttpOnlyForExplicitLoopbackOptIn(string adapterUrl, bool allowInsecureLocalHttp, bool expected)
+        {
+            Assert.AreEqual(expected, ForkGlobalRealmRoom.IsLoopbackHttpAdapter(adapterUrl, allowInsecureLocalHttp));
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Tests/ArchipelagoProtocolSelectionShould.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Tests/ArchipelagoProtocolSelectionShould.cs
@@ -1,3 +1,4 @@
+using DCL.Multiplayer.Connections.Archipelago.Rooms;
 using NUnit.Framework;
 
 namespace DCL.Multiplayer.Connections.Archipelago.Tests

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Tests/ArchipelagoProtocolSelectionShould.cs.meta
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Archipelago/Tests/ArchipelagoProtocolSelectionShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d632c9e9ad04e969b4b63a4a5f1a5b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/app-arguments.md
+++ b/docs/app-arguments.md
@@ -146,6 +146,16 @@ On a `base-domain` deployment, where the value *is* read, anything that does not
 
 ---
 
+### `accept-untrusted-realm`
+**Description:** Explicitly enables the local fixture comms fallback for a signed adapter served over HTTP. The adapter must still resolve to a loopback address (`localhost`, `127.0.0.1`, or `::1`); remote HTTP adapters are rejected. This flag is intended for direct command-line launches only and is not accepted from `decentraland://` deep links. It does not disable TLS validation or bypass the untrusted-realm confirmation for other URLs.
+
+**Usage:**
+```bash
+--accept-untrusted-realm
+```
+
+---
+
 ### `local-scene`
 **Type:** Bool
 **Description:** Enables local scene development mode.


### PR DESCRIPTION
## What does this PR change?

Allows the Archipelago global-room selector to use the fixed comms room when a local fixture returns a signed adapter over HTTP, for example `fixed-adapter:signed-login:http://127.0.0.1:8080/...`.

The fallback is fail-closed:

- It requires the direct command-line flag `--accept-untrusted-realm`.
- The adapter URL must resolve to a loopback host (`localhost`, `127.0.0.1`, or `::1`).
- Remote HTTP adapters remain rejected.
- The flag is not accepted from `decentraland://` deep links.
- HTTPS and WSS behavior is unchanged.

## Test Instructions

### Automated tests

The new protocol-selection tests cover loopback allow/deny cases, remote lookalikes, HTTPS, and the explicit opt-in requirement. The existing deep-link allowlist tests also verify that `accept-untrusted-realm` is dropped from deep links.

Run the Unity test suite in CI, or locally with the project Unity version:

```bash
make test-editmode TEST_FILTER=ArchipelagoProtocolSelectionShould
make test-editmode TEST_FILTER=AppArgsTest
```

### Manual fixture test

Start the local fixture with the Unity Explorer helper from `explorer-e2e-infra`:

```bash
./scripts/fixture-local.sh up
./scripts/fixture-open-unity.sh --world seed
```

Expected result: the local signed HTTP comms adapter is selected as a fixed room instead of failing with `Cannot determine the protocol from the about url`.

## Quality Checklist

- [x] Added coverage for the loopback and opt-in security boundary.
- [x] Updated application argument documentation.
- [x] Preserved the existing HTTPS/WSS paths.
- [ ] Full Unity tests require Unity `6000.4.0f1` and run in CI.
