### PR TITLE
refactor(perf): recalculate wearable mesh tangents only once per shared mesh

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
@@ -18,9 +18,6 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 {
     public class ComputeShaderSkinning : CustomSkinning
     {
-        // Shared asset-bundle meshes are never mutated after load and destroyed instance ids never recur, so no invalidation is needed
-        private static readonly HashSet<int> tangentsComputed = new ();
-
         public override AvatarCustomSkinningComponent Initialize(IList<CachedAttachment> gameObjects,
             UnityEngine.ComputeShader skinningShader, IAvatarMaterialPoolHandler avatarMaterialPool, AvatarShapeComponent avatarShapeComponent,
             in FacialFeaturesTextures facialFeatureTexture, int boneCount)
@@ -57,7 +54,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
                 MeshData meshData = meshesData[i];
                 int meshVertexCount = meshData.Mesh.sharedMesh.vertexCount;
                 ResetTransforms(meshData.Transform, meshData.RootTransform);
-                FillMeshArray(meshData.Mesh.sharedMesh, meshVertexCount, vertCounter, skinnedMeshCounter, computeSkinningBufferContainer, boneCount, meshData.SpringBoneOffset);
+                FillMeshArray(meshData, meshVertexCount, vertCounter, skinnedMeshCounter, computeSkinningBufferContainer, boneCount);
                 vertCounter += meshVertexCount;
                 skinnedMeshCounter++;
             }
@@ -85,13 +82,17 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
             return new AvatarCustomSkinningComponent.Buffers(mBones, kernel);
         }
 
-        private void FillMeshArray(Mesh mesh, int currentMeshVertexCount, int vertexCounter, int skinnedMeshCounter, ComputeSkinningBufferContainer computeSkinningBufferContainer, int boneCount, int springBoneOffset)
+        private void FillMeshArray(in MeshData meshData, int currentMeshVertexCount, int vertexCounter, int skinnedMeshCounter, ComputeSkinningBufferContainer computeSkinningBufferContainer, int boneCount)
         {
+            Mesh mesh = meshData.Mesh.sharedMesh;
+
             // HACK: We only need to do this if the avatar has _NORMALMAPS enabled on the material.
-            if (tangentsComputed.Add(mesh.GetInstanceID()))
+            // The meshes are shared between every instance of the asset and nothing mutates their vertices or
+            // normals after load, so the recalculation only has to run on the first instance that uses each one.
+            if (meshData.OriginalAsset.TryMarkTangentsRecalculated(mesh))
                 mesh.RecalculateTangents();
 
-            computeSkinningBufferContainer.CopyAllBuffers(mesh, currentMeshVertexCount, vertexCounter, skinnedMeshCounter, boneCount, springBoneOffset);
+            computeSkinningBufferContainer.CopyAllBuffers(mesh, currentMeshVertexCount, vertexCounter, skinnedMeshCounter, boneCount, meshData.SpringBoneOffset);
         }
 
         private (int vertCount, int totalBoneBufferCount) SetupCounters(IReadOnlyList<MeshData> meshesData, int boneCount)
@@ -176,7 +177,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
                             cachedWearable.Renderers.Add(tuple.Item1);
 
                             targetList.Add(new MeshData(tuple.Item2, tuple.Item1, tuple.Item1.transform, instance.transform,
-                                originalMaterial, springBoneOffset));
+                                originalMaterial, cachedWearable.OriginalAsset, springBoneOffset));
                         }
                         else
                         {
@@ -184,7 +185,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
                             // From Pooled Object
                             targetList.Add(new MeshData(meshRenderer.GetComponent<MeshFilter>(), meshRenderer, meshRenderer.transform, instance.transform,
-                                originalMaterial, springBoneOffset));
+                                originalMaterial, cachedWearable.OriginalAsset, springBoneOffset));
                         }
                     }
                 }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
