### PR TITLE
refactor(perf): enable native animator culling for remote avatars

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
@@ -6,7 +6,12 @@
 
         // Stamped by AvatarShapeVisibilitySystem's frustum pass so downstream systems
         // (skinning skip, animator gate) share one visibility source instead of re-testing
-        public bool IsInCameraFrustum;
+        public bool IsInCameraFrustum { get; private set; }
+
+        public void SetInCameraFrustum(bool isInFrustum)
+        {
+            IsInCameraFrustum = isInFrustum;
+        }
         private DITHER_STATE currentDitherState;
 
         public bool ShouldUpdateDitherState(float newDistance, float startFadeDithering, float endFadeDithering)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
@@ -3,6 +3,10 @@
     public struct AvatarCachedVisibilityComponent
     {
         public bool IsVisible;
+
+        // Stamped by AvatarShapeVisibilitySystem's frustum pass so downstream systems
+        // (skinning skip, animator gate) share one visibility source instead of re-testing
+        public bool IsInCameraFrustum;
         private DITHER_STATE currentDitherState;
 
         public bool ShouldUpdateDitherState(float newDistance, float startFadeDithering, float endFadeDithering)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -76,9 +76,8 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         public FixedComputeBufferHandler.Slice VertsOutRegion;
 
         /// <summary>
-        ///     After defragmentation the new region holds another avatar's verts, so one re-skin must run regardless of visibility
+        ///     One-shot flag: forces the next skin dispatch to run regardless of visibility or frustum state. Self-clears after consumption.
         /// </summary>
-        public bool ForceSkinNextFrame;
 
         public readonly int VertCount;
         public readonly int BoneCount;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -75,6 +75,11 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         /// </summary>
         public FixedComputeBufferHandler.Slice VertsOutRegion;
 
+        /// <summary>
+        ///     After defragmentation the new region holds another avatar's verts, so one re-skin must run regardless of visibility
+        /// </summary>
+        public bool ForceSkinNextFrame;
+
         public readonly int VertCount;
         public readonly int BoneCount;
 
@@ -98,6 +103,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             this.computeShaderInstance = computeShaderInstance;
             this.LocalBounds = localBounds;
             VertsOutRegion = default(FixedComputeBufferHandler.Slice);
+            ForceSkinNextFrame = false;
 
             disposed = false;
         }
@@ -135,6 +141,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         public void SetVertOutRegion(FixedComputeBufferHandler.Slice region)
         {
             VertsOutRegion = region;
+            ForceSkinNextFrame = true;
 
             computeShaderInstance.SetInt(ComputeShaderConstants.LAST_AVATAR_VERT_COUNT_ID, region.StartIndex);
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -78,6 +78,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         /// <summary>
         ///     One-shot flag: forces the next skin dispatch to run regardless of visibility or frustum state. Self-clears after consumption.
         /// </summary>
+        public bool ForceSkinNextFrame;
 
         public readonly int VertCount;
         public readonly int BoneCount;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -69,6 +69,16 @@ namespace DCL.AvatarRendering.AvatarShape
                 CalculateFrustumPlanes(cameraComponent.Camera);
                 GetAvatarsVisibleWithOutlineQuery(World, cameraComponent);
             }
+            else
+                CalculateFrustumPlanes(camera.GetCameraComponent(World).Camera);
+
+            StampFrustumVisibilityQuery(World);
+        }
+
+        [Query]
+        private void StampFrustumVisibility(in AvatarBase avatarBase, ref AvatarCachedVisibilityComponent cached)
+        {
+            cached.IsInCameraFrustum = IsVisibleInCamera(avatarBase.AvatarSkinnedMeshRenderer.bounds);
         }
 
         internal void CalculateFrustumPlanes(Camera camera)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -78,7 +78,7 @@ namespace DCL.AvatarRendering.AvatarShape
         [Query]
         private void StampFrustumVisibility(in AvatarBase avatarBase, ref AvatarCachedVisibilityComponent cached)
         {
-            cached.IsInCameraFrustum = IsVisibleInCamera(avatarBase.AvatarSkinnedMeshRenderer.bounds);
+            cached.SetInCameraFrustum(IsVisibleInCamera(avatarBase.AvatarSkinnedMeshRenderer.bounds));
         }
 
         internal void CalculateFrustumPlanes(Camera camera)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
@@ -4,6 +4,8 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.AvatarRendering.AvatarShape.ComputeShader;
+using DCL.AvatarRendering.AvatarShape.UnityInterface;
+using DCL.CharacterCamera;
 using DCL.Diagnostics;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
@@ -11,6 +13,7 @@ using Unity.Collections;
 using Unity.Mathematics;
 using System;
 using RichTypes;
