### PR TITLE
feat: stagger avatar wearable loading and gate emotes on instantiation

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Systems/Play/CharacterEmoteSystem.cs
@@ -292,8 +292,12 @@ namespace DCL.AvatarRendering.Emotes.Play
         private void UpdateRemoteMaskedEmoteTags(ref CharacterMaskedEmoteComponent masked, in IAvatarView avatarView) =>
             EmotePlayer.UpdateMaskedEmoteTag(ref masked, avatarView);
 
-        // This query takes care of consuming the CharacterEmoteIntent to trigger an emote
+        // This query takes care of consuming the CharacterEmoteIntent to trigger an emote.
+        // AvatarCustomSkinningComponent gates avatars that are still loading: it appears with the first wearable
+        // instantiation, while the AvatarBase (animator + ghost renderer) is attached earlier — consuming before
+        // it exists would animate the loading ghost. The intent persists until the avatar is instantiated.
         [Query]
+        [All(typeof(AvatarCustomSkinningComponent))]
         [None(typeof(DeleteEntityIntention), typeof(PlayerTeleportIntent.JustTeleported))]
         private void ConsumeEmoteIntent([Data] float dt, Entity entity,
             ref CharacterEmoteComponent emoteComponent,

--- a/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Emotes/Tests/CharacterEmoteSystemShould.cs
@@ -139,7 +139,8 @@ namespace DCL.AvatarRendering.Emotes.Tests
                     Mask = AvatarEmoteMask.AemFullBody,
                 },
                 strandedAvatarView,
-                new AvatarShapeComponent { BodyShape = BodyShape.MALE });
+                new AvatarShapeComponent { BodyShape = BodyShape.MALE },
+                new AvatarCustomSkinningComponent()); // instantiated avatar: the intent is consumable
 
             for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
                 system.Update(1f);
@@ -167,7 +168,8 @@ namespace DCL.AvatarRendering.Emotes.Tests
                     Mask = AvatarEmoteMask.AemFullBody,
                 },
                 movingAvatarView,
-                new AvatarShapeComponent { BodyShape = BodyShape.MALE });
+                new AvatarShapeComponent { BodyShape = BodyShape.MALE },
+                new AvatarCustomSkinningComponent()); // instantiated avatar: the intent is consumable
 
             for (var second = 0; second < StreamableLoadingDefaults.TIMEOUT + 1; second++)
                 system.Update(1f);

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/AvatarWearableAssetsInFlight.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/AvatarWearableAssetsInFlight.cs
@@ -3,15 +3,8 @@ namespace DCL.AvatarRendering.Wearables.Components
     /// <summary>
     ///     Marks a wearable resolution (an avatar's <see cref="Intentions.GetWearablesByPointersIntention" /> promise
     ///     entity) that has been admitted to the asset-loading phase, so its per-wearable asset promises may be created.
-    ///     <see cref="Systems.ResolveWearablePromisesSystem" /> caps how many resolutions carry this marker at once,
-    ///     so avatars finish loading one after another instead of interleaving their downloads.
+    ///     <see cref="Systems.ResolveWearablePromisesSystem" /> admits candidates only while the shared download budget
+    ///     has free slots, so avatars stagger in nearest-first instead of flooding the queue and all finishing together.
     /// </summary>
