### PR TITLE
refactor(perf): avatar skinning + cull + mesh tangents

### DIFF
--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
@@ -4,14 +4,6 @@
     {
         public bool IsVisible;
 
-        // Stamped by AvatarShapeVisibilitySystem's frustum pass so downstream systems
-        // (skinning skip, animator gate) share one visibility source instead of re-testing
-        public bool IsInCameraFrustum { get; private set; }
-
-        public void SetInCameraFrustum(bool isInFrustum)
-        {
-            IsInCameraFrustum = isInFrustum;
-        }
         private DITHER_STATE currentDitherState;
 
         public bool ShouldUpdateDitherState(float newDistance, float startFadeDithering, float endFadeDithering)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
@@ -3,6 +3,15 @@
     public struct AvatarCachedVisibilityComponent
     {
         public bool IsVisible;
+
+        // Stamped by AvatarShapeVisibilitySystem's frustum pass so downstream systems
+        // (skinning skip, animator gate) share one visibility source instead of re-testing
+        public bool IsInCameraFrustum { get; private set; }
+
+        public void SetInCameraFrustum(bool isInFrustum)
+        {
+            IsInCameraFrustum = isInFrustum;
+        }
         private DITHER_STATE currentDitherState;
 
         public bool ShouldUpdateDitherState(float newDistance, float startFadeDithering, float endFadeDithering)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCachedVisibilityComponent.cs
@@ -4,6 +4,12 @@
     {
         public bool IsVisible;
 
+        /// <summary>
+        ///     The footstep-FX flag AvatarShapeVisibilitySystem last applied. Kept here rather than read back from
+        ///     Animator.enabled, which FinishAvatarMatricesCalculationSystem also drives with its culling verdict.
+        /// </summary>
+        public bool PlaysFootstepFX;
+
         private DITHER_STATE currentDitherState;
 
         public bool ShouldUpdateDitherState(float newDistance, float startFadeDithering, float endFadeDithering)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCullingRule.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCullingRule.cs
@@ -1,0 +1,17 @@
+namespace DCL.AvatarRendering.AvatarShape.Components
+{
+    /// <summary>
+    ///     The single definition of when an avatar may skip its skinning dispatch, shared between
+    ///     FinishAvatarMatricesCalculationSystem, which acts on it, and the editor gizmo, which reports it. It lives
+    ///     outside the system so the debug view cannot drift from the decision it shows.
+    /// </summary>
+    public static class AvatarCullingRule
+    {
+        /// <param name="exemptFromCulling">
+        ///     True for the main player, whose pose is sampled by reflections and portraits outside the player
+        ///     frustum, and for preview avatars, which their own camera draws into a render texture.
+        /// </param>
+        public static bool IsCulled(bool exemptFromCulling, bool isVisible, bool isInFrustum) =>
+            !exemptFromCulling && (!isVisible || !isInFrustum);
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCullingRule.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCullingRule.cs
@@ -7,6 +7,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
     /// </summary>
     public static class AvatarCullingRule
     {
+        public static bool IsExempt(bool isMainPlayer, bool isPreview) =>
+            isMainPlayer || isPreview;
+
         /// <param name="exemptFromCulling">
         ///     True for the main player, whose pose is sampled by reflections and portraits outside the player
         ///     frustum, and for preview avatars, which their own camera draws into a render texture.

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCullingRule.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCullingRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7e580dd164f45fb992a63dbe048a95b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -90,7 +90,8 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         private bool disposed;
 
         /// <summary>
-        ///
+        ///     Union of the bind-pose bounds of every mesh the avatar was assembled from, wearables included,
+        ///     expressed in the space of the avatar's own transform. Recomputed on every re-instantiation.
         /// </summary>
         public Bounds LocalBounds { get; private set; }
 
@@ -106,6 +107,30 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             ForceSkinNextFrame = false;
 
             disposed = false;
+        }
+
+#if UNITY_INCLUDE_TESTS
+        public static AvatarCustomSkinningComponent NewWithLocalBounds(Bounds localBounds) =>
+            new () { LocalBounds = localBounds };
+#endif
+
+        /// <summary>
+        ///     Places <see cref="LocalBounds" /> in the world through the avatar's transform, re-axis-aligning the
+        ///     rotated box. The renderers cannot answer this: compute-shader skinning replaced their local bounds
+        ///     with a fixed cube, and the skinned vertices only ever exist in the GPU buffer.
+        ///     This is the managed reference form of the transform; BoneMatrixCalculationJob carries the Burst one.
+        /// </summary>
+        public readonly Bounds ToWorldBounds(Transform avatarTransform)
+        {
+            Matrix4x4 matrix = avatarTransform.localToWorldMatrix;
+            Vector3 extents = LocalBounds.extents;
+
+            var worldExtents = new Vector3(
+                (Mathf.Abs(matrix.m00) * extents.x) + (Mathf.Abs(matrix.m01) * extents.y) + (Mathf.Abs(matrix.m02) * extents.z),
+                (Mathf.Abs(matrix.m10) * extents.x) + (Mathf.Abs(matrix.m11) * extents.y) + (Mathf.Abs(matrix.m12) * extents.z),
+                (Mathf.Abs(matrix.m20) * extents.x) + (Mathf.Abs(matrix.m21) * extents.y) + (Mathf.Abs(matrix.m22) * extents.z));
+
+            return new Bounds(matrix.MultiplyPoint3x4(LocalBounds.center), worldExtents * 2f);
         }
 
         /// <summary>

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -20,8 +20,8 @@ namespace DCL.AvatarRendering.AvatarShape.Components
     {
         public struct Buffers
         {
-            // since it's impossible to guarantee initialization of structure in C# the case requires to provide an additional check
-            private ComputeSkinningBufferContainer computeSkinningBufferContainer;
+            // A struct cannot guarantee initialization, so the container stays null until AssignBuffer runs
+            private ComputeSkinningBufferContainer? computeSkinningBufferContainer;
             private readonly ComputeBuffer bones; 
             internal readonly int kernel;
 
@@ -45,7 +45,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
             public void DisposeBuffers()
             {
-                computeSkinningBufferContainer.Dispose();
+                computeSkinningBufferContainer?.Dispose();
                 bones.Dispose();
             }
         }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarCustomSkinningComponent.cs
@@ -75,6 +75,11 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         /// </summary>
         public FixedComputeBufferHandler.Slice VertsOutRegion;
 
+        /// <summary>
+        ///     One-shot flag: forces the next skin dispatch to run regardless of visibility or frustum state. Self-clears after consumption.
+        /// </summary>
+        public bool ForceSkinNextFrame;
+
         public readonly int VertCount;
         public readonly int BoneCount;
 
@@ -98,6 +103,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             this.computeShaderInstance = computeShaderInstance;
             this.LocalBounds = localBounds;
             VertsOutRegion = default(FixedComputeBufferHandler.Slice);
+            ForceSkinNextFrame = false;
 
             disposed = false;
         }
@@ -135,6 +141,7 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         public void SetVertOutRegion(FixedComputeBufferHandler.Slice region)
         {
             VertsOutRegion = region;
+            ForceSkinNextFrame = true;
 
             computeShaderInstance.SetInt(ComputeShaderConstants.LAST_AVATAR_VERT_COUNT_ID, region.StartIndex);
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarTransformMatrixJobWrapper.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarTransformMatrixJobWrapper.cs
@@ -145,7 +145,12 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
             if (dummyTransform != null)
             {
-                UnityEngine.Object.Destroy(dummyTransform.gameObject);
+                // Destroy is illegal in edit mode, where the system's edit-mode tests dispose this wrapper.
+                if (Application.isPlaying)
+                    UnityEngine.Object.Destroy(dummyTransform.gameObject);
+                else
+                    UnityEngine.Object.DestroyImmediate(dummyTransform.gameObject);
+
                 stopwatch.LogStep("dummyTransform.Destroy");
             }
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarTransformMatrixJobWrapper.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/AvatarTransformMatrixJobWrapper.cs
@@ -30,6 +30,12 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
         public NativeArray<float4x4> RemoteAvatarsBonesResult  => remoteAvatars.Job.BonesMatricesResult;
 
+        /// <summary>
+        ///     World-space bounds per remote avatar, computed by the calculation job. Indexed by
+        ///     IndexInGlobalJobArray and only valid after CompleteBoneMatrixCalculations.
+        /// </summary>
+        public NativeArray<float3x2> RemoteAvatarsWorldBounds => remoteAvatars.WorldBounds;
+
 #if UNITY_INCLUDE_TESTS
         public int MatrixFromAllAvatarsLength => remoteAvatars.MatrixFromAllAvatarsLength;
         public int UpdateAvatarLength => remoteAvatars.UpdateAvatarLength;
@@ -102,6 +108,20 @@ namespace DCL.AvatarRendering.AvatarShape.Components
                 mainPlayerAvatar.SetBoneCount(boneCount);
             else
                 remoteAvatars.SetBoneCount(validIndex, boneCount);
+        }
+
+        /// <summary>
+        ///     Pushes the avatar-space bounds so the calculation job can place them in the world. The main player
+        ///     is never culled, so only remote slots carry bounds.
+        /// </summary>
+        public void SetLocalBounds(ref AvatarTransformMatrixComponent transformMatrixComponent, Bounds localBounds)
+        {
+            if (transformMatrixComponent.IsMainPlayer) return;
+
+            if (transformMatrixComponent.IndexInGlobalJobArray.TryGetValue(out int validIndex) == false)
+                return;
+
+            remoteAvatars.SetLocalBounds(validIndex, new float3x2(localBounds.center, localBounds.extents));
         }
 
         public void Dispose()

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/MainPlayerPipeline.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/MainPlayerPipeline.cs
@@ -24,6 +24,12 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         private NativeArray<float4x4> avatarMatrix;
         private NativeArray<bool> updateFlag;
 
+        // The main player is never culled, so these carry no meaning here. They exist because the shared job
+        // structs declare the containers, and Unity requires every one of them to be valid at schedule time.
+        private NativeArray<float4x4> avatarLocalToWorld;
+        private NativeArray<float3x2> localBounds;
+        private NativeArray<float3x2> worldBounds;
+
         private NativeArray<int> perAvatarBoneCount;
 
         public BoneMatrixCalculationJob Job;
@@ -36,6 +42,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             bonesCombined = new NativeArray<float4x4>(bonesArrayLength, Allocator.Persistent);
             avatarMatrix = new NativeArray<float4x4>(1, Allocator.Persistent);
             updateFlag = new NativeArray<bool>(1, Allocator.Persistent);
+            avatarLocalToWorld = new NativeArray<float4x4>(1, Allocator.Persistent);
+            localBounds = new NativeArray<float3x2>(1, Allocator.Persistent);
+            worldBounds = new NativeArray<float3x2>(1, Allocator.Persistent);
             perAvatarBoneCount = new NativeArray<int>(1, Allocator.Persistent) { [0] = bonesArrayLength };
             Job = new BoneMatrixCalculationJob(bonesArrayLength, bonesArrayLength, bonesCombined);
         }
@@ -81,7 +90,11 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             var boneGather = new BoneGatherJob { BonesCombined = bonesCombined };
             var boneGatherHandle = boneGather.Schedule(bonesTA);
 
-            var rootGather = new AvatarRootGatherJob { MatrixFromAllAvatars = avatarMatrix };
+            var rootGather = new AvatarRootGatherJob
+            {
+                MatrixFromAllAvatars = avatarMatrix,
+                LocalToWorldFromAllAvatars = avatarLocalToWorld,
+            };
             var rootGatherHandle = rootGather.Schedule(rootTA);
 
             var gatherHandle = JobHandle.CombineDependencies(boneGatherHandle, rootGatherHandle);
@@ -89,6 +102,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             Job.AvatarTransform = avatarMatrix;
             Job.UpdateAvatar = updateFlag;
             Job.PerAvatarBoneCount = perAvatarBoneCount;
+            Job.AvatarLocalToWorld = avatarLocalToWorld;
+            Job.LocalBounds = localBounds;
+            Job.WorldBounds = worldBounds;
             var calcHandle = Job.Schedule(1, 1, gatherHandle);
             calcHandle.Complete(); // Fast — 1 avatar, 62 bones. Unlocks main player transforms.
         }
@@ -99,6 +115,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             avatarMatrix.Dispose();
             updateFlag.Dispose();
             perAvatarBoneCount.Dispose();
+            avatarLocalToWorld.Dispose();
+            localBounds.Dispose();
+            worldBounds.Dispose();
             Job.Dispose();
 
             if (bonesTA.isCreated) bonesTA.Dispose();

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/RemoteAvatarPipeline.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Components/RemoteAvatarPipeline.cs
@@ -27,6 +27,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
         private readonly Stack<GlobalJobArrayIndex> releasedIndexes;
 
         private QuickArray<float4x4> matrixFromAllAvatars;
+        private QuickArray<float4x4> localToWorldFromAllAvatars;
+        private QuickArray<float3x2> localBounds;
+        private QuickArray<float3x2> worldBounds;
         private QuickArray<bool> updateAvatar;
         private QuickArray<float4x4> bonesCombined;
 
@@ -46,6 +49,11 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
         public BoneMatrixCalculationJob Job;
 
+        /// <summary>
+        ///     Avatar bounds in world space, written by the calculation job. Only valid after Complete.
+        /// </summary>
+        public NativeArray<float3x2> WorldBounds => worldBounds.InnerNativeArray();
+
 #if UNITY_INCLUDE_TESTS
         public int MatrixFromAllAvatarsLength => matrixFromAllAvatars.Length;
         public int UpdateAvatarLength => updateAvatar.Length;
@@ -61,6 +69,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             Job = new BoneMatrixCalculationJob(bonesArrayLength, bonesPerAvatarLength, bonesCombined.InnerNativeArray());
 
             matrixFromAllAvatars = new QuickArray<float4x4>(initialCapacity);
+            localToWorldFromAllAvatars = new QuickArray<float4x4>(initialCapacity);
+            localBounds = new QuickArray<float3x2>(initialCapacity);
+            worldBounds = new QuickArray<float3x2>(initialCapacity);
             updateAvatar = new QuickArray<bool>(initialCapacity);
 
             perAvatarBoneCount = new QuickArray<int>(initialCapacity);
@@ -170,6 +181,18 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             perAvatarBoneCount[validIndex] = boneCount;
         }
 
+        /// <summary>
+        ///     Refreshes the avatar-space bounds for a live slot. Pushed every frame alongside the bone count, so
+        ///     the value is current whether the avatar kept its slot or was re-registered into a recycled one.
+        /// </summary>
+        public void SetLocalBounds(int validIndex, float3x2 bounds)
+        {
+            if (validIndex < 0 || validIndex >= localBounds.Length)
+                return;
+
+            localBounds[validIndex] = bounds;
+        }
+
         public void Schedule(int batchCount)
         {
             if (avatarIndex == 0)
@@ -184,7 +207,11 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             var boneGatherJob = new BoneGatherJob { BonesCombined = bonesCombined.InnerNativeArray() };
             var boneGatherHandle = boneGatherJob.Schedule(bonesTransformAccessArray);
 
-            var rootGatherJob = new AvatarRootGatherJob { MatrixFromAllAvatars = matrixFromAllAvatars.InnerNativeArray() };
+            var rootGatherJob = new AvatarRootGatherJob
+            {
+                MatrixFromAllAvatars = matrixFromAllAvatars.InnerNativeArray(),
+                LocalToWorldFromAllAvatars = localToWorldFromAllAvatars.InnerNativeArray(),
+            };
             var rootGatherHandle = rootGatherJob.Schedule(rootsTransformAccessArray);
 
             var combinedGatherHandle = JobHandle.CombineDependencies(boneGatherHandle, rootGatherHandle);
@@ -192,6 +219,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
             Job.AvatarTransform = matrixFromAllAvatars.InnerNativeArray();
             Job.UpdateAvatar = updateAvatar.InnerNativeArray();
             Job.PerAvatarBoneCount = perAvatarBoneCount.InnerNativeArray();
+            Job.AvatarLocalToWorld = localToWorldFromAllAvatars.InnerNativeArray();
+            Job.LocalBounds = localBounds.InnerNativeArray();
+            Job.WorldBounds = worldBounds.InnerNativeArray();
             handle = Job.Schedule(avatarIndex, batchCount, combinedGatherHandle);
         }
 
@@ -220,6 +250,9 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
             bonesCombined.ReAlloc(newCapacity * bonesArrayLength);
             matrixFromAllAvatars.ReAlloc(newCapacity);
+            localToWorldFromAllAvatars.ReAlloc(newCapacity);
+            localBounds.ReAlloc(newCapacity, NativeArrayOptions.ClearMemory);
+            worldBounds.ReAlloc(newCapacity, NativeArrayOptions.ClearMemory);
             updateAvatar.ReAlloc(newCapacity);
 
             int oldCapacity = currentAvatarAmountSupported;
@@ -269,6 +302,11 @@ namespace DCL.AvatarRendering.AvatarShape.Components
 
             matrixFromAllAvatars.Dispose();
             stopwatch.LogStep("matrixFromAllAvatars.Dispose");
+
+            localToWorldFromAllAvatars.Dispose();
+            localBounds.Dispose();
+            worldBounds.Dispose();
+            stopwatch.LogStep("avatarBounds.Dispose");
 
             updateAvatar.Dispose();
             stopwatch.LogStep("updateAvatar.Dispose");

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/BoneMatrixCalculationJob.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/BoneMatrixCalculationJob.cs
@@ -22,6 +22,15 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
         [ReadOnly] [NativeDisableParallelForRestriction] public NativeArray<int> PerAvatarBoneCount;
 
+        /// <summary>Avatar root localToWorld, gathered by <see cref="AvatarRootGatherJob" />.</summary>
+        [ReadOnly] [NativeDisableParallelForRestriction] public NativeArray<float4x4> AvatarLocalToWorld;
+
+        /// <summary>Per-avatar bounds in avatar space, c0 is the centre and c1 the extents.</summary>
+        [ReadOnly] [NativeDisableParallelForRestriction] public NativeArray<float3x2> LocalBounds;
+
+        /// <summary>Per-avatar bounds in world space, same layout as <see cref="LocalBounds" />.</summary>
+        [NativeDisableParallelForRestriction] public NativeArray<float3x2> WorldBounds;
+
         public NativeArray<float4x4> BonesMatricesResult => bonesMatricesResult;
 
         public BoneMatrixCalculationJob(int boneStride, int bonesPerAvatarLength, NativeArray<float4x4> boneWorldMatrixArray)
@@ -31,6 +40,9 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
             AvatarTransform = default;
             UpdateAvatar = default;
             PerAvatarBoneCount = default;
+            AvatarLocalToWorld = default;
+            LocalBounds = default;
+            WorldBounds = default;
 
             this.boneWorldMatrixArray = boneWorldMatrixArray;
         }
@@ -53,6 +65,21 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
             for (int b = 0; b < count; b++)
                 bonesMatricesResult[offset + b] = math.mul(avatarMatrix, boneWorldMatrixArray[offset + b]);
+
+            // Re-axis-align the avatar-space bounds through the root matrix. The absolute-valued rotation
+            // maps each local extent onto the world axes, which is the same result Bounds gives on the main
+            // thread; doing it here keeps the culling test off Transform entirely.
+            float4x4 localToWorld = AvatarLocalToWorld[avatarIdx];
+            float3x2 local = LocalBounds[avatarIdx];
+
+            var absRotation = new float3x3(
+                math.abs(localToWorld.c0.xyz),
+                math.abs(localToWorld.c1.xyz),
+                math.abs(localToWorld.c2.xyz));
+
+            WorldBounds[avatarIdx] = new float3x2(
+                math.transform(localToWorld, local.c0),
+                math.mul(absRotation, local.c1));
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
@@ -18,6 +18,9 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 {
     public class ComputeShaderSkinning : CustomSkinning
     {
+        // Shared asset-bundle meshes are never mutated after load and destroyed instance ids never recur, so no invalidation is needed
+        private static readonly HashSet<int> tangentsComputed = new ();
+
         public override AvatarCustomSkinningComponent Initialize(IList<CachedAttachment> gameObjects,
             UnityEngine.ComputeShader skinningShader, IAvatarMaterialPoolHandler avatarMaterialPool, AvatarShapeComponent avatarShapeComponent,
             in FacialFeaturesTextures facialFeatureTexture, int boneCount)
@@ -85,7 +88,8 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
         private void FillMeshArray(Mesh mesh, int currentMeshVertexCount, int vertexCounter, int skinnedMeshCounter, ComputeSkinningBufferContainer computeSkinningBufferContainer, int boneCount, int springBoneOffset)
         {
             // HACK: We only need to do this if the avatar has _NORMALMAPS enabled on the material.
-            mesh.RecalculateTangents();
+            if (tangentsComputed.Add(mesh.GetInstanceID()))
+                mesh.RecalculateTangents();
 
             computeSkinningBufferContainer.CopyAllBuffers(mesh, currentMeshVertexCount, vertexCounter, skinnedMeshCounter, boneCount, springBoneOffset);
         }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/ComputeShaderSkinning.cs
@@ -18,9 +18,6 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 {
     public class ComputeShaderSkinning : CustomSkinning
     {
-        // Shared asset-bundle meshes are never mutated after load and destroyed instance ids never recur, so no invalidation is needed
-        private static readonly HashSet<int> tangentsComputed = new ();
-
         public override AvatarCustomSkinningComponent Initialize(IList<CachedAttachment> gameObjects,
             UnityEngine.ComputeShader skinningShader, IAvatarMaterialPoolHandler avatarMaterialPool, AvatarShapeComponent avatarShapeComponent,
             in FacialFeaturesTextures facialFeatureTexture, int boneCount)
@@ -57,7 +54,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
                 MeshData meshData = meshesData[i];
                 int meshVertexCount = meshData.Mesh.sharedMesh.vertexCount;
                 ResetTransforms(meshData.Transform, meshData.RootTransform);
-                FillMeshArray(meshData.Mesh.sharedMesh, meshVertexCount, vertCounter, skinnedMeshCounter, computeSkinningBufferContainer, boneCount, meshData.SpringBoneOffset);
+                FillMeshArray(meshData, meshVertexCount, vertCounter, skinnedMeshCounter, computeSkinningBufferContainer, boneCount);
                 vertCounter += meshVertexCount;
                 skinnedMeshCounter++;
             }
@@ -85,13 +82,17 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
             return new AvatarCustomSkinningComponent.Buffers(mBones, kernel);
         }
 
-        private void FillMeshArray(Mesh mesh, int currentMeshVertexCount, int vertexCounter, int skinnedMeshCounter, ComputeSkinningBufferContainer computeSkinningBufferContainer, int boneCount, int springBoneOffset)
+        private void FillMeshArray(in MeshData meshData, int currentMeshVertexCount, int vertexCounter, int skinnedMeshCounter, ComputeSkinningBufferContainer computeSkinningBufferContainer, int boneCount)
         {
+            Mesh mesh = meshData.Mesh.sharedMesh;
+
             // HACK: We only need to do this if the avatar has _NORMALMAPS enabled on the material.
-            if (tangentsComputed.Add(mesh.GetInstanceID()))
+            // The meshes are shared between every instance of the asset and nothing mutates their vertices or
+            // normals after load, so the recalculation only has to run on the first instance that uses each one.
+            if (meshData.OriginalAsset.TryMarkTangentsRecalculated(mesh))
                 mesh.RecalculateTangents();
 
-            computeSkinningBufferContainer.CopyAllBuffers(mesh, currentMeshVertexCount, vertexCounter, skinnedMeshCounter, boneCount, springBoneOffset);
+            computeSkinningBufferContainer.CopyAllBuffers(mesh, currentMeshVertexCount, vertexCounter, skinnedMeshCounter, boneCount, meshData.SpringBoneOffset);
         }
 
         private (int vertCount, int totalBoneBufferCount) SetupCounters(IReadOnlyList<MeshData> meshesData, int boneCount)
@@ -176,7 +177,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
                             cachedWearable.Renderers.Add(tuple.Item1);
 
                             targetList.Add(new MeshData(tuple.Item2, tuple.Item1, tuple.Item1.transform, instance.transform,
-                                originalMaterial, springBoneOffset));
+                                originalMaterial, cachedWearable.OriginalAsset, springBoneOffset));
                         }
                         else
                         {
@@ -184,7 +185,7 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 
                             // From Pooled Object
                             targetList.Add(new MeshData(meshRenderer.GetComponent<MeshFilter>(), meshRenderer, meshRenderer.transform, instance.transform,
-                                originalMaterial, springBoneOffset));
+                                originalMaterial, cachedWearable.OriginalAsset, springBoneOffset));
                         }
                     }
                 }
