### PR TITLE
chore: publish view lifecycle state to AltTester

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/MVC/AltTesterViewProbe.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/AltTesterViewProbe.cs
@@ -1,0 +1,70 @@
+#if ALTTESTER
+using System.Collections.Generic;
+using System.Text;
+
+namespace MVC
+{
+    /// <summary>
+    ///     Static view-state probe queryable from AltTester via <c>AltDriver.CallStaticMethod</c>.
+    ///     Answers without a GameObject lookup, so a hidden or never-instantiated view is still
+    ///     addressable. Gated by the <c>ALTTESTER</c> define, so the type is absent from shipping
+    ///     binaries.
+    /// </summary>
+    public static class AltTesterViewProbe
+    {
+        // State names are returned as strings: AltTester serializes enums by numeric value, so an
+        // enum here would silently repoint every test the moment the client reorders it.
+        public const string SHOWING = "Showing";
+        public const string SHOWN = "Shown";
+        public const string HIDING = "Hiding";
+        public const string HIDDEN = "Hidden";
+        public const string UNKNOWN = "Unknown";
+
+        // Keyed by concrete view type name. Values are strings, never Unity objects, so nothing
+        // here keeps a destroyed view alive and no teardown hook is needed.
+        private static readonly Dictionary<string, string> STATES = new (64);
+        private static readonly object GATE = new ();
+
+        internal static void Report(string viewName, string state)
+        {
+            lock (GATE) { STATES[viewName] = state; }
+        }
+
+        public static string GetState(string viewName)
+        {
+            lock (GATE) { return STATES.TryGetValue(viewName, out string state) ? state : UNKNOWN; }
+        }
+
+        /// <summary>Comma-joined names of every view that has reported at least once.</summary>
+        public static string GetKnownViews()
+        {
+            lock (GATE) { return string.Join(",", STATES.Keys); }
+        }
+
+        /// <summary>
+        ///     <c>{"ViewName":"Shown","Other":"Hidden"}</c>. Hand-rolled to avoid a serializer
+        ///     dependency in this assembly.
+        /// </summary>
+        public static string Snapshot()
+        {
+            var sb = new StringBuilder(256);
+            sb.Append('{');
+
+            lock (GATE)
+            {
+                var first = true;
+
+                foreach (KeyValuePair<string, string> entry in STATES)
+                {
+                    if (!first) sb.Append(',');
+                    first = false;
+                    sb.Append('"').Append(entry.Key).Append("\":\"").Append(entry.Value).Append('"');
+                }
+            }
+
+            sb.Append('}');
+            return sb.ToString();
+        }
+    }
+}
+#endif

--- a/Explorer/Assets/DCL/Infrastructure/MVC/AltTesterViewProbe.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/AltTesterViewProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 87275ffce8db96349a8463bdd95ca243

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Tests/ViewBaseAltTesterProbeShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Tests/ViewBaseAltTesterProbeShould.cs
@@ -11,6 +11,20 @@ namespace MVC.Tests
     {
         private class ProbeTestView : ViewBase { }
 
+        private class GatedShowProbeView : ViewBase
+        {
+            public readonly UniTaskCompletionSource ShowGate = new ();
+
+            protected override UniTask PlayShowAnimationAsync(CancellationToken ct) => ShowGate.Task;
+        }
+
+        private class GatedHideProbeView : ViewBase
+        {
+            public readonly UniTaskCompletionSource HideGate = new ();
+
+            protected override UniTask PlayHideAnimationAsync(CancellationToken ct) => HideGate.Task;
+        }
+
         private ProbeTestView view;
 
         [SetUp]
@@ -53,6 +67,56 @@ namespace MVC.Tests
             await view.ShowAsync(CancellationToken.None);
             StringAssert.Contains(nameof(ProbeTestView), AltTesterViewProbe.GetKnownViews());
             StringAssert.Contains("\"" + nameof(ProbeTestView) + "\":\"Shown\"", AltTesterViewProbe.Snapshot());
+        }
+
+        [Test]
+        public async Task NotReportShownUntilShowAnimationCompletes()
+        {
+            var gatedView = new GameObject(nameof(GatedShowProbeView)).AddComponent<GatedShowProbeView>();
+            gatedView.gameObject.SetActive(false);
+
+            try
+            {
+                UniTask show = gatedView.ShowAsync(CancellationToken.None);
+
+                Assert.AreEqual("Showing", AltTesterViewProbe.GetState(nameof(GatedShowProbeView)),
+                    "Fails if Shown is reported right after SetActive(true), before the animation finishes.");
+
+                gatedView.ShowGate.TrySetResult();
+                await show;
+
+                Assert.AreEqual("Shown", AltTesterViewProbe.GetState(nameof(GatedShowProbeView)));
+            }
+            finally
+            {
+                Object.DestroyImmediate(gatedView.gameObject);
+            }
+        }
+
+        [Test]
+        public async Task NotReportHiddenUntilHideAnimationCompletes()
+        {
+            var gatedView = new GameObject(nameof(GatedHideProbeView)).AddComponent<GatedHideProbeView>();
+            gatedView.gameObject.SetActive(false);
+
+            try
+            {
+                await gatedView.ShowAsync(CancellationToken.None);
+
+                UniTask hide = gatedView.HideAsync(CancellationToken.None);
+
+                Assert.AreEqual("Hiding", AltTesterViewProbe.GetState(nameof(GatedHideProbeView)));
+                Assert.IsTrue(gatedView.gameObject.activeSelf);
+
+                gatedView.HideGate.TrySetResult();
+                await hide;
+
+                Assert.AreEqual("Hidden", AltTesterViewProbe.GetState(nameof(GatedHideProbeView)));
+            }
+            finally
+            {
+                Object.DestroyImmediate(gatedView.gameObject);
+            }
         }
     }
 }

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Tests/ViewBaseAltTesterProbeShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Tests/ViewBaseAltTesterProbeShould.cs
@@ -1,0 +1,59 @@
+#if ALTTESTER
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace MVC.Tests
+{
+    public class ViewBaseAltTesterProbeShould
+    {
+        private class ProbeTestView : ViewBase { }
+
+        private ProbeTestView view;
+
+        [SetUp]
+        public void SetUp()
+        {
+            view = new GameObject(nameof(ProbeTestView)).AddComponent<ProbeTestView>();
+            view.gameObject.SetActive(false);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(view.gameObject);
+        }
+
+        [Test]
+        public void ReportUnknownBeforeAnyShow()
+        {
+            Assert.AreEqual("Unknown", AltTesterViewProbe.GetState("NeverShownView"));
+        }
+
+        [Test]
+        public async Task ReportShownAfterShowCompletes()
+        {
+            await view.ShowAsync(CancellationToken.None);
+            Assert.AreEqual("Shown", AltTesterViewProbe.GetState(nameof(ProbeTestView)));
+        }
+
+        [Test]
+        public async Task ReportHiddenAfterHideCompletes()
+        {
+            await view.ShowAsync(CancellationToken.None);
+            await view.HideAsync(CancellationToken.None);
+            Assert.AreEqual("Hidden", AltTesterViewProbe.GetState(nameof(ProbeTestView)));
+        }
+
+        [Test]
+        public async Task ListKnownViewsAndSnapshotThem()
+        {
+            await view.ShowAsync(CancellationToken.None);
+            StringAssert.Contains(nameof(ProbeTestView), AltTesterViewProbe.GetKnownViews());
+            StringAssert.Contains("\"" + nameof(ProbeTestView) + "\":\"Shown\"", AltTesterViewProbe.Snapshot());
+        }
+    }
+}
+#endif

