### PR TITLE
fix: allow raycasts when minimap is collapsed

### DIFF
--- a/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
+++ b/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
@@ -637,12 +637,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Button>k__BackingField: {fileID: 4185186173191747787}
-  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
-  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
   <images>k__BackingField: []
   <text>k__BackingField: {fileID: 0}
   interactableColor: {r: 1, g: 1, b: 1, a: 1}
   hoverColor: {r: 0.54, g: 0.54, b: 0.54, a: 1}
+  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
+  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
 --- !u!1 &1621061830315573737
 GameObject:
   m_ObjectHideFlags: 0
@@ -1554,12 +1554,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Button>k__BackingField: {fileID: 2913232251365639464}
-  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
-  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
   <images>k__BackingField: []
   <text>k__BackingField: {fileID: 0}
   interactableColor: {r: 1, g: 1, b: 1, a: 1}
   hoverColor: {r: 0.54, g: 0.54, b: 0.54, a: 1}
+  <ButtonPressedAudio>k__BackingField: {fileID: 11400000, guid: cbbd6a003fc75e24da47c13feacd92c7, type: 2}
+  <ButtonHoverAudio>k__BackingField: {fileID: 11400000, guid: 59da234351971c0498a566fb811b0c36, type: 2}
 --- !u!1 &3553545222316724595
 GameObject:
   m_ObjectHideFlags: 0
@@ -2655,7 +2655,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.9019608}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -3341,6 +3341,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 1
+  m_UseReflectionProbes: 0
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
@@ -3645,6 +3646,7 @@ MonoBehaviour:
   <placeCoordinatesText>k__BackingField: {fileID: 7838645562935564056}
   <sdk6Label>k__BackingField: {fileID: 2377257890637130518}
   <minimapContainer>k__BackingField: {fileID: 3370025681631351507}
+  <minimapContainerCanvasGroup>k__BackingField: {fileID: 8152538123934842747}
   <sideMenuView>k__BackingField: {fileID: 8345986520417290339}
   <sceneRestrictionsView>k__BackingField: {fileID: 6087439276851581053}
   <minimapAnimator>k__BackingField: {fileID: 5048152786859444568}
@@ -3702,6 +3704,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 0
+  m_UseReflectionProbes: 0
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0

--- a/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
+++ b/Explorer/Assets/DCL/Minimap/Assets/Minimap.prefab
@@ -3637,7 +3637,7 @@ MonoBehaviour:
   <mapRendererTargetImage>k__BackingField: {fileID: 6221276209546346655}
   <minimapRendererButton>k__BackingField: {fileID: 7182984698585332529}
   <sideMenuButton>k__BackingField: {fileID: 4843367397424901149}
-  <SideMenuCanvasGroup>k__BackingField: {fileID: 3561821593630048208}
+  <sideMenuCanvasGroup>k__BackingField: {fileID: 3561821593630048208}
   <pixelPerfectMapRendererTextureProvider>k__BackingField: {fileID: 7898703652701543681}
   <mapRendererVisibleParcels>k__BackingField: 8
   <expandMinimapButton>k__BackingField: {fileID: 2913232251365639464}

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -208,8 +208,8 @@ namespace DCL.Minimap
             viewInstance.favoriteButton.OnButtonClicked += OnFavoriteButtonClicked;
             viewInstance.donateButton.onClick.AddListener(OpenDonateToCreatorPanel);
 
-            viewInstance.SideMenuCanvasGroup.alpha = 0;
-            viewInstance.SideMenuCanvasGroup.gameObject.SetActive(false);
+            viewInstance.sideMenuCanvasGroup.alpha = 0;
+            viewInstance.sideMenuCanvasGroup.gameObject.SetActive(false);
             sideMenuPresenter = new SideMenuPresenter(viewInstance.sideMenuView);
             sceneRestrictionsController = new SceneRestrictionsController(viewInstance.sceneRestrictionsView, sceneRestrictionBusController);
             SetGenesisMode(realmData.IsGenesis());
