### PR TITLE
chore: allow viewing items that are on sale

### DIFF
--- a/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailUtility.cs
+++ b/Explorer/Assets/DCL/InWorldCamera/PhotoDetail/PhotoDetailUtility.cs
@@ -12,7 +12,7 @@ namespace DCL.InWorldCamera.PhotoDetail
         /// </summary>
         public static string GetMarketplaceLink(this IWearable wearable, IDecentralandUrlsSource decentralandUrlsSource)
         {
-            var marketplace = $"{decentralandUrlsSource.Url(DecentralandUrl.ShopLink)}/item/{{0}}/{{1}}&utm_source=client";
+            var marketplace = $"{decentralandUrlsSource.Url(DecentralandUrl.ShopLink)}/item/{{0}}/{{1}}?utm_source=client";
             ReadOnlySpan<char> idSpan = wearable.GetUrn().ToString().AsSpan();
             int lastColonIndex = idSpan.LastIndexOf(':');
 

--- a/Explorer/Assets/DCL/Passport/Modules/Creations/CreationsDetailsPassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/Creations/CreationsDetailsPassportModuleController.cs
@@ -253,7 +253,7 @@ namespace DCL.Passport.Modules.Creations
             bool hasLink = marketplaceLink != string.Empty;
             bool isBaseWearable = itemView.ItemId.IsBaseWearable();
             bool showBuy = !isBaseWearable && item.isOnSale && hasLink;
-            bool showView = !isBaseWearable && !item.isOnSale && hasLink;
+            bool showView = !isBaseWearable && hasLink;
 
             itemView.BuyButton.gameObject.SetActive(showBuy);
             itemView.ViewButton.gameObject.SetActive(showView);

--- a/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
@@ -229,6 +229,7 @@ namespace DCL.Passport.Modules
 
                 if (hasMarketplaceActions)
                 {
+                    equippedWearableItem.ViewButton.gameObject.SetActive(true);
                     equippedWearableItem.ViewButton.onClick.AddListener(() => webBrowser.OpenUrlMainThreadOnly(marketPlaceLink));
                     primaryListingCandidates.Add((equippedWearableItem, wearableUrn));
                 }
@@ -268,6 +269,7 @@ namespace DCL.Passport.Modules
 
                 if (hasEmoteMarketplaceActions)
                 {
+                    equippedWearableItem.ViewButton.gameObject.SetActive(true);
                     equippedWearableItem.ViewButton.onClick.AddListener(() => webBrowser.OpenUrlMainThreadOnly(marketPlaceLink));
                     primaryListingCandidates.Add((equippedWearableItem, emoteUrn));
                 }
@@ -325,7 +327,6 @@ namespace DCL.Passport.Modules
                     bool isOnPrimarySale = onSalePrices.TryGetValue(urn, out int priceCredits);
                     itemView.BuyButton.gameObject.SetActive(isOnPrimarySale);
                     itemView.OnSaleFlap.gameObject.SetActive(isOnPrimarySale);
-                    itemView.ViewButton.gameObject.SetActive(!isOnPrimarySale);
 
                     bool showPrice = isOnPrimarySale && priceCredits > 0;
                     itemView.ItemPriceContainer.SetActive(showPrice);
@@ -338,12 +339,6 @@ namespace DCL.Passport.Modules
             catch (Exception e)
             {
                 ReportHub.LogError(ReportCategory.WEARABLE, $"There was an error while resolving primary listings for equipped items. ERROR: {e.Message}");
-
-                if (ct.IsCancellationRequested)
-                    return;
-
-                foreach ((EquippedItemPassportFieldView itemView, _) in primaryListingCandidates)
-                    itemView.ViewButton.gameObject.SetActive(true);
             }
         }
 

--- a/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
+++ b/Explorer/Assets/DCL/Passport/Modules/EquippedItemsPassportModuleController.cs
@@ -451,7 +451,7 @@ namespace DCL.Passport.Modules
 
         private string GetMarketplaceLink(string id)
         {
-            var marketplace = $"{decentralandUrlsSource.Url(DecentralandUrl.ShopLink)}/item/{{0}}/{{1}}&utm_source=client";
+            var marketplace = $"{decentralandUrlsSource.Url(DecentralandUrl.ShopLink)}/item/{{0}}/{{1}}?utm_source=client";
             ReadOnlySpan<char> idSpan = id.AsSpan();
             int lastColonIndex = idSpan.LastIndexOf(':');
 

--- a/Explorer/Assets/DCL/Passport/Prefabs/EquippedItem_PassportField.prefab
+++ b/Explorer/Assets/DCL/Passport/Prefabs/EquippedItem_PassportField.prefab
@@ -367,7 +367,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 167.42825, y: -220.36}
+  m_AnchoredPosition: {x: 167.42825, y: -223.73}
   m_SizeDelta: {x: 154.8565, y: 33.094}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &8912541461013005766
@@ -688,7 +688,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 90, y: -263.22}
+  m_AnchoredPosition: {x: 90, y: -335.564}
   m_SizeDelta: {x: 134, y: 36}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &5287588688190303136
@@ -1305,7 +1305,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 15}
-  m_SizeDelta: {x: 30, y: 96.45401}
+  m_SizeDelta: {x: 30, y: 103.194}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &4864578315824885445
 CanvasRenderer:
@@ -1377,7 +1377,7 @@ MonoBehaviour:
     m_Top: 0
     m_Bottom: 21
   m_ChildAlignment: 4
-  m_Spacing: 0
+  m_Spacing: 3.37
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
@@ -1527,7 +1527,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 90, y: -289.4542}
+  m_AnchoredPosition: {x: 90, y: -296.194}
   m_SizeDelta: {x: 134, y: 36}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &6693780194188386477


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fix #9894 
Allow viewing on shop items that are on sale

## Test Instructions

### Test Steps
1. Open the client
2. Open a user passprt
3. Hover an item that is flagged as on sale
4. Verify that the hover state has both the buy and view buttons

<img width="382" height="708" alt="Screenshot 2026-08-28 at 09 19 42" src="https://github.com/user-attachments/assets/5a98314e-5b51-48ef-bfb0-5eddac45ee56" />


### Additional Testing Notes
- Note any edge cases to verify
- Mention specific areas that need careful testing
- List known limitations or potential issues

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