-    public struct AvatarWearableAssetsInFlight
-    {
-        /// <summary>
-        ///     Seconds since admission. A resolution stuck beyond a threshold stops counting against the cap so it
-        ///     cannot starve the queue.
-        /// </summary>
-        public float Age;
-    }
+    public struct AvatarWearableAssetsInFlight { }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/AvatarWearableAssetsInFlight.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/AvatarWearableAssetsInFlight.cs
@@ -1,0 +1,17 @@
+namespace DCL.AvatarRendering.Wearables.Components
+{
+    /// <summary>
+    ///     Marks a wearable resolution (an avatar's <see cref="Intentions.GetWearablesByPointersIntention" /> promise
+    ///     entity) that has been admitted to the asset-loading phase, so its per-wearable asset promises may be created.
+    ///     <see cref="Systems.ResolveWearablePromisesSystem" /> caps how many resolutions carry this marker at once,
+    ///     so avatars finish loading one after another instead of interleaving their downloads.
+    /// </summary>
+    public struct AvatarWearableAssetsInFlight
+    {
+        /// <summary>
+        ///     Seconds since admission. A resolution stuck beyond a threshold stops counting against the cap so it
+        ///     cannot starve the queue.
+        /// </summary>
+        public float Age;
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/AvatarWearableAssetsInFlight.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Components/AvatarWearableAssetsInFlight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7646679d72b9418bbd2bfc5e54352168
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/ResolveWearablePromisesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/ResolveWearablePromisesSystem.cs
@@ -11,6 +11,7 @@ using DCL.AvatarRendering.Wearables.Helpers;
 using DCL.Diagnostics;
 using DCL.Ipfs;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Optimization.PerformanceBudgeting;
 using ECS;
 using ECS.Abstract;
 using ECS.Prioritization.Components;
@@ -31,33 +32,29 @@ namespace DCL.AvatarRendering.Wearables.Systems
     [LogCategory(ReportCategory.WEARABLE)]
     public partial class ResolveWearablePromisesSystem : BaseUnityLoopSystem
     {
-        /// <summary>
-        ///     A resolution stuck in the asset phase for this long stops holding an in-flight slot, so a wearable
-        ///     whose assets never resolve cannot starve the avatars queued behind it.
-        /// </summary>
-        private const float IN_FLIGHT_STUCK_TIMEOUT_SECS = 30f;
-
         private readonly URLSubdirectory customStreamingSubdirectory;
         private readonly IWearableStorage wearableStorage;
         private readonly IDecentralandUrlsSource urlsSource;
-        private readonly int maxAvatarsWithAssetsInFlight;
+        private readonly ConcurrentLoadingPerformanceBudget loadingBudget;
+        private readonly int estimatedAssetsPerAvatar;
 
         // Per-frame aggregation only
         private readonly List<(Entity entity, float sqrDistance)> assetPhaseCandidates = new ();
-        private int avatarsWithAssetsInFlight;
 
         public ResolveWearablePromisesSystem(
             World world,
             IWearableStorage wearableStorage,
             IDecentralandUrlsSource urlsSource,
             URLSubdirectory customStreamingSubdirectory,
-            int maxAvatarsWithAssetsInFlight
+            ConcurrentLoadingPerformanceBudget loadingBudget,
+            int estimatedAssetsPerAvatar
             ) : base(world)
         {
             this.wearableStorage = wearableStorage;
             this.urlsSource = urlsSource;
             this.customStreamingSubdirectory = customStreamingSubdirectory;
-            this.maxAvatarsWithAssetsInFlight = Math.Max(1, maxAvatarsWithAssetsInFlight);
+            this.loadingBudget = loadingBudget;
+            this.estimatedAssetsPerAvatar = Math.Max(1, estimatedAssetsPerAvatar);
         }
 
         public override void Initialize()
@@ -68,34 +65,40 @@ namespace DCL.AvatarRendering.Wearables.Systems
         {
             assetPhaseCandidates.Clear();
             ResolveWearablePromiseQuery(World);
-
-            avatarsWithAssetsInFlight = 0;
-            CountAvatarsWithAssetsInFlightQuery(World, t);
             AdmitNextAvatarsToAssetPhase();
         }
 
-        [Query]
-        [None(typeof(StreamableResult))]
-        private void CountAvatarsWithAssetsInFlight([Data] float dt, ref AvatarWearableAssetsInFlight inFlight)
-        {
-            inFlight.Age += dt;
-
-            if (inFlight.Age < IN_FLIGHT_STUCK_TIMEOUT_SECS)
-                avatarsWithAssetsInFlight++;
-        }
-
+        /// <summary>
+        ///     Admits DTO-ready avatars into the asset phase, nearest first, only while the shared download budget has
+        ///     free slots. Each admission is assumed to add <see cref="estimatedAssetsPerAvatar" /> downloads to the
+        ///     pipe, so we stop once we predict it is full instead of flooding it. This keeps the budget saturated (the
+        ///     admitted avatars' downloads fill it) while still serializing at the avatar granularity, so avatars
+        ///     complete and reveal one wave after another. As avatars finish they release budget and the next wave is
+        ///     admitted, so admission self-tunes to the completion rate and a stalled avatar (holding no budget) never
+        ///     blocks the queue.
+        /// </summary>
         private void AdmitNextAvatarsToAssetPhase()
         {
-            int freeSlots = maxAvatarsWithAssetsInFlight - avatarsWithAssetsInFlight;
+            if (assetPhaseCandidates.Count == 0)
+                return;
 
-            if (freeSlots <= 0 || assetPhaseCandidates.Count == 0)
+            // CurrentBudget is the whole app's free concurrent-download slots; admitted avatars compete for the same
+            // pool as scenes and everything else, which is exactly what we want to avoid oversubscribing.
+            int freeSlots = loadingBudget.CurrentBudget;
+
+            if (freeSlots <= 0)
                 return;
 
             // Nearest first, so the stagger reveals the most visible avatars earlier
             assetPhaseCandidates.Sort(static (c1, c2) => c1.sqrDistance.CompareTo(c2.sqrDistance));
 
-            for (var i = 0; i < assetPhaseCandidates.Count && i < freeSlots; i++)
+            // Admit at least the nearest candidate whenever there is any room (freeSlots checked before the decrement),
+            // so avatars keep progressing even when the pipe only has a sliver free.
+            for (var i = 0; i < assetPhaseCandidates.Count && freeSlots > 0; i++)
+            {
                 World.Add(assetPhaseCandidates[i].entity, new AvatarWearableAssetsInFlight());
+                freeSlots -= estimatedAssetsPerAvatar;
+            }
         }
 
         [Query]
@@ -157,8 +160,10 @@ namespace DCL.AvatarRendering.Wearables.Systems
                 return;
             }
 
-            // Only a capped number of avatars may load wearable assets at once, so they complete one after another
-            // instead of interleaving downloads and all finishing together at the tail of one shared queue.
+            // Avatars enter the asset phase through a nearest-first gate (see AdmitNextAvatarsToAssetPhase) so their
+            // downloads keep the shared pipe busy without flooding it, and they complete one wave after another instead
+            // of interleaving and all finishing together at the tail of one queue. Until admitted, an avatar with all
+            // its DTOs resolved is only a candidate.
             // DTO resolution above is exempt: definitions are batched into a single request and shared via the storage.
             if (finishedDTOs == wearablesByPointersIntention.Pointers.Count && !World.Has<AvatarWearableAssetsInFlight>(entity))
             {

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/ResolveWearablePromisesSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Systems/ResolveWearablePromisesSystem.cs
@@ -31,20 +31,33 @@ namespace DCL.AvatarRendering.Wearables.Systems
     [LogCategory(ReportCategory.WEARABLE)]
     public partial class ResolveWearablePromisesSystem : BaseUnityLoopSystem
     {
+        /// <summary>
+        ///     A resolution stuck in the asset phase for this long stops holding an in-flight slot, so a wearable
+        ///     whose assets never resolve cannot starve the avatars queued behind it.
+        /// </summary>
+        private const float IN_FLIGHT_STUCK_TIMEOUT_SECS = 30f;
+
         private readonly URLSubdirectory customStreamingSubdirectory;
         private readonly IWearableStorage wearableStorage;
         private readonly IDecentralandUrlsSource urlsSource;
+        private readonly int maxAvatarsWithAssetsInFlight;
+
+        // Per-frame aggregation only
+        private readonly List<(Entity entity, float sqrDistance)> assetPhaseCandidates = new ();
+        private int avatarsWithAssetsInFlight;
 
         public ResolveWearablePromisesSystem(
             World world,
             IWearableStorage wearableStorage,
             IDecentralandUrlsSource urlsSource,
-            URLSubdirectory customStreamingSubdirectory
+            URLSubdirectory customStreamingSubdirectory,
+            int maxAvatarsWithAssetsInFlight
             ) : base(world)
         {
             this.wearableStorage = wearableStorage;
             this.urlsSource = urlsSource;
             this.customStreamingSubdirectory = customStreamingSubdirectory;
+            this.maxAvatarsWithAssetsInFlight = Math.Max(1, maxAvatarsWithAssetsInFlight);
         }
 
         public override void Initialize()
@@ -53,7 +66,36 @@ namespace DCL.AvatarRendering.Wearables.Systems
 
         protected override void Update(float t)
         {
+            assetPhaseCandidates.Clear();
             ResolveWearablePromiseQuery(World);
+
+            avatarsWithAssetsInFlight = 0;
+            CountAvatarsWithAssetsInFlightQuery(World, t);
+            AdmitNextAvatarsToAssetPhase();
+        }
+
+        [Query]
+        [None(typeof(StreamableResult))]
+        private void CountAvatarsWithAssetsInFlight([Data] float dt, ref AvatarWearableAssetsInFlight inFlight)
+        {
+            inFlight.Age += dt;
+
+            if (inFlight.Age < IN_FLIGHT_STUCK_TIMEOUT_SECS)
+                avatarsWithAssetsInFlight++;
+        }
+
+        private void AdmitNextAvatarsToAssetPhase()
+        {
+            int freeSlots = maxAvatarsWithAssetsInFlight - avatarsWithAssetsInFlight;
+
+            if (freeSlots <= 0 || assetPhaseCandidates.Count == 0)
+                return;
+
+            // Nearest first, so the stagger reveals the most visible avatars earlier
+            assetPhaseCandidates.Sort(static (c1, c2) => c1.sqrDistance.CompareTo(c2.sqrDistance));
+
+            for (var i = 0; i < assetPhaseCandidates.Count && i < freeSlots; i++)
+                World.Add(assetPhaseCandidates[i].entity, new AvatarWearableAssetsInFlight());
         }
 
         [Query]
@@ -112,6 +154,18 @@ namespace DCL.AvatarRendering.Wearables.Systems
             if (missingPointers.Count > 0)
             {
                 CreateMissingPointersPromise(missingPointers, ref wearablesByPointersIntention, partitionComponent);
+                return;
+            }
+
+            // Only a capped number of avatars may load wearable assets at once, so they complete one after another
+            // instead of interleaving downloads and all finishing together at the tail of one shared queue.
+            // DTO resolution above is exempt: definitions are batched into a single request and shared via the storage.
+            if (finishedDTOs == wearablesByPointersIntention.Pointers.Count && !World.Has<AvatarWearableAssetsInFlight>(entity))
+            {
+                assetPhaseCandidates.Add((entity, partitionComponent.RawSqrDistance));
+
+                WearableComponentsUtils.WEARABLES_POOL.Release(resolvedDTOs);
+                WearableComponentsUtils.POINTERS_POOL.Release(missingPointers);
                 return;
             }
 

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WearableContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/WearableContainer.cs
@@ -125,6 +125,7 @@ namespace Global.Dynamic
                 WearableCatalog,
                 trimmedWearableCatalog,
                 bootstrapContainer.Analytics.EntitiesAnalytics,
+                staticContainer.AssetsLoadingBudget,
                 BuilderContentUrl.Value);
 
         public EmotePlugin CreateEmotePlugin(

--- a/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/StaticContainer.cs
@@ -105,6 +105,12 @@ namespace Global
         /// </summary>
         public IReadOnlyList<IDCLGlobalPlugin> SharedPlugins { get; private set; }
         public ECSWorldSingletonSharedDependencies SingletonSharedDependencies { get; private set; }
+
+        /// <summary>
+        ///     The shared concurrent-download budget backing <see cref="ECSWorldSingletonSharedDependencies.LoadingBudget" />,
+        ///     exposed concretely so consumers can read its remaining slots (e.g. avatar asset-phase admission).
+        /// </summary>
+        public ConcurrentLoadingPerformanceBudget AssetsLoadingBudget { get; private set; }
         public Profiler Profiler { get; private set; }
         public IEntityCollidersGlobalCache EntityCollidersGlobalCache { get; private set; }
         public IPartitionSettings PartitionSettings => StaticSettings.PartitionSettings;
@@ -196,12 +202,15 @@ namespace Global
 
             container.LoadingStatus = enableAnalytics ? new LoadingStatusAnalyticsDecorator(new LoadingStatus(), analyticsContainer.Controller, web3IdentityProvider) : new LoadingStatus();
 
+            var assetsLoadingBudget = new ConcurrentLoadingPerformanceBudget(staticSettings.AssetsLoadingBudget);
+            container.AssetsLoadingBudget = assetsLoadingBudget;
+
             var sharedDependencies = new ECSWorldSingletonSharedDependencies(
                 componentsContainer.ComponentPoolsRegistry,
                 reportHandlingSettings,
                 new SceneEntityFactory(),
                 new PartitionedWorldsAggregate.Factory(),
-                new ConcurrentLoadingPerformanceBudget(staticSettings.AssetsLoadingBudget),
+                assetsLoadingBudget,
                 new FrameTimeCapBudget(staticSettings.FrameTimeCap, profilingProvider, container.LoadingStatus.IsLoadingScreenOn),
                 new MemoryBudget(memoryCap, profilingProvider, staticSettings.MemoryThresholds),
                 new SceneMapping()

--- a/Explorer/Assets/DCL/PluginSystem/Global/Plugin Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Plugin Settings.asset
@@ -595,6 +595,7 @@ MonoBehaviour:
       type: {class: WearablePlugin/Settings, ns: DCL.AvatarRendering.Wearables, asm: DCL.Plugins}
       data:
         <BatchHeartbeatMs>k__BackingField: 100
+        <MaxAvatarsWithAssetsInFlight>k__BackingField: 3
     - rid: 1709771761983946845
       type: {class: AnalyticsContainer/Settings, ns: DCL.PerformanceAndDiagnostics.Analytics, asm: DCL.Plugins}
       data:

--- a/Explorer/Assets/DCL/PluginSystem/Global/Plugin Settings.asset
+++ b/Explorer/Assets/DCL/PluginSystem/Global/Plugin Settings.asset
@@ -595,7 +595,7 @@ MonoBehaviour:
       type: {class: WearablePlugin/Settings, ns: DCL.AvatarRendering.Wearables, asm: DCL.Plugins}
       data:
         <BatchHeartbeatMs>k__BackingField: 100
-        <MaxAvatarsWithAssetsInFlight>k__BackingField: 3
+        <EstimatedAssetsPerAvatar>k__BackingField: 6
     - rid: 1709771761983946845
       type: {class: AnalyticsContainer/Settings, ns: DCL.PerformanceAndDiagnostics.Analytics, asm: DCL.Plugins}
       data:

--- a/Explorer/Assets/DCL/PluginSystem/Global/WearablePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/WearablePlugin.cs
@@ -40,6 +40,7 @@ namespace DCL.AvatarRendering.Wearables
         private readonly EntitiesAnalytics entitiesAnalytics;
 
         private TimeSpan batchHeartbeat;
+        private int maxAvatarsWithAssetsInFlight;
 
         public WearablePlugin(IWebRequestController webRequestController,
             IRealmData realmData,
@@ -81,12 +82,13 @@ namespace DCL.AvatarRendering.Wearables
                 FinalizeRawWearableLoadingSystem.InjectToWorld(ref builder, wearableStorage, realmData);
 
             ResolveAvatarAttachmentThumbnailSystem.InjectToWorld(ref builder);
-            ResolveWearablePromisesSystem.InjectToWorld(ref builder, wearableStorage, urlsSource, WEARABLES_EMBEDDED_SUBDIRECTORY);
+            ResolveWearablePromisesSystem.InjectToWorld(ref builder, wearableStorage, urlsSource, WEARABLES_EMBEDDED_SUBDIRECTORY, maxAvatarsWithAssetsInFlight);
         }
 
         UniTask IDCLPlugin<Settings>.InitializeAsync(Settings settings, CancellationToken ct)
         {
             batchHeartbeat = TimeSpan.FromMilliseconds(settings.BatchHeartbeatMs);
+            maxAvatarsWithAssetsInFlight = settings.MaxAvatarsWithAssetsInFlight;
             return UniTask.CompletedTask;
         }
 
@@ -94,6 +96,12 @@ namespace DCL.AvatarRendering.Wearables
         public class Settings : IDCLPluginSettings
         {
             [field: SerializeField] public uint BatchHeartbeatMs { get; private set; } = 100;
+
+            /// <summary>
+            ///     How many avatars may have their wearable assets downloading at once. The rest wait, nearest first,
+            ///     so avatars appear one after another instead of all together.
+            /// </summary>
+            [field: SerializeField] public int MaxAvatarsWithAssetsInFlight { get; private set; } = 3;
         }
     }
 }

--- a/Explorer/Assets/DCL/PluginSystem/Global/WearablePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/Global/WearablePlugin.cs
@@ -9,6 +9,7 @@ using DCL.AvatarRendering.Wearables.Systems;
 using DCL.AvatarRendering.Wearables.Systems.Load;
 using DCL.FeatureFlags;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.Optimization.PerformanceBudgeting;
 using DCL.PerformanceAndDiagnostics.Analytics;
 using DCL.PluginSystem;
 using DCL.PluginSystem.Global;
@@ -38,9 +39,10 @@ namespace DCL.AvatarRendering.Wearables
         private readonly IWearableStorage wearableStorage;
         private readonly ITrimmedWearableStorage trimmedWearableStorage;
         private readonly EntitiesAnalytics entitiesAnalytics;
+        private readonly ConcurrentLoadingPerformanceBudget loadingBudget;
 
         private TimeSpan batchHeartbeat;
-        private int maxAvatarsWithAssetsInFlight;
+        private int estimatedAssetsPerAvatar;
 
         public WearablePlugin(IWebRequestController webRequestController,
             IRealmData realmData,
@@ -49,6 +51,7 @@ namespace DCL.AvatarRendering.Wearables
             IWearableStorage wearableStorage,
             ITrimmedWearableStorage trimmedWearableStorage,
             EntitiesAnalytics entitiesAnalytics,
+            ConcurrentLoadingPerformanceBudget loadingBudget,
             string builderContentURL)
         {
             this.wearableStorage = wearableStorage;
@@ -59,6 +62,7 @@ namespace DCL.AvatarRendering.Wearables
             this.builderContentURL = builderContentURL;
             this.builderCollectionsPreview = FeaturesRegistry.Instance.IsEnabled(FeatureId.SelfPreviewBuilderCollections);
             this.entitiesAnalytics = entitiesAnalytics;
+            this.loadingBudget = loadingBudget;
 
             cacheCleaner.Register(this.wearableStorage);
             cacheCleaner.Register(this.trimmedWearableStorage);
@@ -82,13 +86,13 @@ namespace DCL.AvatarRendering.Wearables
                 FinalizeRawWearableLoadingSystem.InjectToWorld(ref builder, wearableStorage, realmData);
 
             ResolveAvatarAttachmentThumbnailSystem.InjectToWorld(ref builder);
-            ResolveWearablePromisesSystem.InjectToWorld(ref builder, wearableStorage, urlsSource, WEARABLES_EMBEDDED_SUBDIRECTORY, maxAvatarsWithAssetsInFlight);
+            ResolveWearablePromisesSystem.InjectToWorld(ref builder, wearableStorage, urlsSource, WEARABLES_EMBEDDED_SUBDIRECTORY, loadingBudget, estimatedAssetsPerAvatar);
         }
 
         UniTask IDCLPlugin<Settings>.InitializeAsync(Settings settings, CancellationToken ct)
         {
             batchHeartbeat = TimeSpan.FromMilliseconds(settings.BatchHeartbeatMs);
-            maxAvatarsWithAssetsInFlight = settings.MaxAvatarsWithAssetsInFlight;
+            estimatedAssetsPerAvatar = settings.EstimatedAssetsPerAvatar;
             return UniTask.CompletedTask;
         }
 
@@ -98,10 +102,13 @@ namespace DCL.AvatarRendering.Wearables
             [field: SerializeField] public uint BatchHeartbeatMs { get; private set; } = 100;
 
             /// <summary>
-            ///     How many avatars may have their wearable assets downloading at once. The rest wait, nearest first,
-            ///     so avatars appear one after another instead of all together.
+            ///     Assumed number of concurrent downloads a freshly admitted avatar adds to the shared loading budget.
+            ///     Avatars are admitted to the asset phase nearest first only while that budget has free slots, so this
+            ///     estimate sets how many are let in per wave: near the real per-avatar cost the pipe stays full with the
+            ///     fewest avatars in flight (best stagger at full throughput); higher values stagger more but may
+            ///     under-fill the pipe, lower values approach loading everything at once.
             /// </summary>
-            [field: SerializeField] public int MaxAvatarsWithAssetsInFlight { get; private set; } = 3;
+            [field: SerializeField] public int EstimatedAssetsPerAvatar { get; private set; } = 6;
         }
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Two changes aimed at how avatars *feel* while loading (profile loading is untouched):

**1. Avatars are admitted into wearable-asset downloading a wave at a time, nearest first, sized to keep the download pipe full.**

Previously, all avatars' wearable definitions resolved in one bulk-batched request, which put every avatar's asset-bundle promises into the shared deferred-loading queue in the same frame. That queue (one global 50-slot `ConcurrentLoadingPerformanceBudget`, sorted only by partition bucket) interleaves downloads across avatars — and since an avatar only instantiates when **all** of its wearables are resolved, every avatar's last wearable landed at the tail of the whole batch and they all popped in at once.

`ResolveWearablePromisesSystem` now gates the transition from DTO resolution to asset downloading through **budget-driven admission**:
- Once an avatar's DTOs are resolved it becomes a candidate. Each frame the system admits candidates **nearest first** (by `RawSqrDistance`), but only **while the shared `ConcurrentLoadingPerformanceBudget` has free slots** — decrementing a local estimate of `EstimatedAssetsPerAvatar` (new `WearablePlugin.Settings` field, default **6**, serialized in `Plugin Settings.asset`) per admission so it fills the pipe without flooding it. At least the nearest candidate is admitted whenever any slot is free, so avatars never stall behind a too-high estimate.
- The admitted avatars' own downloads saturate the 50-slot budget, so **total load time stays close to the old all-at-once behavior** — the pipe is never starved. As each nearby avatar completes and releases budget, the next wave is admitted, so admission **self-tunes to the completion rate** and avatars still reveal one wave after another, nearest first.
- Admitted avatars carry a new `AvatarWearableAssetsInFlight` marker (a pure "admitted" tag) so their per-wearable asset promises are created and they don't re-enter the candidate pool.
- Because admission is gated on real budget occupancy rather than an avatar count, a resolution stalled in the asset phase holds **no** budget and therefore cannot starve the avatars queued behind it — no explicit stuck-timeout is needed.
- DTO (definition) resolution stays bulk-batched and uncapped — queued avatars have their definitions ready the moment they are admitted, and fully cached avatars complete instantly once admitted.

This replaces an earlier revision of this branch that used a fixed `MaxAvatarsWithAssetsInFlight` cap (default 3). That cap staggered reveals correctly but throttled download concurrency to ~3×wearables, well under the 50-slot pipe, so a full crowd loaded noticeably slower. Budget-driven admission keeps the stagger while recovering full throughput, and it also avoids the "3 avatars each on their last wearable → pipe idling at 3/50" waste that a fixed cap suffers as avatars wind down.

**2. Emotes no longer play on loading ghosts.**

`CharacterEmoteSystem.ConsumeEmoteIntent` is now gated on `AvatarCustomSkinningComponent`, which appears with the first wearable instantiation. The pooled `AvatarBase` (animator + ghost renderer, both driven by the same skeleton) is attached before wearables load, so a remote emote intent arriving during loading used to animate the ghost. The intent now persists until the avatar is instantiated and then plays; a remote stop received meanwhile still removes the pending intent. The gate applies uniformly to remote players, the local player, SDK avatars, and the backpack preview — they all consume intents through this system.

**Known trade-offs (intentional for this experiment):**
- Admission reads the **global** loading budget, shared with scene/terrain/other asset loading. The budget churns constantly as downloads complete, so avatars are admitted in the gaps; once even one avatar is in flight the cycle self-sustains. The narrow edge is startup — if non-avatar loading pins the budget at 0 before any avatar becomes a candidate, avatars wait for a free window rather than competing directly in the deferred sort.
- `EstimatedAssetsPerAvatar` is a heuristic: near the real average downloads-per-avatar the pipe stays full with the fewest avatars in flight (tightest stagger at full throughput); lower values are burstier/coarser, higher values stagger more but may under-fill the pipe.
- The local player is not exempt: it wins the nearest-first sort, but re-dressing while the pipe is full waits for a free slot.
- A gated emote intent does not tick its play-timeout, so an emote received during a very long load fires when the avatar finally appears.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 9890
```

**Expected result**: In a crowded area (e.g. Genesis Plaza), avatars materialize progressively — closest first, a wave at a time — instead of all appearing in the same instant, and the full crowd finishes loading roughly as fast as before (the download pipe stays busy). Ghosts never play emotes; an avatar that was emoting while loading starts its emote only once its wearables are on.

### Test Steps
1. Teleport to a crowded scene with a cold cache and watch the crowd fill in: reveals should stagger, nearest avatars first, and the crowd should not take noticeably longer to fully load than on `dev`.
2. Watch a loading ghost while nearby players emote — the ghost must keep idle/locomotion animation only; the emote should start after the avatar reveals.
3. Change your own outfit in the backpack — the preview updates as usual and the in-world avatar re-instantiates (may briefly wait for a free slot in a crowd).
4. Tweak `EstimatedAssetsPerAvatar` in `Plugin Settings.asset` (WearablePlugin section): higher values admit fewer avatars per wave (more staggered, may under-fill the pipe); lower values admit more at once (faster/coarser, approaching the old all-at-once behavior).

### Additional Testing Notes
- Watch whether the crowd's total load time matches `dev` — the point of budget-driven admission is that the shared 50-slot pipe stays saturated.
- Edge cases: player disconnecting mid-load and outfit changes mid-load should free their budget (avatar entity destruction / promise re-creation); a wearable whose assets never resolve should not block the avatars queued behind it.

## Quality Checklist
- [ ] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