@@ -354,11 +354,11 @@ namespace DCL.Minimap
 
         private void OpenSideMenu()
         {
-            if (viewInstance!.SideMenuCanvasGroup.gameObject.activeInHierarchy) { viewInstance.SideMenuCanvasGroup.DOFade(0, ANIMATION_TIME).SetEase(Ease.InOutQuad).OnComplete(() => viewInstance.SideMenuCanvasGroup.gameObject.gameObject.SetActive(false)); }
+            if (viewInstance!.sideMenuCanvasGroup.gameObject.activeInHierarchy) { viewInstance.sideMenuCanvasGroup.DOFade(0, ANIMATION_TIME).SetEase(Ease.InOutQuad).OnComplete(() => viewInstance.sideMenuCanvasGroup.gameObject.gameObject.SetActive(false)); }
             else
             {
-                viewInstance.SideMenuCanvasGroup.gameObject.gameObject.SetActive(true);
-                viewInstance.SideMenuCanvasGroup.DOFade(1, ANIMATION_TIME).SetEase(Ease.InOutQuad);
+                viewInstance.sideMenuCanvasGroup.gameObject.gameObject.SetActive(true);
+                viewInstance.sideMenuCanvasGroup.DOFade(1, ANIMATION_TIME).SetEase(Ease.InOutQuad);
             }
         }
 

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -340,6 +340,7 @@ namespace DCL.Minimap
             viewInstance.expandMinimapButton.gameObject.SetActive(false);
             viewInstance.minimapRendererButton.gameObject.SetActive(true);
             viewInstance.minimapAnimator.SetTrigger(UIAnimationHashes.EXPAND);
+            viewInstance.minimapContainerCanvasGroup.blocksRaycasts = true;
         }
 
         private void CollapseMinimap()
@@ -348,6 +349,7 @@ namespace DCL.Minimap
             viewInstance.expandMinimapButton.gameObject.SetActive(true);
             viewInstance.minimapRendererButton.gameObject.SetActive(false);
             viewInstance.minimapAnimator.SetTrigger(UIAnimationHashes.COLLAPSE);
+            viewInstance.minimapContainerCanvasGroup.blocksRaycasts = false;
         }
 
         private void OpenSideMenu()

--- a/Explorer/Assets/DCL/Minimap/MinimapView.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapView.cs
@@ -1,10 +1,8 @@
-using DCL.Character.CharacterMotion.Components;
 using DCL.MapRenderer.ConsumerUtils;
 using DCL.MapRenderer.MapLayers.Pins;
 using DCL.UI;
 using DCL.UI.Buttons;
 using MVC;
-using System;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -49,6 +47,9 @@ namespace DCL.Minimap
 
         [field: SerializeField]
         internal RectTransform minimapContainer { get; private set; }
+
+        [field: SerializeField]
+        internal CanvasGroup minimapContainerCanvasGroup { get; private set; }
 
         [field: SerializeField]
         internal SideMenuView sideMenuView { get; private set; }