@@ -219,6 +220,10 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
         /// <returns>A bounding box that contains all the meshes.</returns>
         private static Bounds CalculateLocalBoundsFromMeshes(List<MeshData> meshes)
         {
+            // Seeding the corners from an empty list would yield negative extents, which reads as an inverted
+            // box everywhere downstream, culling included.
+            if (meshes.Count == 0) return default(Bounds);
+
             Vector3 maxCorner = new Vector3(float.MinValue, float.MinValue, float.MinValue);
             Vector3 minCorner = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/MeshData.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/MeshData.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using DCL.AvatarRendering.Loading.Assets;
+using UnityEngine;
 
 namespace DCL.AvatarRendering.AvatarShape.ComputeShader
 {
@@ -11,18 +12,25 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
         public readonly Transform RootTransform;
 
         /// <summary>
+        ///     The attachment asset <see cref="Mesh" /> was instantiated from, which owns the mesh and therefore
+        ///     the record of whether its tangents have already been recalculated.
+        /// </summary>
+        public readonly AttachmentRegularAsset OriginalAsset;
+
+        /// <summary>
         ///     Number of spring bones from previous wearables. Added to BoneWeight indices >= BASE_BONE_COUNT
         ///     so each wearable's spring bones map to the correct slot in the global bone matrix buffer.
         /// </summary>
         public readonly int SpringBoneOffset;
 
-        public MeshData(MeshFilter mesh, Renderer renderer, Transform transform, Transform rootTransform, Material originalMaterial, int springBoneOffset = 0)
+        public MeshData(MeshFilter mesh, Renderer renderer, Transform transform, Transform rootTransform, Material originalMaterial, AttachmentRegularAsset originalAsset, int springBoneOffset = 0)
         {
             Mesh = mesh;
             Transform = transform;
             RootTransform = rootTransform;
             OriginalMaterial = originalMaterial;
             Renderer = renderer;
+            OriginalAsset = originalAsset;
             SpringBoneOffset = springBoneOffset;
         }
     }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/TransformGatherJobs.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/ComputeShader/TransformGatherJobs.cs
@@ -23,9 +23,11 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
     }
 
     /// <summary>
