### PR TITLE
fix: sanitize the currentTime input before applying, avoid FMOD errors

### DIFF
--- a/Explorer/Assets/DCL/Audio/WorldAudioPlaybackController.cs
+++ b/Explorer/Assets/DCL/Audio/WorldAudioPlaybackController.cs
@@ -15,18 +15,20 @@ namespace DCL.Audio
     public class WorldAudioPlaybackController : MonoBehaviour, IDisposable
     {
         [SerializeField]
-        private WorldAudioSettings audioSettings;
+        private WorldAudioSettings audioSettings = null!;
         [SerializeField]
-        private AudioSource audioSourcePrefab;
+        private AudioSource audioSourcePrefab = null!;
 
         private readonly Dictionary<WorldAudioClipType, Dictionary<int, List<WorldPlaybackAudioData>>> audioDatasPerIndexDictionary = new ();
-        private GameObjectPool<AudioSource> audioSourcePool;
-        private CancellationTokenSource mainCancellationTokenSource;
+
+        // Dedicated to be initialized at the Initialize method
+        private GameObjectPool<AudioSource> audioSourcePool = null!;
+        private CancellationTokenSource mainCancellationTokenSource = null!;
 
         public void Dispose()
         {
             audioDatasPerIndexDictionary.Clear();
-            audioSourcePool?.Dispose();
+            audioSourcePool.Dispose();
             mainCancellationTokenSource.SafeCancelAndDispose();
         }
 

--- a/Explorer/Assets/DCL/Audio/WorldAudioPlaybackController.cs
+++ b/Explorer/Assets/DCL/Audio/WorldAudioPlaybackController.cs
@@ -58,7 +58,11 @@ namespace DCL.Audio
             int clipIndex = AudioPlaybackUtilities.GetClipIndex(audioClipConfig);
             AudioClip clip = audioClipConfig.AudioClips[clipIndex];
             audioData.AudioSource.clip = clip;
-            audioData.AudioSource.time = Random.Range(0, clip.length);
+
+            // The int overload is max-exclusive, so the result is always a valid sample index —
+            // the float Random.Range(0, clip.length) is max-inclusive and seeking to the exact
+            // clip end is an invalid FMOD position.
+            audioData.AudioSource.timeSamples = Random.Range(0, clip.samples);
             audioData.AudioSource.volume = audioClipConfig.RelativeVolume;
             audioData.AudioSource.Play();
 

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Systems/UpdateAudioSourceSystem.cs
@@ -23,6 +23,11 @@ namespace DCL.SDKComponents.AudioSources
     [LogCategory(ReportCategory.SDK_AUDIO_SOURCES)]
     public partial class UpdateAudioSourceSystem : BaseUnityLoopSystem
     {
+        /// <summary>
+        ///     Seeking to the very end of a clip is an invalid FMOD position; keep the cursor this far before it.
+        /// </summary>
+        private const float CLIP_END_SEEK_MARGIN = 0.01f;
+
         private readonly IPerformanceBudget frameTimeBudgetProvider;
         private readonly IPerformanceBudget memoryBudgetProvider;
         private readonly IComponentPool<AudioSource> audioSourcesPool;
@@ -148,8 +153,16 @@ namespace DCL.SDKComponents.AudioSources
                     if (sdkComponent is {HasPlaying: true, Playing: true })
                     {
                         // LWW PUT with playing:true is an explicit retrigger — seek first so the cursor is correct.
+                        // CurrentTime arrives from the scene unvalidated: clamp it into the clip's seekable
+                        // range, otherwise FMOD rejects the seek ("An invalid seek position was passed").
                         if (sdkComponent.HasCurrentTime)
-                            audioSource.time = sdkComponent.CurrentTime;
+                        {
+                            float currentTime = sdkComponent.CurrentTime;
+
+                            audioSource.time = float.IsNaN(currentTime)
+                                ? 0f
+                                : Mathf.Clamp(currentTime, 0f, Mathf.Max(0f, audioSource.clip.length - CLIP_END_SEEK_MARGIN));
+                        }
 
                         audioSource.Play();
                     }

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Tests/UpdateAudioSourceSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Tests/UpdateAudioSourceSystemShould.cs
@@ -6,7 +6,6 @@ using DCL.PluginSystem.World;
 using DCL.Tests.Editor;
 using ECS.Prioritization.Components;
 using ECS.StreamableLoading.AudioClips;
-using ECS.StreamableLoading.Cache;
 using ECS.StreamableLoading.Common;
 using ECS.StreamableLoading.Common.Components;
 using ECS.TestSuite;
@@ -57,7 +56,7 @@ namespace DCL.SDKComponents.AudioSources.Tests
             ISceneStateProvider sceneStateProvider = Substitute.For<ISceneStateProvider>();
             sceneStateProvider.IsCurrent.Returns(true);
 
-            return new UpdateAudioSourceSystem(world, ECSTestUtils.SceneDataSub(), poolsRegistry, budgetProvider, budgetProvider, null, sceneStateProvider, new AudioSourcesPlugin.AudioSourcesPluginSettings());
+            return new UpdateAudioSourceSystem(world, ECSTestUtils.SceneDataSub(), poolsRegistry, budgetProvider, budgetProvider, null!, sceneStateProvider, new AudioSourcesPlugin.AudioSourcesPluginSettings());
         }
 
         [Test]
@@ -85,7 +84,7 @@ namespace DCL.SDKComponents.AudioSources.Tests
             AudioSourceComponent afterUpdate = world.Get<AudioSourceComponent>(entity);
             Assert.That(afterUpdate.ClipPromise, Is.Not.Null);
             Assert.That(afterUpdate.AudioSource, Is.Not.Null);
-            Assert.That(afterUpdate.AudioSource.clip, Is.EqualTo(TestAudioClip));
+            Assert.That(afterUpdate.AudioSource!.clip, Is.EqualTo(TestAudioClip));
         }
 
         [Test]

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Tests/UpdateAudioSourceSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Tests/UpdateAudioSourceSystemShould.cs
@@ -125,6 +125,7 @@ namespace DCL.SDKComponents.AudioSources.Tests
         [TestCase(9999f)]
         [TestCase(-5f)]
         [TestCase(float.NaN)]