@@ -18,6 +18,9 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 {
     public class ComputeShaderSkinning : CustomSkinning
     {
+        // Shared asset-bundle meshes are never mutated after load and destroyed instance ids never recur, so no invalidation is needed
+        private static readonly HashSet<int> tangentsComputed = new ();
+
         public override AvatarCustomSkinningComponent Initialize(IList<CachedAttachment> gameObjects,
             UnityEngine.ComputeShader skinningShader, IAvatarMaterialPoolHandler avatarMaterialPool, AvatarShapeComponent avatarShapeComponent,
             in FacialFeaturesTextures facialFeatureTexture, int boneCount)
@@ -85,7 +88,8 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
         private void FillMeshArray(Mesh mesh, int currentMeshVertexCount, int vertexCounter, int skinnedMeshCounter, ComputeSkinningBufferContainer computeSkinningBufferContainer, int boneCount, int springBoneOffset)
         {
             // HACK: We only need to do this if the avatar has _NORMALMAPS enabled on the material.
-            mesh.RecalculateTangents();
+            if (tangentsComputed.Add(mesh.GetInstanceID()))
+                mesh.RecalculateTangents();
 
             computeSkinningBufferContainer.CopyAllBuffers(mesh, currentMeshVertexCount, vertexCounter, skinnedMeshCounter, boneCount, springBoneOffset);
         }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/MeshData.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/MeshData.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using DCL.AvatarRendering.Loading.Assets;
+using UnityEngine;
 
 namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 {
@@ -11,18 +12,25 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
         public readonly Transform RootTransform;
 
         /// <summary>
+        ///     The attachment asset <see cref="Mesh" /> was instantiated from, which owns the mesh and therefore
+        ///     the record of whether its tangents have already been recalculated.
+        /// </summary>
+        public readonly AttachmentRegularAsset OriginalAsset;
+
+        /// <summary>
         ///     Number of spring bones from previous wearables. Added to BoneWeight indices >= BASE_BONE_COUNT
         ///     so each wearable's spring bones map to the correct slot in the global bone matrix buffer.
         /// </summary>
         public readonly int SpringBoneOffset;
 
-        public MeshData(MeshFilter mesh, Renderer renderer, Transform transform, Transform rootTransform, Material originalMaterial, int springBoneOffset = 0)
+        public MeshData(MeshFilter mesh, Renderer renderer, Transform transform, Transform rootTransform, Material originalMaterial, AttachmentRegularAsset originalAsset, int springBoneOffset = 0)
         {
             Mesh = mesh;
             Transform = transform;
             RootTransform = rootTransform;
             OriginalMaterial = originalMaterial;
             Renderer = renderer;
+            OriginalAsset = originalAsset;
             SpringBoneOffset = springBoneOffset;
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetBase.cs
@@ -32,6 +32,7 @@ namespace DCL.AvatarRendering.Loading.Assets
         public static readonly ListObjectPool<RendererInfo> RENDERER_INFO_POOL = new (listInstanceDefaultCapacity: 3, defaultCapacity: 500);
 
         private readonly List<RendererInfo> rendererInfos;
+        private readonly HashSet<EntityId> tangentsRecalculatedMeshes = new ();
         public readonly GameObject MainAsset;
 
         public IReadOnlyList<RendererInfo> RendererInfos => rendererInfos;
@@ -50,6 +51,7 @@ namespace DCL.AvatarRendering.Loading.Assets
         protected override void DisposeInternal()
         {
             RENDERER_INFO_POOL.Release(rendererInfos);
+            tangentsRecalculatedMeshes.Clear();
 
             if (ReferenceCount > 0)
                 ProfilingCounters.WearablesAssetsReferencedAmount.Value--;
@@ -59,6 +61,15 @@ namespace DCL.AvatarRendering.Loading.Assets
 
             ProfilingCounters.WearablesAssetsAmount.Value--;
         }
+
+        /// <summary>
+        ///     Marks the tangents of <paramref name="mesh" /> as recalculated, returning true only the first time
+        ///     the mesh is passed in. The marks are kept per asset because the meshes belong to the streamable data
+        ///     this asset references: they are dropped on disposal, before that data is destroyed and the entity ids
+        ///     of its meshes become free for Unity to hand out to newly loaded ones.
+        /// </summary>
+        public bool TryMarkTangentsRecalculated(Mesh mesh) =>
+            tangentsRecalculatedMeshes.Add(mesh.GetEntityId());
 
         public readonly struct RendererInfo
         {

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/WearableAssetShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/WearableAssetShould.cs
@@ -1,5 +1,6 @@
 ﻿using DCL.AvatarRendering.Loading.Assets;
 using DCL.AvatarRendering.Wearables.Helpers;
+using ECS.StreamableLoading;
 using NUnit.Framework;
 using System.Collections.Generic;
 using UnityEngine;
@@ -8,6 +9,17 @@ namespace DCL.AvatarRendering.Wearables.Tests
 {
     public class WearableAssetShould
     {
+        private readonly List<Object> createdObjects = new ();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (Object createdObject in createdObjects)
+                Object.DestroyImmediate(createdObject);
+
+            createdObjects.Clear();
+        }
+
         [TestCase(0)]
         [TestCase(5)]
         public void ProperlyCountReferenceWhenAddReferenceCalled(int refCount)
@@ -40,6 +52,43 @@ namespace DCL.AvatarRendering.Wearables.Tests
 
             // Assert
             Assert.That(wearableAsset.ReferenceCount, Is.EqualTo(remainedRefs));
+        }
+
+        [Test]
+        public void MarkTangentsOfTheSameMeshOnlyOnce()
+        {
+            // Arrange
+            var wearableAsset = new AttachmentRegularAsset(new GameObject(), new List<AttachmentRegularAsset.RendererInfo>(5), IStreamableRefCountData.Null.INSTANCE);
+            var mesh = new Mesh();
+            var anotherMesh = new Mesh();
+            createdObjects.Add(mesh);
+            createdObjects.Add(anotherMesh);
+
+            // Act
+            bool firstMark = wearableAsset.TryMarkTangentsRecalculated(mesh);
+            bool repeatedMark = wearableAsset.TryMarkTangentsRecalculated(mesh);
+            bool anotherMeshMark = wearableAsset.TryMarkTangentsRecalculated(anotherMesh);
+
+            // Assert
+            Assert.That(firstMark, Is.True);
+            Assert.That(repeatedMark, Is.False);
+            Assert.That(anotherMeshMark, Is.True);
+        }
+
+        [Test]
+        public void ForgetMarkedTangentsWhenDisposed()
+        {
+            // Arrange
+            var wearableAsset = new AttachmentRegularAsset(new GameObject(), new List<AttachmentRegularAsset.RendererInfo>(5), IStreamableRefCountData.Null.INSTANCE);
+            var mesh = new Mesh();
+            createdObjects.Add(mesh);
+            wearableAsset.TryMarkTangentsRecalculated(mesh);
+
+            // Act
+            wearableAsset.Dispose();
+
+            // Assert
+            Assert.That(wearableAsset.TryMarkTangentsRecalculated(mesh), Is.True);
         }
     }
 }


### PR DESCRIPTION
## What

`RecalculateTangents` ran on every avatar instantiation for meshes that are shared asset-bundle assets and are never mutated after load. It now runs once per mesh, memoized on the attachment asset that owns that mesh.

Complements #9914 and #9915 — the three combine on the same avatar pipeline.

## Technical

The memo lives on `AttachmentRegularAsset` (`TryMarkTangentsRecalculated`) rather than in a session-wide static set, because that object's lifetime is exactly the lifetime of the meshes it owns:

- while the asset is alive it holds the `IStreamableRefCountData` reference that keeps its `AssetBundleData` — and therefore the prefab and its meshes — alive, so no entity id in its memo can be recycled onto a different object;
- the memo is dropped in `DisposeInternal`, which is the same dereference that lets the bundle be destroyed.

A static set is not safe here, because wearable meshes *do* get destroyed mid-session: `AttachmentsAssetsCache.Unload` → `CachedAttachment.Dispose` → asset dereference → `AssetBundleData.DestroyObject` (which drops the prefab holding the meshes; the bundle itself was already `UnloadAsync(false)`'d at construction) → the meshes become unreferenced and are collected by `Resources.UnloadUnusedAssets()`, which runs on teleport (`UnloadCacheImmediateTeleportOperation`), under memory pressure (`UnloadUnusedAssetUnloadStrategy`) and on LSD `/reload`. Unity 6 hands the freed ids out again, so a later-loaded mesh can inherit a memoized id and silently skip the recalculation — wrong tangents, i.e. broken normal mapping, for the rest of the session. The static set also grew unbounded and survived world disposal and EditMode test teardown.

The marks are per mesh, not a single per-asset flag: `HideBodyShape` deactivates individual body-part renderer GameObjects per avatar and `CreateMeshData` skips inactive renderers, so two avatars sharing one body-shape asset present different mesh subsets to the skinning setup.

The key type is `EntityId` — `Object.GetInstanceID()` is deprecated in Unity 6000.4 (CS0618) in favour of `GetEntityId()`, and `EntityId`'s implicit `int` cast is obsolete too.

## QA

Expected result: **no visual change**. Wearables keep shading correctly; avatar instantiation just does less work. The risk being tested is the opposite — normal-mapped wearables losing their tangents after caches are evicted.

### 1. Baseline
1. Enter Genesis Plaza with several other avatars around.
2. Confirm wearables that use normal maps (metallic/leather/embossed jackets, hats, hair) light and shade normally. Keep one or two in view as reference.

### 2. Memory pressure → cache eviction → reload (the regression this guards against)
1. Open the debug panel and expand the **MEMORY** widget.
2. Press **Memory FULL** and leave it there for ~10 seconds. `ReleaseMemorySystem` then drains the caches through `CacheCleaner` every frame — cached wearable instances, then wearable assets, then asset bundles — and after ~250 consecutive frames under pressure it escalates to `Resources.UnloadUnusedAssets()` on its own. (No need to touch *Toggle Abundance*; simulating FULL already keeps the handler in its unloading state.)
3. Press **Resources.UnloadUnusedAssets** to make that last step immediate — this is what actually destroys the freed meshes and releases their entity ids for reuse.
4. Press **Memory NORMAL**.
5. Force fresh wearable loads so newly loaded meshes take the recycled ids: teleport away and back (e.g. `/goto 50,50` then `/goto 0,0`), or walk into a crowded area so new avatars stream in.
6. Repeat steps 2–5 a few times — id reuse is opportunistic, so several cycles give it more chances.
7. **Pass:** every avatar, yours and remote, still renders with correct normal-mapped shading. **Fail** would look like flat, washed-out or blotchy surfaces on wearables that looked correct in step 1, persisting until the client is restarted.

### 3. Own avatar round-trip
1. Open the Backpack and change outfit several times, closing the Backpack between changes.
2. Between changes, run **Memory FULL** → **Resources.UnloadUnusedAssets** → **Memory NORMAL**.
3. **Pass:** each equipped wearable renders correctly both on the Backpack preview avatar and in-world.

### 4. Long session (secondary)
1. Roam busy parcels for a while without touching the debug panel, letting real memory pressure drive the cleaner.
2. **Pass:** avatars keep rendering correctly; no progressive degradation of wearable shading over the session.

Note: teleporting on its own is *not* enough to reproduce. `UnloadCacheImmediateTeleportOperation` calls `Resources.UnloadUnusedAssets()` but its `cacheCleaner.UnloadCache(false)` call is commented out, so a teleport only finishes off meshes that cache eviction already released — scenario 2 is the one that exercises the path end to end.

### Automated
`WearableAssetShould.MarkTangentsOfTheSameMeshOnlyOnce` and `WearableAssetShould.ForgetMarkedTangentsWhenDisposed` (EditMode) cover the memo and its invalidation on disposal.