-    ///     Reads each avatar root's worldToLocalMatrix from worker threads into matrixFromAllAvatars.
+    ///     Reads each avatar root's matrix from worker threads: the inverse into matrixFromAllAvatars for the
+    ///     bone calculation, and the forward matrix into localToWorldFromAllAvatars so the bounds transform can
+    ///     run in the job instead of touching Transform again on the main thread.
     ///     The TAA has one entry per slot (including dummy entries for released slots),
-    ///     so transform index maps directly to matrixFromAllAvatars index.
+    ///     so transform index maps directly to both arrays.
     /// </summary>
     [BurstCompile]
     public struct AvatarRootGatherJob : IJobParallelForTransform
@@ -33,9 +35,15 @@ namespace DCL.AvatarRendering.AvatarShape.ComputeShader
         [NativeDisableParallelForRestriction]
         public NativeArray<float4x4> MatrixFromAllAvatars;
 
+        [NativeDisableParallelForRestriction]
+        public NativeArray<float4x4> LocalToWorldFromAllAvatars;
+
         public void Execute(int index, TransformAccess transform)
         {
-            MatrixFromAllAvatars[index] = math.inverse((float4x4)transform.localToWorldMatrix);
+            var localToWorld = (float4x4)transform.localToWorldMatrix;
+
+            LocalToWorldFromAllAvatars[index] = localToWorld;
+            MatrixFromAllAvatars[index] = math.inverse(localToWorld);
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Editor/AvatarBaseBoundsGizmo.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Editor/AvatarBaseBoundsGizmo.cs
@@ -1,0 +1,284 @@
+using Arch.Core;
+using DCL.AvatarRendering.AvatarShape.Components;
+using DCL.AvatarRendering.AvatarShape.UnityInterface;
+using Global.Dynamic;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace DCL.AvatarRendering.AvatarShape.Editor
+{
+    // Declared inside the namespace on purpose: aliases at file scope lose to the DCL.Gizmos and DCL.Time
+    // namespaces, which name lookup reaches first while walking out of DCL.AvatarRendering.AvatarShape.Editor
+    using Gizmos = UnityEngine.Gizmos;
+    using Time = UnityEngine.Time;
+
+    /// <summary>
+    ///     Labels every avatar with the culling verdict FinishAvatarMatricesCalculationSystem acts on, and draws the
+    ///     three boxes an avatar carries so their fit can be compared: the one that system frustum-tests, the
+    ///     ghost-renderer box that used to be tested, and the union of Renderer.bounds that Unity culls the drawn
+    ///     geometry with. Every box is read from the source its own consumer reads, and the verdict comes from that
+    ///     system's own predicate, so what is shown here is what the runtime decided.
+    /// </summary>
+    public static class AvatarBaseBoundsGizmo
+    {
+        private const string MENU_PATH = "Decentraland/Debug/Draw AvatarBase Bounds";
+        private const string ENABLED_PREF_KEY = "DCL.AvatarBaseBoundsGizmo.Enabled";
+        private const float ROOT_BONE_MARKER_RADIUS = 0.06f;
+
+        // Yellow / red: the box the frustum test reads, coloured by the culling verdict
+        private static readonly Color SKINNING_COLOR = new (1f, 0.85f, 0.1f, 1f);
+        private static readonly Color CULLED_COLOR = new (1f, 0.25f, 0.2f, 1f);
+
+        // Magenta: the ghost-renderer box this test read before, kept for comparison
+        private static readonly Color GHOST_BOUNDS_COLOR = new (1f, 0.3f, 0.9f, 1f);
+
+        // Cyan: what Unity culls the drawn geometry with, which is the hardcoded cube from SetupMesh
+        private static readonly Color DRAWN_GEOMETRY_COLOR = new (0.2f, 0.85f, 1f, 1f);
+        private static readonly Color ROOT_BONE_COLOR = Color.white;
+
+        private static readonly QueryDescription CULLABLE_AVATARS =
+            new QueryDescription().WithAll<AvatarBase, AvatarCustomSkinningComponent, AvatarShapeComponent, AvatarTransformMatrixComponent>();
+
+        private static readonly Plane[] FRUSTUM_PLANES = new Plane[6];
+        private static readonly List<Renderer> CHILD_RENDERERS = new ();
+        private static readonly Dictionary<AvatarBase, CullingInputs> CULLING_INPUTS = new ();
+
+        private static GUIStyle verdictLabel;
+        private static int cachedFrame = -1;
+
+        private static bool Enabled
+        {
+            get => EditorPrefs.GetBool(ENABLED_PREF_KEY, true);
+            set => EditorPrefs.SetBool(ENABLED_PREF_KEY, value);
+        }
+
+        [MenuItem(MENU_PATH)]
+        private static void ToggleEnabled()
+        {
+            Enabled = !Enabled;
+            Menu.SetChecked(MENU_PATH, Enabled);
+            SceneView.RepaintAll();
+        }
+
+        [MenuItem(MENU_PATH, true)]
+        private static bool ValidateToggleEnabled()
+        {
+            Menu.SetChecked(MENU_PATH, Enabled);
+            return true;
+        }
+
+        [DrawGizmo(GizmoType.NonSelected | GizmoType.Selected)]
+        private static void DrawAvatarBaseBounds(AvatarBase avatarBase, GizmoType gizmoType)
+        {
+            if (!Enabled) return;
+
+            RefreshCullingInputs();
+
+            // The system reads the ECS camera singleton, which DCL.Editor cannot reference; in a scene with one
+            // tagged MainCamera these are the same camera.
+            Camera mainCamera = Camera.main;
+
+            bool hasInputs = CULLING_INPUTS.TryGetValue(avatarBase, out CullingInputs inputs);
+            bool hasVerdict = hasInputs && mainCamera != null;
+
+            // Hands the rule the same argument the system does, short-circuiting the frustum for exempt avatars
+            bool culled = hasVerdict
+                          && AvatarCullingRule.IsCulled(inputs.ExemptFromCulling, inputs.IsVisible,
+                              inputs.ExemptFromCulling || IsInsideFrustum(mainCamera, inputs.Bounds));
+
+            if (hasInputs)
+            {
+                Gizmos.color = culled ? CULLED_COLOR : SKINNING_COLOR;
+                Gizmos.DrawWireCube(inputs.Bounds.center, inputs.Bounds.size);
+            }
+
+            SkinnedMeshRenderer ghostRenderer = avatarBase.AvatarSkinnedMeshRenderer;
+
+            // The reference is serialized, so a prefab that was never wired up can leave it empty
+            if (ghostRenderer != null)
+            {
+                Bounds ghost = ghostRenderer.bounds;
+                Gizmos.color = GHOST_BOUNDS_COLOR;
+                Gizmos.DrawWireCube(ghost.center, ghost.size);
+
+                Transform rootBone = ghostRenderer.rootBone;
+
+                if (rootBone != null)
+                {
+                    Gizmos.color = ROOT_BONE_COLOR;
+                    Gizmos.DrawWireSphere(rootBone.position, ROOT_BONE_MARKER_RADIUS);
+                }
+            }
+
+            bool hasDrawnGeometry = TryGetDrawnGeometryBounds(avatarBase, ghostRenderer, out Bounds drawn);
+
+            if (hasDrawnGeometry)
+            {
+                Gizmos.color = DRAWN_GEOMETRY_COLOR;
+                Gizmos.DrawWireCube(drawn.center, drawn.size);
+            }
+
+            DrawVerdict(avatarBase, inputs, hasInputs, culled, mainCamera != null);
+
+            if ((gizmoType & GizmoType.Selected) != 0)
+                DrawDetails(avatarBase, inputs, hasInputs, drawn, hasDrawnGeometry);
+        }
+
+        /// <summary>
+        ///     Collects, once per frame, everything FinishAvatarMatricesCalculationSystem feeds its culling rule:
+        ///     the LocalBounds snapshot the skinning component holds placed in the world, plus the exemption and
+        ///     visibility flags. The runtime gets its bounds from BoneMatrixCalculationJob instead; that array is
+        ///     not reachable from editor code, so the identical formula is applied here through ToWorldBounds. The
+        ///     only way the two can differ is the avatar moving between the job gather and this draw.
+        /// </summary>
+        private static void RefreshCullingInputs()
+        {
+            if (cachedFrame == Time.frameCount) return;
+
+            cachedFrame = Time.frameCount;
+            CULLING_INPUTS.Clear();
+
+            World world = GlobalWorld.ECSWorldInstance;
+
+            // Null until the global world is built, and in edit mode
+            if (world == null) return;
+
+            foreach (ref Chunk chunk in world.Query(CULLABLE_AVATARS))
+            {
+                AvatarBase[] avatars = chunk.GetArray<AvatarBase>();
+                AvatarCustomSkinningComponent[] skinnings = chunk.GetArray<AvatarCustomSkinningComponent>();
+                AvatarShapeComponent[] shapes = chunk.GetArray<AvatarShapeComponent>();
+                AvatarTransformMatrixComponent[] matrices = chunk.GetArray<AvatarTransformMatrixComponent>();
+
+                foreach (int entityIndex in chunk)
+                {
+                    AvatarBase avatar = avatars[entityIndex];
+
+                    if (avatar == null) continue;
+
+                    CULLING_INPUTS[avatar] = new CullingInputs(
+                        skinnings[entityIndex].ToWorldBounds(avatar.transform),
+                        matrices[entityIndex].IsMainPlayer,
+                        shapes[entityIndex].IsPreview,
+                        shapes[entityIndex].IsVisible);
+                }
+            }
+        }
+
+        private static bool IsInsideFrustum(Camera camera, Bounds bounds)
+        {
+            GeometryUtility.CalculateFrustumPlanes(camera, FRUSTUM_PLANES);
+            return GeometryUtility.TestPlanesAABB(FRUSTUM_PLANES, bounds);
+        }
+
+        /// <summary>
+        ///     Unions the bounds of every renderer under the avatar except the ghost. With the compute-shader
+        ///     skinning pipeline these are MeshRenderers whose local bounds were replaced by a fixed 5 m cube, so
+        ///     the union reports that cube rather than the real silhouette.
+        /// </summary>
+        private static bool TryGetDrawnGeometryBounds(AvatarBase avatarBase, Renderer ghostRenderer, out Bounds drawn)
+        {
+            drawn = default(Bounds);
+            var found = false;
+
+            avatarBase.GetComponentsInChildren(true, CHILD_RENDERERS);
+
+            foreach (Renderer renderer in CHILD_RENDERERS)
+            {
+                if (renderer == ghostRenderer || !renderer.enabled || !renderer.gameObject.activeInHierarchy)
+                    continue;
+
+                if (found)
+                    drawn.Encapsulate(renderer.bounds);
+                else
+                {
+                    drawn = renderer.bounds;
+                    found = true;
+                }
+            }
+
+            CHILD_RENDERERS.Clear();
+            return found;
+        }
+
+        /// <summary>
+        ///     Always-on one-liner above the avatar, so the culling state is readable from the scene view without
+        ///     selecting anything. Names the reason as well as the verdict, since an avatar can skip culling for
+        ///     three different reasons.
+        /// </summary>
+        private static void DrawVerdict(AvatarBase avatarBase, CullingInputs inputs, bool hasInputs, bool culled, bool hasCamera)
+        {
+            string verdict;
+
+            if (!hasInputs)
+                verdict = "no skinning component, never culled";
+            else if (!hasCamera)
+                verdict = "no Camera.main, verdict unknown";
+            else if (culled)
+                verdict = inputs.IsVisible ? "CULLED - out of frustum" : "CULLED - hidden";
+            else if (inputs.IsMainPlayer)
+                verdict = "SKINNING - main player";
+            else if (inputs.IsPreview)
+                verdict = "SKINNING - preview";
+            else
+                verdict = "SKINNING - in frustum";
+
+            // Built lazily: a GUIStyle constructed during static initialisation carries no font and draws nothing
+            verdictLabel ??= new GUIStyle(EditorStyles.label);
+            verdictLabel.normal.textColor = culled ? CULLED_COLOR : SKINNING_COLOR;
+
+            Handles.Label(LabelAnchor(avatarBase, inputs, hasInputs, above: true),
+                $"{avatarBase.name}  {verdict}", verdictLabel);
+        }
+
+        private static void DrawDetails(AvatarBase avatarBase, CullingInputs inputs, bool hasInputs, Bounds drawn, bool hasDrawnGeometry)
+        {
+            string testedLine = hasInputs
+                ? $"tested bounds  size {Format(inputs.Bounds.size)}  center {Format(inputs.Bounds.center)}"
+                : "tested bounds  none";
+
+            string drawnLine = hasDrawnGeometry
+                ? $"cyan    Renderer.bounds union  size {Format(drawn.size)}  center {Format(drawn.center)}"
+                : "cyan    Renderer.bounds union  none enabled";
+
+            Handles.Label(LabelAnchor(avatarBase, inputs, hasInputs, above: false),
+                $@"{testedLine}
+{drawnLine}
+magenta ghost renderer bounds, tested before");
+        }
+
+        private static Vector3 LabelAnchor(AvatarBase avatarBase, CullingInputs inputs, bool hasInputs, bool above)
+        {
+            if (!hasInputs)
+                return avatarBase.transform.position;
+
+            float offset = above ? inputs.Bounds.extents.y : -inputs.Bounds.extents.y;
+            return inputs.Bounds.center + (Vector3.up * offset);
+        }
+
+        private static string Format(Vector3 value) =>
+            $"({value.x:0.00}, {value.y:0.00}, {value.z:0.00})";
+
+        /// <summary>
+        ///     Everything the culling rule consumes for one avatar, snapshotted once per frame.
+        /// </summary>
+        private readonly struct CullingInputs
+        {
+            public readonly Bounds Bounds;
+            public readonly bool IsMainPlayer;
+            public readonly bool IsPreview;
+            public readonly bool IsVisible;
+
+            public bool ExemptFromCulling => IsMainPlayer || IsPreview;
+
+            public CullingInputs(Bounds bounds, bool isMainPlayer, bool isPreview, bool isVisible)
+            {
+                Bounds = bounds;
+                IsMainPlayer = isMainPlayer;
+                IsPreview = isPreview;
+                IsVisible = isVisible;
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Editor/AvatarBaseBoundsGizmo.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Editor/AvatarBaseBoundsGizmo.cs
@@ -270,7 +270,7 @@ magenta ghost renderer bounds, tested before");
             public readonly bool IsPreview;
             public readonly bool IsVisible;
 
-            public bool ExemptFromCulling => IsMainPlayer || IsPreview;
+            public bool ExemptFromCulling => AvatarCullingRule.IsExempt(IsMainPlayer, IsPreview);
 
             public CullingInputs(Bounds bounds, bool isMainPlayer, bool isPreview, bool isVisible)
             {

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Editor/AvatarBaseBoundsGizmo.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Editor/AvatarBaseBoundsGizmo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb0f06a5113f4fb5b636d052f9acb741
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -69,6 +69,16 @@ namespace DCL.AvatarRendering.AvatarShape
                 CalculateFrustumPlanes(cameraComponent.Camera);
                 GetAvatarsVisibleWithOutlineQuery(World, cameraComponent);
             }
+            else
+                CalculateFrustumPlanes(camera.GetCameraComponent(World).Camera);
+
+            StampFrustumVisibilityQuery(World);
+        }
+
+        [Query]
+        private void StampFrustumVisibility(in AvatarBase avatarBase, ref AvatarCachedVisibilityComponent cached)
+        {
+            cached.SetInCameraFrustum(IsVisibleInCamera(avatarBase.AvatarSkinnedMeshRenderer.bounds));
         }
 
         internal void CalculateFrustumPlanes(Camera camera)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -253,10 +253,11 @@ namespace DCL.AvatarRendering.AvatarShape
         private void UpdateVisibilityState(ref AvatarShapeComponent avatarShape, IAvatarView avatarView, ref AvatarCachedVisibilityComponent avatarCachedVisibility, bool shouldBeHidden, bool shouldPlayFootstepFX,
             in CharacterEmoteComponent characterEmoteComponent)
         {
-            bool isAnimationsEnabled = avatarView.AvatarAnimator.enabled;
-
+            // Compared against the cached flag, not Animator.enabled: the culling gate in
+            // FinishAvatarMatricesCalculationSystem also writes that property, and reading it back here would
+            // re-run this transition every frame an avatar is culled.
             if (avatarCachedVisibility.IsVisible == shouldBeHidden
-                && isAnimationsEnabled == shouldPlayFootstepFX)
+                && avatarCachedVisibility.PlaysFootstepFX == shouldPlayFootstepFX)
                 return;
 
             if (shouldBeHidden)
@@ -265,6 +266,7 @@ namespace DCL.AvatarRendering.AvatarShape
                 Show(ref avatarShape);
 
             avatarCachedVisibility.IsVisible = shouldBeHidden;
+            avatarCachedVisibility.PlaysFootstepFX = shouldPlayFootstepFX;
 
             avatarView.AvatarAnimator.enabled = shouldPlayFootstepFX && !avatarView.IsLegacyAnimationPlaying;
             avatarView.AvatarAnimator.fireEvents = shouldPlayFootstepFX;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/AvatarShapeVisibilitySystem.cs
@@ -63,22 +63,11 @@ namespace DCL.AvatarRendering.AvatarShape
             UpdateAvatarsVisibilityStateQuery(World);
             UpdateMainPlayerAvatarVisibilityStateQuery(World, camera.GetCameraComponent(World));
 
-            if (outlineFeature != null && outlineFeature.isActive)
-            {
-                CameraComponent cameraComponent = camera.GetCameraComponent(World);
-                CalculateFrustumPlanes(cameraComponent.Camera);
-                GetAvatarsVisibleWithOutlineQuery(World, cameraComponent);
-            }
-            else
-                CalculateFrustumPlanes(camera.GetCameraComponent(World).Camera);
+            if (outlineFeature == null || !outlineFeature.isActive) return;
 
-            StampFrustumVisibilityQuery(World);
-        }
-
-        [Query]
-        private void StampFrustumVisibility(in AvatarBase avatarBase, ref AvatarCachedVisibilityComponent cached)
-        {
-            cached.SetInCameraFrustum(IsVisibleInCamera(avatarBase.AvatarSkinnedMeshRenderer.bounds));
+            CameraComponent cameraComponent = camera.GetCameraComponent(World);
+            CalculateFrustumPlanes(cameraComponent.Camera);
+            GetAvatarsVisibleWithOutlineQuery(World, cameraComponent);
         }
 
         internal void CalculateFrustumPlanes(Camera camera)

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
@@ -4,6 +4,7 @@ using Arch.SystemGroups;
 using Arch.SystemGroups.DefaultSystemGroups;
 using DCL.AvatarRendering.AvatarShape.Components;
 using DCL.AvatarRendering.AvatarShape.ComputeShader;
+using DCL.AvatarRendering.AvatarShape.UnityInterface;
 using DCL.Diagnostics;
 using ECS.Abstract;
 using ECS.LifeCycle.Components;
@@ -36,13 +37,31 @@ namespace DCL.AvatarRendering.AvatarShape
         }
 
         [Query]
-        [All(typeof(AvatarShapeComponent))]
         [None(typeof(DeleteEntityIntention))]
         private void Execute(
             ref AvatarTransformMatrixComponent avatarTransformMatrixComponent,
-            ref AvatarCustomSkinningComponent computeShaderSkinning
+            ref AvatarCustomSkinningComponent computeShaderSkinning,
+            in AvatarShapeComponent avatarShape,
+            in AvatarCachedVisibilityComponent cachedVisibility,
+            in AvatarBase avatarBase
         )
         {
+            bool culled = !avatarTransformMatrixComponent.IsMainPlayer
+                          && (!avatarShape.IsVisible || !cachedVisibility.IsInCameraFrustum);
+
+            // Unity's own animator culling only consults SkinnedMeshRenderers and the custom skinning
+            // pipeline deletes them all, so visibility must gate the Animator manually
+            if (avatarBase.AvatarAnimator.enabled == culled)
+                avatarBase.AvatarAnimator.enabled = !culled;
+
+            if (!computeShaderSkinning.ForceSkinNextFrame && culled)
+                return;
+
+            computeShaderSkinning.ForceSkinNextFrame = false;
+                return;
+
+            computeShaderSkinning.ForceSkinNextFrame = false;
+
             NativeArray<float4x4> bonesResult = avatarTransformMatrixComponent.IsMainPlayer
                 ? mainPlayerResult
                 : remoteResult;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
@@ -11,7 +11,9 @@ using ECS.LifeCycle.Components;
 using Unity.Collections;
 using Unity.Mathematics;
 using System;
+using DCL.CharacterCamera;
 using RichTypes;
+using UnityEngine;
 
 namespace DCL.AvatarRendering.AvatarShape
 {
@@ -19,12 +21,24 @@ namespace DCL.AvatarRendering.AvatarShape
     public partial class FinishAvatarMatricesCalculationSystem : BaseUnityLoopSystem
     {
         private readonly AvatarTransformMatrixJobWrapper jobWrapper;
+
+        // Reused frustum-plane scratch buffer, rewritten once per tick before the query reads it.
+        private readonly Plane[] frustumPlanes = new Plane[6];
+
         private NativeArray<float4x4> remoteResult;
         private NativeArray<float4x4> mainPlayerResult;
+        private NativeArray<float3x2> worldBounds;
+
+        private SingleInstanceEntity camera;
 
         internal FinishAvatarMatricesCalculationSystem(World world, AvatarTransformMatrixJobWrapper jobWrapper) : base(world)
         {
             this.jobWrapper = jobWrapper;
+        }
+
+        public override void Initialize()
+        {
+            camera = World.CacheCamera();
         }
 
         protected override void Update(float t)
@@ -32,6 +46,11 @@ namespace DCL.AvatarRendering.AvatarShape
             jobWrapper.CompleteBoneMatrixCalculations();
             remoteResult = jobWrapper.RemoteAvatarsBonesResult;
             mainPlayerResult = jobWrapper.MainPlayerBonesResult;
+            worldBounds = jobWrapper.RemoteAvatarsWorldBounds;
+
+            // Extracted here rather than at schedule time so the planes and the completed job output are read
+            // in the same place, one tick of the player loop apart at most.
+            GeometryUtility.CalculateFrustumPlanes(camera.GetCameraComponent(World).Camera, frustumPlanes);
 
             ExecuteQuery(World);
         }
@@ -42,22 +61,24 @@ namespace DCL.AvatarRendering.AvatarShape
             ref AvatarTransformMatrixComponent avatarTransformMatrixComponent,
             ref AvatarCustomSkinningComponent computeShaderSkinning,
             in AvatarShapeComponent avatarShape,
-            in AvatarCachedVisibilityComponent cachedVisibility,
             in AvatarBase avatarBase
         )
         {
-            bool culled = !avatarTransformMatrixComponent.IsMainPlayer
-                          && (!avatarShape.IsVisible || !cachedVisibility.IsInCameraFrustum);
+            // The main player never skips: reflections and portraits sample it outside this frustum. Preview
+            // avatars are drawn by their own camera into a render texture, so the player camera says nothing
+            // about them either.
+            bool exempt = avatarTransformMatrixComponent.IsMainPlayer || avatarShape.IsPreview;
+
+            // The || short-circuits, so an exempt avatar never indexes the remote bounds array.
+            bool culled = AvatarCullingRule.IsCulled(exempt, avatarShape.IsVisible,
+                exempt || IsInFrustum(avatarTransformMatrixComponent.IndexInGlobalJobArray));
 
             // Unity's own animator culling only consults SkinnedMeshRenderers and the custom skinning
-            // pipeline deletes them all, so visibility must gate the Animator manually
+            // pipeline deletes them all, so visibility must gate the Animator manually.
             if (avatarBase.AvatarAnimator.enabled == culled)
                 avatarBase.AvatarAnimator.enabled = !culled;
 
             if (!computeShaderSkinning.ForceSkinNextFrame && culled)
-                return;
-
-            computeShaderSkinning.ForceSkinNextFrame = false;
                 return;
 
             computeShaderSkinning.ForceSkinNextFrame = false;
@@ -70,6 +91,17 @@ namespace DCL.AvatarRendering.AvatarShape
 
             if (result.Success == false)
                 ReportHub.LogException(new Exception(result.ErrorMessage), ReportCategory.AVATAR);
+        }
+
+        private bool IsInFrustum(GlobalJobArrayIndex indexInGlobalJobArray)
+        {
+            // An avatar that has not been registered into the job yet has no bounds to test, so it is kept
+            // alive rather than culled on missing data.
+            if (indexInGlobalJobArray.TryGetValue(out int validIndex) == false || validIndex >= worldBounds.Length)
+                return true;
+
+            float3x2 bounds = worldBounds[validIndex];
+            return GeometryUtility.TestPlanesAABB(frustumPlanes, new Bounds(bounds.c0, bounds.c1 * 2f));
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
@@ -67,7 +67,7 @@ namespace DCL.AvatarRendering.AvatarShape
             // The main player never skips: reflections and portraits sample it outside this frustum. Preview
             // avatars are drawn by their own camera into a render texture, so the player camera says nothing
             // about them either.
-            bool exempt = avatarTransformMatrixComponent.IsMainPlayer || avatarShape.IsPreview;
+            bool exempt = AvatarCullingRule.IsExempt(avatarTransformMatrixComponent.IsMainPlayer, avatarShape.IsPreview);
 
             // The || short-circuits, so an exempt avatar never indexes the remote bounds array.
             bool culled = AvatarCullingRule.IsCulled(exempt, avatarShape.IsVisible,

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/FinishAvatarMatricesCalculationSystem.cs
@@ -74,9 +74,14 @@ namespace DCL.AvatarRendering.AvatarShape
                 exempt || IsInFrustum(avatarTransformMatrixComponent.IndexInGlobalJobArray));
 
             // Unity's own animator culling only consults SkinnedMeshRenderers and the custom skinning
-            // pipeline deletes them all, so visibility must gate the Animator manually.
-            if (avatarBase.AvatarAnimator.enabled == culled)
-                avatarBase.AvatarAnimator.enabled = !culled;
+            // pipeline deletes them all, so visibility must gate the Animator manually. The rule is a strict
+            // refinement of the one AvatarShapeVisibilitySystem applies on its transitions, so the two writers
+            // agree whenever nothing changed: no footstep FX inside a hide-avatars modifier area, which culling
+            // covers for everyone but the exempt avatars, and never while a legacy Animation drives the rig.
+            bool animatorShouldRun = !culled && !avatarShape.HiddenByModifierArea && !avatarBase.IsLegacyAnimationPlaying;
+
+            if (avatarBase.AvatarAnimator.enabled != animatorShouldRun)
+                avatarBase.AvatarAnimator.enabled = animatorShouldRun;
 
             if (!computeShaderSkinning.ForceSkinNextFrame && culled)
                 return;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/StartAvatarMatricesCalculationSystem.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Systems/StartAvatarMatricesCalculationSystem.cs
@@ -30,7 +30,7 @@ namespace DCL.AvatarRendering.AvatarShape
             RegisterMainPlayerQuery(World);
             RegisterRemoteAvatarsQuery(World);
 
-            RefreshBoneCountsQuery(World);
+            RefreshPerAvatarJobInputsQuery(World);
 
             avatarTransformMatrixBatchJob.ScheduleBoneMatrixCalculation();
         }
@@ -60,9 +60,10 @@ namespace DCL.AvatarRendering.AvatarShape
 
         [Query]
         [None(typeof(DeleteEntityIntention))]
-        private void RefreshBoneCounts(ref AvatarTransformMatrixComponent transformMatrixComponent, ref AvatarCustomSkinningComponent skinningComponent)
+        private void RefreshPerAvatarJobInputs(ref AvatarTransformMatrixComponent transformMatrixComponent, in AvatarCustomSkinningComponent skinningComponent)
         {
             avatarTransformMatrixBatchJob.SetBoneCount(ref transformMatrixComponent, skinningComponent.BoneCount);
+            avatarTransformMatrixBatchJob.SetLocalBounds(ref transformMatrixComponent, skinningComponent.LocalBounds);
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/AvatarShapeVisibilitySystemShould.cs
@@ -503,6 +503,28 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
         }
 
         [Test]
+        public void LeaveAnAnimatorTheCullingGateDisabledAlone()
+        {
+            // Arrange - a visible non-player avatar, primed so the cache holds its visible state
+            var avatarShape = CreateAvatarShapeComponent();
+            world.Create(avatarShape, avatarBase, new CharacterEmoteComponent());
+            system!.Update(0);
+
+            Assume.That(avatarBase.AvatarAnimator.enabled, Is.True,
+                "Sanity check: a visible avatar outside any modifier area starts animated.");
+
+            // FinishAvatarMatricesCalculationSystem culls the avatar later in the same frame
+            avatarBase.AvatarAnimator.enabled = false;
+
+            // Act
+            system.Update(0);
+
+            // Assert
+            Assert.IsFalse(avatarBase.AvatarAnimator.enabled,
+                "With no visibility change the system must leave the Animator alone, otherwise it re-enables every culled avatar each frame.");
+        }
+
+        [Test]
         public void HidePlayerAvatarWhenTransitioningToFirstPersonAndCloseToCameraStart()
         {
             // Arrange

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/FinishAvatarMatricesCalculationSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/FinishAvatarMatricesCalculationSystemShould.cs
@@ -1,0 +1,189 @@
+using Arch.Core;
+using DCL.AvatarRendering.AvatarShape.Components;
+using DCL.AvatarRendering.AvatarShape.UnityInterface;
+using DCL.CharacterCamera;
+using ECS.TestSuite;
+using NUnit.Framework;
+using System.Collections.Generic;
+using Unity.Mathematics;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
+
+namespace DCL.AvatarRendering.AvatarShape.Tests
+{
+    public class FinishAvatarMatricesCalculationSystemShould : UnitySystemTestBase<FinishAvatarMatricesCalculationSystem>
+    {
+        private const string AVATAR_BASE_TEST_ASSET_PATH = "Assets/DCL/AvatarRendering/AvatarShape/Tests/Instantiate/TestAssets/AvatarBase_TestAsset.prefab";
+        private const float TOLERANCE = 0.001f;
+
+        private static readonly Vector3 BEHIND_CAMERA = new (0, 0, -50);
+        private static readonly Vector3 IN_FRONT_OF_CAMERA = new (0, 0, 10);
+
+        private readonly List<GameObject> createdGameObjects = new ();
+
+        private AvatarTransformMatrixJobWrapper jobWrapper = null!;
+        private GameObject cameraGameObject = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            cameraGameObject = new GameObject("TestCamera");
+            createdGameObjects.Add(cameraGameObject);
+            cameraGameObject.transform.position = Vector3.zero;
+
+            // Looking down +Z, so anything at negative Z is behind it
+            cameraGameObject.transform.rotation = Quaternion.identity;
+
+            var testCamera = cameraGameObject.AddComponent<Camera>();
+            testCamera.nearClipPlane = 0.1f;
+            testCamera.farClipPlane = 1000f;
+            world.Create(new CameraComponent(testCamera) { Mode = CameraMode.ThirdPerson });
+
+            jobWrapper = new AvatarTransformMatrixJobWrapper();
+
+            system = new FinishAvatarMatricesCalculationSystem(world, jobWrapper);
+            system.Initialize();
+        }
+
+        protected override void OnTearDown()
+        {
+            LogAssert.ignoreFailingMessages = false;
+            jobWrapper.Dispose();
+
+            foreach (GameObject createdGameObject in createdGameObjects)
+                if (createdGameObject != null)
+                    Object.DestroyImmediate(createdGameObject);
+
+            createdGameObjects.Clear();
+        }
+
+        [Test]
+        public void CullAnInWorldAvatarBehindTheCamera()
+        {
+            // Arrange - start animated, so the assertion can only pass on a transition the system drove
+            AvatarBase avatarBase = CreateAvatar(BEHIND_CAMERA, isPreview: false, out _);
+            avatarBase.AvatarAnimator.enabled = true;
+
+            // Act
+            RunFrame();
+
+            // Assert
+            Assert.IsFalse(avatarBase.AvatarAnimator.enabled,
+                "an in-world avatar outside the frustum must be culled, which gates its Animator");
+        }
+
+        [Test]
+        public void NotCullAnInWorldAvatarInFrontOfTheCamera()
+        {
+            AllowTheSkinningDispatchToReport();
+
+            // Arrange - start culled, so the assertion can only pass on a transition the system drove
+            AvatarBase avatarBase = CreateAvatar(IN_FRONT_OF_CAMERA, isPreview: false, out _);
+            avatarBase.AvatarAnimator.enabled = false;
+
+            // Act
+            RunFrame();
+
+            // Assert
+            Assert.IsTrue(avatarBase.AvatarAnimator.enabled,
+                "an in-world avatar inside the frustum must not be culled");
+        }
+
+        [Test]
+        public void KeepThePreviewAvatarLiveWhereverThePlayerCameraLooks()
+        {
+            AllowTheSkinningDispatchToReport();
+
+            // Arrange - same position that culls the in-world avatar above, and start culled so the assertion
+            // can only pass on a transition the system drove
+            AvatarBase avatarBase = CreateAvatar(BEHIND_CAMERA, isPreview: true, out _);
+            avatarBase.AvatarAnimator.enabled = false;
+
+            // Act
+            RunFrame();
+
+            // Assert
+            Assert.IsTrue(avatarBase.AvatarAnimator.enabled,
+                "a preview avatar is drawn by its own camera, so the player camera must never cull it");
+        }
+
+        /// <summary>
+        ///     Locks the Burst transform in BoneMatrixCalculationJob against the managed reference form, under a
+        ///     rotation and translation, which is what would catch a transposed column in either of them.
+        /// </summary>
+        [Test]
+        public void PlaceTheAvatarBoundsInTheWorldTheSameWayTheReferenceFormDoes()
+        {
+            // Arrange - behind the camera, so the avatar is culled and the dispatch never reports; the job
+            // computes bounds regardless of the culling verdict
+            var localBounds = new Bounds(new Vector3(0.1f, 0.9f, -0.2f), new Vector3(0.8f, 1.8f, 0.5f));
+
+            AvatarBase avatarBase = CreateAvatar(BEHIND_CAMERA, isPreview: false, out AvatarTransformMatrixComponent transformMatrix,
+                localBounds);
+
+            avatarBase.transform.rotation = Quaternion.Euler(0, 37f, 0);
+
+            // Act
+            RunFrame();
+
+            // Assert
+            Assert.IsTrue(transformMatrix.IndexInGlobalJobArray.TryGetValue(out int index), "the avatar must hold a job slot");
+
+            float3x2 fromJob = jobWrapper.RemoteAvatarsWorldBounds[index];
+            Bounds expected = AvatarCustomSkinningComponent.NewWithLocalBounds(localBounds).ToWorldBounds(avatarBase.transform);
+
+            Assert.That((float)fromJob.c0.x, Is.EqualTo(expected.center.x).Within(TOLERANCE));
+            Assert.That((float)fromJob.c0.y, Is.EqualTo(expected.center.y).Within(TOLERANCE));
+            Assert.That((float)fromJob.c0.z, Is.EqualTo(expected.center.z).Within(TOLERANCE));
+            Assert.That((float)fromJob.c1.x, Is.EqualTo(expected.extents.x).Within(TOLERANCE));
+            Assert.That((float)fromJob.c1.y, Is.EqualTo(expected.extents.y).Within(TOLERANCE));
+            Assert.That((float)fromJob.c1.z, Is.EqualTo(expected.extents.z).Within(TOLERANCE));
+        }
+
+        /// <summary>
+        ///     An avatar that is not culled reaches ComputeSkinning, which reports against the placeholder
+        ///     skinning component this fixture creates rather than a real one backed by GPU buffers.
+        /// </summary>
+        private static void AllowTheSkinningDispatchToReport()
+        {
+            LogAssert.ignoreFailingMessages = true;
+        }
+
+        private void RunFrame()
+        {
+            jobWrapper.ScheduleBoneMatrixCalculation();
+            system!.Update(0);
+        }
+
+        /// <summary>
+        ///     Places an avatar and registers it with the job, so the calculation job produces real world bounds
+        ///     for it, which is what the system tests against.
+        /// </summary>
+        private AvatarBase CreateAvatar(Vector3 position, bool isPreview, out AvatarTransformMatrixComponent transformMatrix,
+            Bounds? localBounds = null)
+        {
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(AVATAR_BASE_TEST_ASSET_PATH);
+            Assert.IsNotNull(prefab, $"Could not load AvatarBase test prefab from {AVATAR_BASE_TEST_ASSET_PATH}");
+
+            GameObject instance = Object.Instantiate(prefab);
+            createdGameObjects.Add(instance);
+            instance.transform.position = position;
+
+            AvatarBase avatarBase = instance.GetComponentInChildren<AvatarBase>();
+            Assert.IsNotNull(avatarBase, "AvatarBase component not found on test prefab");
+
+            Bounds bounds = localBounds ?? new Bounds(Vector3.zero, Vector3.one);
+
+            transformMatrix = AvatarTransformMatrixComponent.NewDefault();
+            jobWrapper.RegisterAvatar(avatarBase, ref transformMatrix);
+            jobWrapper.SetLocalBounds(ref transformMatrix, bounds);
+
+            var avatarShape = new AvatarShapeComponent("test-user-id", "TestUser") { IsPreview = isPreview };
+
+            world.Create(avatarShape, transformMatrix, avatarBase, AvatarCustomSkinningComponent.NewWithLocalBounds(bounds));
+            return avatarBase;
+        }
+    }
+}

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/FinishAvatarMatricesCalculationSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/FinishAvatarMatricesCalculationSystemShould.cs
@@ -92,6 +92,24 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
         }
 
         [Test]
+        public void KeepTheMainPlayerAnimatorOffInsideAHideAvatarsArea()
+        {
+            AllowTheSkinningDispatchToReport();
+
+            // Arrange - exempt from culling and in view, so only the modifier-area rule can turn the Animator
+            // off; start animated so the assertion can only pass on a transition the system drove
+            AvatarBase avatarBase = CreateAvatar(IN_FRONT_OF_CAMERA, isPreview: false, out _, isMainPlayer: true, hiddenByModifierArea: true);
+            avatarBase.AvatarAnimator.enabled = true;
+
+            // Act
+            RunFrame();
+
+            // Assert
+            Assert.IsFalse(avatarBase.AvatarAnimator.enabled,
+                "the main player skips culling, so its Animator must still follow the hide-avatars modifier area");
+        }
+
+        [Test]
         public void KeepThePreviewAvatarLiveWhereverThePlayerCameraLooks()
         {
             AllowTheSkinningDispatchToReport();
@@ -162,7 +180,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
         ///     for it, which is what the system tests against.
         /// </summary>
         private AvatarBase CreateAvatar(Vector3 position, bool isPreview, out AvatarTransformMatrixComponent transformMatrix,
-            Bounds? localBounds = null)
+            Bounds? localBounds = null, bool isMainPlayer = false, bool hiddenByModifierArea = false)
         {
             var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(AVATAR_BASE_TEST_ASSET_PATH);
             Assert.IsNotNull(prefab, $"Could not load AvatarBase test prefab from {AVATAR_BASE_TEST_ASSET_PATH}");
@@ -177,10 +195,16 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
             Bounds bounds = localBounds ?? new Bounds(Vector3.zero, Vector3.one);
 
             transformMatrix = AvatarTransformMatrixComponent.NewDefault();
-            jobWrapper.RegisterAvatar(avatarBase, ref transformMatrix);
-            jobWrapper.SetLocalBounds(ref transformMatrix, bounds);
 
-            var avatarShape = new AvatarShapeComponent("test-user-id", "TestUser") { IsPreview = isPreview };
+            if (isMainPlayer)
+                jobWrapper.RegisterMainPlayerAvatar(avatarBase, ref transformMatrix);
+            else
+            {
+                jobWrapper.RegisterAvatar(avatarBase, ref transformMatrix);
+                jobWrapper.SetLocalBounds(ref transformMatrix, bounds);
+            }
+
+            var avatarShape = new AvatarShapeComponent("test-user-id", "TestUser") { IsPreview = isPreview, HiddenByModifierArea = hiddenByModifierArea };
 
             world.Create(avatarShape, transformMatrix, avatarBase, AvatarCustomSkinningComponent.NewWithLocalBounds(bounds));
             return avatarBase;

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/FinishAvatarMatricesCalculationSystemShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/FinishAvatarMatricesCalculationSystemShould.cs
@@ -49,7 +49,6 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
 
         protected override void OnTearDown()
         {
-            LogAssert.ignoreFailingMessages = false;
             jobWrapper.Dispose();
 
             foreach (GameObject createdGameObject in createdGameObjects)
@@ -77,7 +76,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
         [Test]
         public void NotCullAnInWorldAvatarInFrontOfTheCamera()
         {
-            AllowTheSkinningDispatchToReport();
+            ExpectMissingSkinningBuffer();
 
             // Arrange - start culled, so the assertion can only pass on a transition the system drove
             AvatarBase avatarBase = CreateAvatar(IN_FRONT_OF_CAMERA, isPreview: false, out _);
@@ -94,7 +93,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
         [Test]
         public void KeepTheMainPlayerAnimatorOffInsideAHideAvatarsArea()
         {
-            AllowTheSkinningDispatchToReport();
+            ExpectMissingSkinningBuffer();
 
             // Arrange - exempt from culling and in view, so only the modifier-area rule can turn the Animator
             // off; start animated so the assertion can only pass on a transition the system drove
@@ -112,7 +111,7 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
         [Test]
         public void KeepThePreviewAvatarLiveWhereverThePlayerCameraLooks()
         {
-            AllowTheSkinningDispatchToReport();
+            ExpectMissingSkinningBuffer();
 
             // Arrange - same position that culls the in-world avatar above, and start culled so the assertion
             // can only pass on a transition the system drove
@@ -164,9 +163,9 @@ namespace DCL.AvatarRendering.AvatarShape.Tests
         ///     An avatar that is not culled reaches ComputeSkinning, which reports against the placeholder
         ///     skinning component this fixture creates rather than a real one backed by GPU buffers.
         /// </summary>
-        private static void AllowTheSkinningDispatchToReport()
+        private static void ExpectMissingSkinningBuffer()
         {
-            LogAssert.ignoreFailingMessages = true;
+            LogAssert.Expect(LogType.Exception, "Exception: ComputeSkinning error: Cannot get bones (ComputeBuffer)");
         }
 
         private void RunFrame()

--- a/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/FinishAvatarMatricesCalculationSystemShould.cs.meta
+++ b/Explorer/Assets/DCL/AvatarRendering/AvatarShape/Tests/EditMode/FinishAvatarMatricesCalculationSystemShould.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8203db8807f9d14448fa0a33c910faa6

--- a/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetBase.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Loading/Assets/AttachmentAssetBase.cs
@@ -32,6 +32,7 @@ namespace DCL.AvatarRendering.Loading.Assets
         public static readonly ListObjectPool<RendererInfo> RENDERER_INFO_POOL = new (listInstanceDefaultCapacity: 3, defaultCapacity: 500);
 
         private readonly List<RendererInfo> rendererInfos;
+        private readonly HashSet<EntityId> tangentsRecalculatedMeshes = new ();
         public readonly GameObject MainAsset;
 
         public IReadOnlyList<RendererInfo> RendererInfos => rendererInfos;
@@ -50,6 +51,7 @@ namespace DCL.AvatarRendering.Loading.Assets
         protected override void DisposeInternal()
         {
             RENDERER_INFO_POOL.Release(rendererInfos);
+            tangentsRecalculatedMeshes.Clear();
 
             if (ReferenceCount > 0)
                 ProfilingCounters.WearablesAssetsReferencedAmount.Value--;
@@ -59,6 +61,15 @@ namespace DCL.AvatarRendering.Loading.Assets
 
             ProfilingCounters.WearablesAssetsAmount.Value--;
         }
+
+        /// <summary>
+        ///     Marks the tangents of <paramref name="mesh" /> as recalculated, returning true only the first time
+        ///     the mesh is passed in. The marks are kept per asset because the meshes belong to the streamable data
+        ///     this asset references: they are dropped on disposal, before that data is destroyed and the entity ids
+        ///     of its meshes become free for Unity to hand out to newly loaded ones.
+        /// </summary>
+        public bool TryMarkTangentsRecalculated(Mesh mesh) =>
+            tangentsRecalculatedMeshes.Add(mesh.GetEntityId());
 
         public readonly struct RendererInfo
         {

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/WearableAssetShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/WearableAssetShould.cs
@@ -1,5 +1,6 @@
 ﻿using DCL.AvatarRendering.Loading.Assets;
 using DCL.AvatarRendering.Wearables.Helpers;
+using ECS.StreamableLoading;
 using NUnit.Framework;
 using System.Collections.Generic;
 using UnityEngine;
@@ -8,6 +9,17 @@ namespace DCL.AvatarRendering.Wearables.Tests
 {
     public class WearableAssetShould
     {
+        private readonly List<Object> createdObjects = new ();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (Object createdObject in createdObjects)
+                Object.DestroyImmediate(createdObject);
+
+            createdObjects.Clear();
+        }
+
         [TestCase(0)]
         [TestCase(5)]
         public void ProperlyCountReferenceWhenAddReferenceCalled(int refCount)
@@ -40,6 +52,43 @@ namespace DCL.AvatarRendering.Wearables.Tests
 
             // Assert
             Assert.That(wearableAsset.ReferenceCount, Is.EqualTo(remainedRefs));
+        }
+
+        [Test]
+        public void MarkTangentsOfTheSameMeshOnlyOnce()
+        {
+            // Arrange
+            var wearableAsset = new AttachmentRegularAsset(new GameObject(), new List<AttachmentRegularAsset.RendererInfo>(5), IStreamableRefCountData.Null.INSTANCE);
+            var mesh = new Mesh();
+            var anotherMesh = new Mesh();
+            createdObjects.Add(mesh);
+            createdObjects.Add(anotherMesh);
+
+            // Act
+            bool firstMark = wearableAsset.TryMarkTangentsRecalculated(mesh);
+            bool repeatedMark = wearableAsset.TryMarkTangentsRecalculated(mesh);
+            bool anotherMeshMark = wearableAsset.TryMarkTangentsRecalculated(anotherMesh);
+
+            // Assert
+            Assert.That(firstMark, Is.True);
+            Assert.That(repeatedMark, Is.False);
+            Assert.That(anotherMeshMark, Is.True);
+        }
+
+        [Test]
+        public void ForgetMarkedTangentsWhenDisposed()
+        {
+            // Arrange
+            var wearableAsset = new AttachmentRegularAsset(new GameObject(), new List<AttachmentRegularAsset.RendererInfo>(5), IStreamableRefCountData.Null.INSTANCE);
+            var mesh = new Mesh();
+            createdObjects.Add(mesh);
+            wearableAsset.TryMarkTangentsRecalculated(mesh);
+
+            // Act
+            wearableAsset.Dispose();
+
+            // Assert
+            Assert.That(wearableAsset.TryMarkTangentsRecalculated(mesh), Is.True);
         }
     }
 }

--- a/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/WearableAssetShould.cs
+++ b/Explorer/Assets/DCL/AvatarRendering/Wearables/Tests/WearableAssetShould.cs
@@ -25,7 +25,7 @@ namespace DCL.AvatarRendering.Wearables.Tests
         public void ProperlyCountReferenceWhenAddReferenceCalled(int refCount)
         {
             // Arrange
-            var wearableAsset = new AttachmentRegularAsset(new GameObject(), new List<AttachmentRegularAsset.RendererInfo>(5), null);
+            var wearableAsset = new AttachmentRegularAsset(new GameObject(), new List<AttachmentRegularAsset.RendererInfo>(5), IStreamableRefCountData.Null.INSTANCE);
 
             // Act
             for (var i = 0; i < refCount; i++)
@@ -41,7 +41,7 @@ namespace DCL.AvatarRendering.Wearables.Tests
         public void ProperlyRemoveReferenceWhenDereferenced(int initialRefs, int derefs, int remainedRefs)
         {
             // Arrange
-            var wearableAsset = new AttachmentRegularAsset(new GameObject(), new List<AttachmentRegularAsset.RendererInfo>(5), null);
+            var wearableAsset = new AttachmentRegularAsset(new GameObject(), new List<AttachmentRegularAsset.RendererInfo>(5), IStreamableRefCountData.Null.INSTANCE);
 
             for (var i = 0; i < initialRefs; i++)
                 wearableAsset.AddReference();


### PR DESCRIPTION
Combines & superseedes https://github.com/decentraland/unity-explorer/pull/9919 https://github.com/decentraland/unity-explorer/pull/9915 & https://github.com/decentraland/unity-explorer/pull/9914

Re-measured the reworked version on our M4 bench (real scene, 100 avatars, 5v5 interleaved legs, per-leg Mann-Whitney): the three avatar PRs together now measure −8.8% median to −10.3% p99 frame time, fully separated, with remote avatars verified animating — the enabled-gate outperforms the old culling-mode approach, since a culled-mode animator still ticks its state machine while a disabled one costs nothing.