+        [TestCase(float.PositiveInfinity)]
         public void ClampOutOfRangeSeekOnRetrigger(float currentTime)
         {
             // Arrange: resolve the clip promise and run one update to instantiate the Unity AudioSource.

--- a/Explorer/Assets/DCL/SDKComponents/AudioSources/Tests/UpdateAudioSourceSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AudioSources/Tests/UpdateAudioSourceSystemShould.cs
@@ -121,5 +121,33 @@ namespace DCL.SDKComponents.AudioSources.Tests
             Assert.That(afterUpdate.AudioSource!.time, Is.EqualTo(0f).Within(0.01f));
             Assert.That(world.Get<PBAudioSource>(entity).IsDirty, Is.False);
         }
+
+        [TestCase(9999f)]
+        [TestCase(-5f)]
+        [TestCase(float.NaN)]
+        public void ClampOutOfRangeSeekOnRetrigger(float currentTime)
+        {
+            // Arrange: resolve the clip promise and run one update to instantiate the Unity AudioSource.
+            world.Add(component.ClipPromise.Entity, new StreamableLoadingResult<AudioClipData>(new AudioClipData(TestAudioClip)));
+            system.Update(0);
+
+            ref AudioSourceComponent loaded = ref world.Get<AudioSourceComponent>(entity);
+            Assert.That(loaded.AudioSource, Is.Not.Null);
+
+            // Simulate a fresh LWW PUT from the scene carrying a CurrentTime outside the clip's seekable range.
+            ref PBAudioSource sdk = ref world.Get<PBAudioSource>(entity);
+            sdk.AudioClipUrl = loaded.AudioClipUrl;
+            sdk.Playing = true;
+            sdk.CurrentTime = currentTime;
+            sdk.IsDirty = true;
+
+            // Act
+            system.Update(0);
+
+            // Assert: the cursor stays inside the clip so FMOD never sees an invalid seek position.
+            AudioSourceComponent afterUpdate = world.Get<AudioSourceComponent>(entity);
+            Assert.That(afterUpdate.AudioSource!.time, Is.GreaterThanOrEqualTo(0f));
+            Assert.That(afterUpdate.AudioSource.time, Is.LessThan(TestAudioClip.length));
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes the recurring FMOD engine error `SoundChannel.cpp(345): An invalid seek position was passed to this function`, tracked by Sentry as [UNITY-EXPLORER-PR6](https://decentraland.sentry.io/issues/7682033981/) and [UNITY-EXPLORER-PDY](https://decentraland.sentry.io/issues/7582044126/).

Closes #9825
Closes #9118

The error is an engine-level FMOD log (no managed stack), so Sentry groups every bad-seek call site into one issue. There were exactly two call sites in the codebase (excluding 3-d party code) that could produce an invalid seek position, and both are fixed here:

1. **`UpdateAudioSourceSystem`** applied the scene-supplied `PBAudioSource.CurrentTime` to `AudioSource.time` unvalidated. A scene can send a negative value, `NaN`, or a value beyond the clip length (e.g. retriggering `playSound()` with a cursor saved from a longer clip), and FMOD rejects the seek on every visitor's client. The value is now clamped into `[0, clip.length - 0.01s]`, with `NaN` falling back to `0` (seeking to the exact clip end is itself an invalid FMOD position, hence the margin).

2. **`WorldAudioPlaybackController`** randomized the ambient-audio start position with the **max-inclusive** float `Random.Range(0, clip.length)`, which can land exactly on the clip end — an invalid position. It now seeks via `timeSamples = Random.Range(0, clip.samples)`: the int overload is max-exclusive, so the result is always a valid sample index. The `remainingTime` computation below still reads `AudioSource.time`, which reflects the sample-based seek, so it needed no change.

Since both call sites emit the identical engine string, fixing only one would not have resolved the Sentry group — they ship together.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
No `SoundChannel.cpp ... invalid seek position` errors in the logs while roaming Genesis City (world ambient audio) or visiting scenes that use `AudioSource` with `currentTime`.

**Steps (fresh account)**:
```bash
metaforge account create --clear
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
Same as above.

**Automation** (if applicable):
```bash
metaforge explorer test XXXX
```

### Prerequisites
- [ ] None — any standard build

### Test Steps
1. Start the client and tail logs: `metaforge explorer logs tail --filter "invalid seek"`
2. Roam outdoor Genesis City parcels for a few minutes so terrain ambient audio (birds/wind) sets up repeatedly — this exercises the randomized start position.
3. Visit a scene that plays sound via the SDK `AudioSource` component with `currentTime` set (any scene calling `playSound()` with an offset).
4. Verify no `invalid seek position` errors appear in the log and audio plays normally from a sensible position.

### Additional Testing Notes
- The scene-input clamp handles three edge cases covered by new unit tests: `currentTime` beyond clip length, negative, and `NaN` — all must land the cursor inside the clip.
- `DCL.SDKComponents.AudioSources.Tests` EditMode suite passes locally (16/16), including 3 new `ClampOutOfRangeSeekOnRetrigger` cases.
- The error is fleet-statistical (it fires rarely per client), so local verification is mostly "no regressions"; Sentry event volume after release is the real signal.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.