--- a/Explorer/Assets/DCL/Infrastructure/MVC/Tests/ViewBaseAltTesterProbeShould.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/Tests/ViewBaseAltTesterProbeShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 445ed6888f80bef4ea677fd962856ed8

--- a/Explorer/Assets/DCL/Infrastructure/MVC/ViewBase.AltTester.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ViewBase.AltTester.cs
@@ -1,0 +1,10 @@
+#if ALTTESTER
+namespace MVC
+{
+    public abstract partial class ViewBase
+    {
+        partial void ReportViewState(string state) =>
+            AltTesterViewProbe.Report(GetType().Name, state);
+    }
+}
+#endif

--- a/Explorer/Assets/DCL/Infrastructure/MVC/ViewBase.AltTester.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ViewBase.AltTester.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b766a313da5ad584196819b72120db96

--- a/Explorer/Assets/DCL/Infrastructure/MVC/ViewBase.cs
+++ b/Explorer/Assets/DCL/Infrastructure/MVC/ViewBase.cs
@@ -6,10 +6,13 @@ using UnityEngine.UI;
 
 namespace MVC
 {
-    public abstract class ViewBase : MonoBehaviour
+    public abstract partial class ViewBase : MonoBehaviour
     {
         public event Action? OnViewHidden;
         public event Action? OnViewShown;
+
+        // Implemented only under ALTTESTER (ViewBase.AltTester.cs); erased with its call sites otherwise.
+        partial void ReportViewState(string state);
 
         [field: Header("Can be Null")]
         [field: SerializeField] protected Canvas? canvas { get; private set; }
@@ -25,21 +28,25 @@ namespace MVC
 
         public virtual async UniTask ShowAsync(CancellationToken ct)
         {
+            ReportViewState("Showing");
             gameObject.SetActive(true);
             if (raycaster != null) raycaster.enabled = false; // Disable raycasts while the show animation is playing
             await PlayShowAnimationAsync(ct);
             if (raycaster != null) raycaster.enabled = true;
+            ReportViewState("Shown");
             OnViewShown?.Invoke();
         }
 
         public virtual async UniTask HideAsync(CancellationToken ct, bool isInstant = false)
         {
+            ReportViewState("Hiding");
             if (raycaster != null) raycaster.enabled = false;
 
             if (!isInstant)
                 await PlayHideAnimationAsync(ct);
 
             gameObject.SetActive(false);
+            ReportViewState("Hidden");
             OnViewHidden?.Invoke();
         }
 


### PR DESCRIPTION
The automation suite infers "this view is ready" from `activeInHierarchy`, which is true for the whole show animation (raycaster off, view unclickable) and stays true for the whole hide animation. That window is the source of the suite's "clicked the button, nothing happened" flakiness.

`ViewBase` now latches `Showing` / `Shown` / `Hiding` / `Hidden` at the four points where it already toggles the GameObject, through a `partial void` hook implemented only under `ALTTESTER`. `Shown` lands after the show animation completes, where the raycaster comes back on. A static probe in the same assembly exposes the state to AltTester by view name, so a hidden or not-yet-instantiated view is still answerable.

Release builds carry zero IL for this: the partial method has no implementing declaration without `ALTTESTER`, so the compiler erases it and every call site.

Paired with explorer-automation branch `chore/explorer-view-explicit-signals`, which consumes the probe.