--- a/Explorer/Assets/DCL/Minimap/MinimapView.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapView.cs
@@ -13,84 +13,84 @@ namespace DCL.Minimap
     public class MinimapView : ViewBase, IView
     {
         [field: SerializeField]
-        internal RawImage mapRendererTargetImage { get; private set; }
+        internal RawImage mapRendererTargetImage { get; private set; } = null!;
 
         [field: SerializeField]
-        internal HoverableButton minimapRendererButton { get; private set; }
+        internal HoverableButton minimapRendererButton { get; private set; } = null!;
 
         [field: SerializeField]
-        internal Button sideMenuButton { get; private set; }
+        internal Button sideMenuButton { get; private set; } = null!;
 
         [field: SerializeField]
-        internal CanvasGroup SideMenuCanvasGroup { get; private set; }
+        internal CanvasGroup sideMenuCanvasGroup { get; private set; } = null!;
 
         [field: SerializeField]
-        internal PixelPerfectMapRendererTextureProvider pixelPerfectMapRendererTextureProvider { get; private set; }
+        internal PixelPerfectMapRendererTextureProvider pixelPerfectMapRendererTextureProvider { get; private set; } = null!;
 
         [field: SerializeField]
         internal int mapRendererVisibleParcels { get; private set; }
 
         [field: SerializeField]
-        internal Button expandMinimapButton { get; private set; }
+        internal Button expandMinimapButton { get; private set; } = null!;
 
         [field: SerializeField]
-        internal Button collapseMinimapButton { get; private set; }
+        internal Button collapseMinimapButton { get; private set; } = null!;
 
         [field: SerializeField]
-        internal TMP_Text placeNameText { get; private set; }
+        internal TMP_Text placeNameText { get; private set; } = null!;
 
         [field: SerializeField]
-        internal TMP_Text placeCoordinatesText { get; private set; }
+        internal TMP_Text placeCoordinatesText { get; private set; } = null!;
 
         [field: SerializeField]
-        internal RectTransform sdk6Label { get; private set; }
+        internal RectTransform sdk6Label { get; private set; } = null!;
 
         [field: SerializeField]
-        internal RectTransform minimapContainer { get; private set; }
+        internal RectTransform minimapContainer { get; private set; } = null!;
 
         [field: SerializeField]
-        internal CanvasGroup minimapContainerCanvasGroup { get; private set; }
+        internal CanvasGroup minimapContainerCanvasGroup { get; private set; } = null!;
 
         [field: SerializeField]
-        internal SideMenuView sideMenuView { get; private set; }
+        internal SideMenuView sideMenuView { get; private set; } = null!;
 
         [field: SerializeField]
-        internal SceneRestrictionsView sceneRestrictionsView { get; private set; }
+        internal SceneRestrictionsView sceneRestrictionsView { get; private set; } = null!;
 
         [field: SerializeField]
-        internal Animator minimapAnimator { get; private set; }
+        internal Animator minimapAnimator { get; private set; } = null!;
 
         [field: SerializeField]
-        internal ButtonView minimapContextualButtonView { get; private set; }
+        internal ButtonView minimapContextualButtonView { get; private set; } = null!;
 
         [field: SerializeField]
-        internal ToggleButtonWithDisabledState favoriteButton { get; private set; }
+        internal ToggleButtonWithDisabledState favoriteButton { get; private set; } = null!;
 
         [field: SerializeField]
-        internal Button donateButton { get; private set; }
+        internal Button donateButton { get; private set; } = null!;
 
         [field: SerializeField]
-        internal RuntimeAnimatorController genesisCityAnimatorController { get; private set; }
+        internal RuntimeAnimatorController genesisCityAnimatorController { get; private set; } = null!;
 
         [field: SerializeField]
-        internal RuntimeAnimatorController worldsAnimatorController { get; private set; }
+        internal RuntimeAnimatorController worldsAnimatorController { get; private set; } = null!;
 
         [field: SerializeField]
-        internal List<GameObject> objectsToActivateForGenesis { get; private set; }
+        internal List<GameObject> objectsToActivateForGenesis { get; private set; } = null!;
 
         [field: SerializeField]
-        internal List<GameObject> objectsToActivateForWorlds { get; private set; }
+        internal List<GameObject> objectsToActivateForWorlds { get; private set; } = null!;
 
         [field: SerializeField]
-        internal MinimapPinMarkerObject destinationPinMarker { get; private set; }
+        internal MinimapPinMarkerObject destinationPinMarker { get; private set; } = null!;
 
         [field: SerializeField]
-        internal GameObject ownPlayerBannedMark { get; private set; }
+        internal GameObject ownPlayerBannedMark { get; private set; } = null!;
 
         [field: SerializeField]
-        internal GameObject ownPlayerBannedTooltip { get; private set; }
+        internal GameObject ownPlayerBannedTooltip { get; private set; } = null!;
 
-        [SerializeField] internal Button contextMenuButton;
+        [SerializeField] internal Button contextMenuButton = null!;
 
         private void Start()
         {


### PR DESCRIPTION
# Pull Request Description
Fixes #9470 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

When the minimap is collapsed, its canvasgroup was blocking raycasts + its background image was raycastable (another block).

Fix:
- the image is no longer raycastable since there's always something on top that is already interactable
- manipulate the canvas group's raycastability in its show/hide transition

### Test Steps
1. Verify the minimap is still fully interactable and works as before
2. Collapse it and verify you are able to interact with the scene behind using the screen-space the minimap was using
3. Do the same in both land and worlds
4. Verify the repro steps in the linked issue


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
