### PR TITLE
fix: skip the media converter for private-network content hosts

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/NFTShapes/LoadNFTTypeSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/NFTShapes/LoadNFTTypeSystem.cs
@@ -38,7 +38,7 @@ namespace ECS.StreamableLoading.NFTShapes
             StreamableLoadingState state, IPartitionComponent partition, CancellationToken ct)
         {
             string imageUrl = await ImageUrlAsync(intention.CommonArguments, ct);
-            string convertUrl = ktxEnabled ? string.Format(urlsSource.Url(DecentralandUrl.MediaConverter), Uri.EscapeDataString(imageUrl)) : imageUrl;
+            string convertUrl = ktxEnabled && !WebRequestUtils.IsPrivateNetworkHost(imageUrl) ? string.Format(urlsSource.Url(DecentralandUrl.MediaConverter), Uri.EscapeDataString(imageUrl)) : imageUrl;
             var contentInfo = await WebContentInfo.FetchAsync(convertUrl, ct);
 
             if (!ktxEnabled && contentInfo is { Type: WebContentInfo.ContentType.Image, SizeInBytes: > MAX_PREVIEW_SIZE })

--- a/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
+++ b/Explorer/Assets/DCL/WebRequests/Texture/GetTextureWebRequest.cs
@@ -37,7 +37,7 @@ namespace DCL.WebRequests
 
         internal static GetTextureWebRequest Initialize(string url, GetTextureArguments textureArguments, IDecentralandUrlsSource urlsSource, bool ktxEnabled)
         {
-            bool useKtx = textureArguments.UseKtx && ktxEnabled && KtxNativeSupport.IsSupported && !WebRequestUtils.IsLocalhost(url);
+            bool useKtx = textureArguments.UseKtx && ktxEnabled && KtxNativeSupport.IsSupported && !WebRequestUtils.IsLocalhost(url) && !WebRequestUtils.IsPrivateNetworkHost(url);
             string requestUrl = useKtx ? string.Format(urlsSource.Url(DecentralandUrl.MediaConverter), Uri.EscapeDataString(url)) : url;
             UnityWebRequest webRequest = UnityWebRequest.Get(requestUrl);
 

--- a/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
+++ b/Explorer/Assets/DCL/WebRequests/WebRequestUtils.cs
@@ -2,7 +2,10 @@ using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Utilities.Extensions;
 using System;
+using System.Collections.Concurrent;
 using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using UnityEngine.Networking;
 
@@ -16,6 +19,8 @@ namespace DCL.WebRequests
         public const int UNAUTHORIZED_ACCESS = 401;
         public const int FORBIDDEN_ACCESS = 403;
         public const int NOT_FOUND = 404;
+
+        private static readonly ConcurrentDictionary<string, bool> PRIVATE_HOST_CACHE = new ();
 
         public static SuppressExceptionWithFallback<TCoreOp, TWebRequest, TResult> SuppressExceptionsWithFallback<TCoreOp, TWebRequest, TResult>(this TCoreOp coreOp, TResult fallbackValue, SuppressExceptionWithFallback.Behaviour behaviour = SuppressExceptionWithFallback.Behaviour.Default, ReportData? reportContext = null) where TWebRequest: struct, ITypedWebRequest where TCoreOp: IWebRequestOp<TWebRequest, TResult> =>
             new (coreOp, fallbackValue, behaviour, reportContext);
@@ -175,6 +180,47 @@ namespace DCL.WebRequests
             || url.StartsWith("https://127.0.0.1", StringComparison.OrdinalIgnoreCase)
             || url.StartsWith("http://[::1]", StringComparison.OrdinalIgnoreCase)
             || url.StartsWith("https://[::1]", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        ///     True when the URL's host resolves only to loopback, private (RFC 1918), link-local,
+        ///     carrier-grade-NAT (RFC 6598), or IPv6 ULA addresses. Content on such hosts cannot be
+        ///     reached by public server-side services (e.g. the media converter), so it must be
+        ///     fetched directly. The verdict is cached per host; the first call for a host performs
+        ///     a blocking DNS resolution.
+        /// </summary>
+        public static bool IsPrivateNetworkHost(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+                return false;
+
+            return PRIVATE_HOST_CACHE.GetOrAdd(uri.Host, static host =>
+            {
+                try
+                {
+                    IPAddress[] addresses = Dns.GetHostAddresses(host);
+                    return addresses.Length > 0 && Array.TrueForAll(addresses, IsPrivateAddress);
+                }
+                catch (Exception) { return false; }
+            });
+        }
+
+        private static bool IsPrivateAddress(IPAddress address)
+        {
+            if (IPAddress.IsLoopback(address)) return true;
+
+            if (address.AddressFamily == AddressFamily.InterNetwork)
+            {
+                byte[] b = address.GetAddressBytes();
+
+                return b[0] == 10
+                       || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
+                       || (b[0] == 192 && b[1] == 168)
+                       || (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
+                       || (b[0] == 169 && b[1] == 254);
+            }
+
+            return address.IsIPv6LinkLocal || address.IsIPv6SiteLocal || (address.GetAddressBytes()[0] & 0xFE) == 0xFC;
+        }
 
         /// <summary>
         ///     Does nothing with the web request


### PR DESCRIPTION

# Pull Request Description

## What does this PR change?

Fixes **permanently broken raw-GLTF textures (and NFT shapes) in any world served from a private-network Catalyst** — a LAN content server, a VPN/tailnet overlay host, or any host that resolves to a non-publicly-routable address.

**Failure mode.** When KTX is enabled, `GetTextureWebRequest.Initialize` rewrites every raw texture URL through the media converter (`metamorph-api.<domain>/convert?url=...`), and `LoadNFTTypeSystem` does the same for NFT-shape content probes. The converter is a *public server-side service*: it fetches the source URL itself. When the content host resolves only to private addresses, the converter cannot reach it and responds **403 "url host is not publicly routable"**. There is no direct-URL fallback on that path, so every texture request fails through all its retries, textures never fill, and affected meshes render with uninitialized texture memory (visual noise). The failure repeats on every request — a boot against a private catalyst burns thousands of doomed converter round-trips.

**Root cause.** The converter bypass only covered literal localhost prefixes (`WebRequestUtils.IsLocalhost` — `localhost`, `127.0.0.1`, `[::1]`). Any other private host — RFC 1918 ranges, CGNAT (RFC 6598, what VPN overlays like Tailscale hand out), link-local, IPv6 ULA, or a DNS name resolving to any of those — still went through the converter that can never fetch it.

**Fix (+48/−2, 3 files):**
- `WebRequestUtils.IsPrivateNetworkHost(url)`: resolves the URL's host via DNS and returns true when *all* resolved addresses are loopback, RFC 1918 private, link-local, RFC 6598 CGNAT, or IPv6 ULA/link-local/site-local. The verdict is cached per host in a `ConcurrentDictionary`, so the blocking resolution happens once per host per session (and the OS resolver caches beneath it).
- `GetTextureWebRequest.Initialize`: adds `!WebRequestUtils.IsPrivateNetworkHost(url)` to the `useKtx` condition, next to the existing `IsLocalhost` bypass — private-host textures are fetched directly as raw images.
- `LoadNFTTypeSystem`: same skip for the NFT-shape content-info probe.

Public hosts are unaffected: the check short-circuits to the converter path exactly as before (one cached DNS lookup per new host). Hosts with mixed public/private records are treated as public, preserving converter behavior.

**Verification.** Reproduced and validated live against a private-network Catalyst (Unity player, 2026-08-27): before the fix, ~2,324 failed converter requests per boot (every raw-GLTF texture, each retried to exhaustion) and noise-textured meshes; after the fix, zero converter 403s, all 5 raw-GLTF textures in the test scene load and render correctly. Genesis City content (public CDN hosts) is unchanged — requests still route through the converter.

## Test Instructions

The regression surface is the converter routing decision, so testing is two-sided: private hosts must bypass, public hosts must not.

**Steps (standard run — public content, no behavior change)**:
```bash
metaforge explorer run 9911
```

**Expected result**:
Genesis City loads normally; texture requests to public content hosts still go through the media converter (KTX path), visuals unchanged.

**Steps (private catalyst)**:
1. Serve a world from a content server on a private address (e.g. a local Catalyst on `192.168.x.x`, or a host reachable only over a VPN/tailnet `100.64.x.x` address).
2. Launch the explorer against that realm with KTX enabled.

**Expected result**:
Raw-GLTF textures load and render correctly (fetched directly, no converter round-trip); no repeated 403 "url host is not publicly routable" failures in the log.

### Prerequisites
- [ ] For the private-host case: any content server on a private/CGNAT address hosting a scene with raw (non-asset-bundle) GLTF textures.

### Test Steps
1. Run against Genesis City: confirm textures load and converter URLs still appear in the web-request log for public hosts.
2. Run against the private catalyst: confirm textures load, and no `metamorph-api.*/convert` requests are issued for the private host.
3. Check an NFT frame in both runs: NFT images load in both.

### Additional Testing Notes
- The first request to a given host performs one blocking DNS resolution; subsequent requests hit the in-memory per-host cache. No measurable impact on the frame loop (the check runs on the request-initialization path, once per host).
- If DNS resolution fails, the host is treated as public (fail-open to current behavior).

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required) — N/A
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included — N/A

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
