### PR TITLE
fix: improve places screen sorting

### DIFF
--- a/Explorer/Assets/DCL/Places/PlacesFilterSelectorView.cs
+++ b/Explorer/Assets/DCL/Places/PlacesFilterSelectorView.cs
@@ -47,12 +47,12 @@ namespace DCL.Places
 
             if (invokeEvents)
             {
-                sortByBestRated.isOn = true;
+                sortByMostActive.isOn = true;
                 sdk7Only.isOn = true;
             }
             else
             {
-                sortByBestRated.SetIsOnWithoutNotify(true);
+                sortByMostActive.SetIsOnWithoutNotify(true);
                 sdk7Only.SetIsOnWithoutNotify(true);
             }
 

--- a/Explorer/Assets/DCL/Places/PlacesView.cs
+++ b/Explorer/Assets/DCL/Places/PlacesView.cs
@@ -196,7 +196,7 @@ namespace DCL.Places
         {
             currentFilters.Section = null;
             currentFilters.CategoryId = null;
-            currentFilters.SortBy = IPlacesAPIService.SortBy.LIKE_SCORE;
+            currentFilters.SortBy = IPlacesAPIService.SortBy.MOST_ACTIVE;
             currentFilters.SDKVersion = IPlacesAPIService.SDKVersion.SDK7_ONLY;
             currentFilters.SearchText = string.Empty;
         }

--- a/Explorer/Assets/DCL/Places/Prefabs/Places_FilterSelector.prefab
+++ b/Explorer/Assets/DCL/Places/Prefabs/Places_FilterSelector.prefab
@@ -271,7 +271,7 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_IsOn: 0
+  m_IsOn: 1
 --- !u!114 &596507731615795761
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1834,7 +1834,7 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_IsOn: 1
+  m_IsOn: 0
 --- !u!114 &6867466248103151330
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## What does this PR change?

We need to prioritize places with people in it, and align with website results. Sets the default sorting option to most active.

## Test Instructions

1. Go to https://decentraland.org/discover
2. Check how places are sorted out in the grid
3. Open the explorer
4. Go to places screen
5. Check the results are the same
6. Check the active number of people in the place makes sense