+using UnityEngine;
 
 namespace DCL.AvatarRendering.AvatarShape
 {
@@ -18,12 +21,19 @@ namespace DCL.AvatarRendering.AvatarShape
     public partial class FinishAvatarMatricesCalculationSystem : BaseUnityLoopSystem
     {
         private readonly AvatarTransformMatrixJobWrapper jobWrapper;
+        private readonly Plane[] frustumPlanes = new Plane[6];
         private NativeArray<float4x4> remoteResult;
         private NativeArray<float4x4> mainPlayerResult;
+        private SingleInstanceEntity camera;
 
         internal FinishAvatarMatricesCalculationSystem(World world, AvatarTransformMatrixJobWrapper jobWrapper) : base(world)
         {
             this.jobWrapper = jobWrapper;
+        }
+
+        public override void Initialize()
+        {
+            camera = World.CacheCamera();
         }
 
         protected override void Update(float t)
@@ -32,17 +42,28 @@ namespace DCL.AvatarRendering.AvatarShape
             remoteResult = jobWrapper.RemoteAvatarsBonesResult;
             mainPlayerResult = jobWrapper.MainPlayerBonesResult;
 
+            GeometryUtility.CalculateFrustumPlanes(camera.GetCameraComponent(World).Camera, frustumPlanes);
+
             ExecuteQuery(World);
         }
 
         [Query]
-        [All(typeof(AvatarShapeComponent))]
         [None(typeof(DeleteEntityIntention))]
         private void Execute(
             ref AvatarTransformMatrixComponent avatarTransformMatrixComponent,
-            ref AvatarCustomSkinningComponent computeShaderSkinning
+            ref AvatarCustomSkinningComponent computeShaderSkinning,
+            in AvatarShapeComponent avatarShape,
+            in AvatarBase avatarBase
         )
         {
+            // Skinned verts persist between dispatches, so hidden and out-of-frustum avatars can skip theirs;
+            // the main player never skips (reflections and portraits sample it outside this frustum test)
+            if (computeShaderSkinning.ForceSkinNextFrame)
+                computeShaderSkinning.ForceSkinNextFrame = false;
+            else if (!avatarTransformMatrixComponent.IsMainPlayer
+                     && (!avatarShape.IsVisible || !GeometryUtility.TestPlanesAABB(frustumPlanes, avatarBase.AvatarSkinnedMeshRenderer.bounds)))
+                return;
+
             NativeArray<float4x4> bonesResult = avatarTransformMatrixComponent.IsMainPlayer
                 ? mainPlayerResult
                 : remoteResult;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
@@ -4,8 +4,6 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.AvatarRendering.AvatarShape.ComputeShader;
-using DCL.AvatarRendering.AvatarShape.UnityInterface;
-using DCL.CharacterCamera;
 using DCL.Diagnostics;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
@@ -13,7 +11,6 @@ using Unity.Collections;
 using Unity.Mathematics;
 using System;
 using RichTypes;
-using UnityEngine;
 
 namespace DCL.AvatarRendering.AvatarShape
 {
@@ -21,19 +18,12 @@ namespace DCL.AvatarRendering.AvatarShape
     public partial class FinishAvatarMatricesCalculationSystem : BaseUnityLoopSystem
     {
         private readonly AvatarTransformMatrixJobWrapper jobWrapper;
-        private readonly Plane[] frustumPlanes = new Plane[6];
         private NativeArray<float4x4> remoteResult;
         private NativeArray<float4x4> mainPlayerResult;
-        private SingleInstanceEntity camera;
 
         internal FinishAvatarMatricesCalculationSystem(World world, AvatarTransformMatrixJobWrapper jobWrapper) : base(world)
         {
             this.jobWrapper = jobWrapper;
-        }
-
-        public override void Initialize()
-        {
-            camera = World.CacheCamera();
         }
 
         protected override void Update(float t)
@@ -41,8 +31,6 @@ namespace DCL.AvatarRendering.AvatarShape
             jobWrapper.CompleteBoneMatrixCalculations();
             remoteResult = jobWrapper.RemoteAvatarsBonesResult;
             mainPlayerResult = jobWrapper.MainPlayerBonesResult;
-
-            GeometryUtility.CalculateFrustumPlanes(camera.GetCameraComponent(World).Camera, frustumPlanes);
 
             ExecuteQuery(World);
         }
@@ -53,7 +41,7 @@ namespace DCL.AvatarRendering.AvatarShape
             ref AvatarTransformMatrixComponent avatarTransformMatrixComponent,
             ref AvatarCustomSkinningComponent computeShaderSkinning,
             in AvatarShapeComponent avatarShape,
-            in AvatarBase avatarBase
+            in AvatarCachedVisibilityComponent cachedVisibility
         )
         {
             // Skinned verts persist between dispatches, so hidden and out-of-frustum avatars can skip theirs.
@@ -61,7 +49,7 @@ namespace DCL.AvatarRendering.AvatarShape
             if (computeShaderSkinning.ForceSkinNextFrame)
                 computeShaderSkinning.ForceSkinNextFrame = false;
             else if (!avatarTransformMatrixComponent.IsMainPlayer
-                     && (!avatarShape.IsVisible || !GeometryUtility.TestPlanesAABB(frustumPlanes, avatarBase.AvatarSkinnedMeshRenderer.bounds)))
+                     && (!avatarShape.IsVisible || !cachedVisibility.IsInCameraFrustum))
                 return;
 
             NativeArray<float4x4> bonesResult = avatarTransformMatrixComponent.IsMainPlayer

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
@@ -56,8 +56,8 @@ namespace DCL.AvatarRendering.AvatarShape
             in AvatarBase avatarBase
         )
         {
-            // Skinned verts persist between dispatches, so hidden and out-of-frustum avatars can skip theirs;
-            // the main player never skips (reflections and portraits sample it outside this frustum test)
+            // Skinned verts persist between dispatches, so hidden and out-of-frustum avatars can skip theirs.
+            // The main player is always re-skinned regardless of visibility or frustum state.
             if (computeShaderSkinning.ForceSkinNextFrame)
                 computeShaderSkinning.ForceSkinNextFrame = false;
             else if (!avatarTransformMatrixComponent.IsMainPlayer

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
@@ -46,11 +46,12 @@ namespace DCL.AvatarRendering.AvatarShape
         {
             // Skinned verts persist between dispatches, so hidden and out-of-frustum avatars can skip theirs.
             // The main player is always re-skinned regardless of visibility or frustum state.
-            if (computeShaderSkinning.ForceSkinNextFrame)
-                computeShaderSkinning.ForceSkinNextFrame = false;
-            else if (!avatarTransformMatrixComponent.IsMainPlayer
-                     && (!avatarShape.IsVisible || !cachedVisibility.IsInCameraFrustum))
+            if (!computeShaderSkinning.ForceSkinNextFrame
+                && !avatarTransformMatrixComponent.IsMainPlayer
+                && (!avatarShape.IsVisible || !cachedVisibility.IsInCameraFrustum))
                 return;
+
+            computeShaderSkinning.ForceSkinNextFrame = false;
 
             NativeArray<float4x4> bonesResult = avatarTransformMatrixComponent.IsMainPlayer
                 ? mainPlayerResult

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
@@ -4,6 +4,7 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.AvatarRendering.AvatarShape.ComputeShader;
+using DCL.AvatarRendering.AvatarShape.UnityInterface;
 using DCL.Diagnostics;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
@@ -41,14 +42,22 @@ namespace DCL.AvatarRendering.AvatarShape
             ref AvatarTransformMatrixComponent avatarTransformMatrixComponent,
             ref AvatarCustomSkinningComponent computeShaderSkinning,
             in AvatarShapeComponent avatarShape,
-            in AvatarCachedVisibilityComponent cachedVisibility
+            in AvatarCachedVisibilityComponent cachedVisibility,
+            in AvatarBase avatarBase
         )
         {
-            // Skinned verts persist between dispatches, so hidden and out-of-frustum avatars can skip theirs.
-            // The main player is always re-skinned regardless of visibility or frustum state.
-            if (!computeShaderSkinning.ForceSkinNextFrame
-                && !avatarTransformMatrixComponent.IsMainPlayer
-                && (!avatarShape.IsVisible || !cachedVisibility.IsInCameraFrustum))
+            bool culled = !avatarTransformMatrixComponent.IsMainPlayer
+                          && (!avatarShape.IsVisible || !cachedVisibility.IsInCameraFrustum);
+
+            // Unity's own animator culling only consults SkinnedMeshRenderers and the custom skinning
+            // pipeline deletes them all, so visibility must gate the Animator manually
+            if (avatarBase.AvatarAnimator.enabled == culled)
+                avatarBase.AvatarAnimator.enabled = !culled;
+
+            if (!computeShaderSkinning.ForceSkinNextFrame && culled)
+                return;
+
+            computeShaderSkinning.ForceSkinNextFrame = false;
                 return;
 
             computeShaderSkinning.ForceSkinNextFrame = false;


### PR DESCRIPTION
Remote avatars' Animators run with CullUpdateTransforms, so Mecanim skips pose evaluation while they're outside every camera frustum. State machines still advance — emote transitions and finish detection are unaffected. The main player stays AlwaysAnimate.