### PR TITLE
chore: better spawn error message with underlying OS error

### DIFF
--- a/Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/macOS/libuuav.dylib
+++ b/Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/macOS/libuuav.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:19504315bd3fce4b3950e9d52ae25897bdebd2f421e8c771628112e9dd09c5e9
+oid sha256:60a3b18ca58c84419cee15c6fb25000009ef24bb3d259dd142a71c5c599833d1
 size 1495744

--- a/Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/x86_64/uuav-helper.exe
+++ b/Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/x86_64/uuav-helper.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e65e1eb93b4846dbc7c33a3e250f772c738950ca5638d5a728cec61029c5aab4
-size 1409024
+oid sha256:f61345dceeaa0824bc80e172b57df3e68dd2618da3ad6036660508fbe957fd1e
+size 1408000

--- a/Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/x86_64/uuav.dll
+++ b/Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/x86_64/uuav.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3406936a8dfe0c2477e70960f266babb14a20c213bcae8971edd629724e3d90c
-size 1326080
+oid sha256:8df1d6145b5f00b1d191d2cbb6378ca305411a3144098acc69efa4358cce8cdd
+size 1325568

--- a/Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/x86_64/uuav_core.dll
+++ b/Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/x86_64/uuav_core.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:60adca10ba61595efbf0b81ce32a193115c41bb6557f6713f6056d79e800a286
-size 1244160
+oid sha256:26374a96cc263a684bde34a2ab3c509af2c12dbc88a6880c05017b20ed47ee14
+size 1243136

--- a/Explorer/Assets/Plugins/UUAV/native/uuav-client/src/lib.rs
+++ b/Explorer/Assets/Plugins/UUAV/native/uuav-client/src/lib.rs
@@ -398,7 +398,7 @@ fn start_session(
                 child.kill();
                 child.wait();
             }
-            return Err(format!("failed to start uuav helper: {e}"));
+            return Err(format!("failed to start uuav helper: {e:#}"));
         }
     };
     let Some(child) = child else {
@@ -788,7 +788,7 @@ pub unsafe extern "C" fn uuav_init(
 
     let unity = match unsafe { platform::capture_probe(texture) } {
         Ok(unity) => Arc::new(unity),
-        Err(e) => return ResultFFI::error(e.to_string()),
+        Err(e) => return ResultFFI::error(format!("{e:#}")),
     };
     #[cfg(target_os = "macos")]
     let adapter = unity.registry_id;
@@ -1498,7 +1498,7 @@ extern "C" fn uuav_render_event(event_id: i32) {
             Err(e) => {
                 client
                     .sinks
-                    .on_player_error(Some(player_id), &format!("present failed: {e}"));
+                    .on_player_error(Some(player_id), &format!("present failed: {e:#}"));
                 return;
             }
         }

--- a/Explorer/Assets/Plugins/UUAV/native/uuav-client/src/spawn.rs
+++ b/Explorer/Assets/Plugins/UUAV/native/uuav-client/src/spawn.rs
@@ -51,7 +51,7 @@ pub fn spawn_helper(
     }
     let child = command
         .spawn()
-        .with_context(|| format!("failed to spawn {}", path.display()))?;
+        .map_err(|e| anyhow::anyhow!("failed to spawn {}: {}", path.display(), e))?;
     drop(handoff);
     Ok(HelperChild(child))
 }
@@ -180,7 +180,7 @@ pub fn spawn_helper(handoff: ChildHandoff, token: &str) -> Result<HelperChild> {
                 &startup.StartupInfo,
                 &mut process_info,
             )
-            .with_context(|| format!("failed to spawn {}", path.display()))?;
+            .map_err(|e| anyhow::anyhow!("failed to spawn {}: {}", path.display(), e))?;
             Ok(process_info)
         })
     };

--- a/Explorer/Assets/Plugins/UUAV/native/uuav-client/src/spawn.rs
+++ b/Explorer/Assets/Plugins/UUAV/native/uuav-client/src/spawn.rs
@@ -51,7 +51,7 @@ pub fn spawn_helper(
     }
     let child = command
         .spawn()
-        .map_err(|e| anyhow::anyhow!("failed to spawn {}: {}", path.display(), e))?;
+        .with_context(|| format!("failed to spawn {}", path.display()))?;
     drop(handoff);
     Ok(HelperChild(child))
 }
@@ -180,7 +180,7 @@ pub fn spawn_helper(handoff: ChildHandoff, token: &str) -> Result<HelperChild> {
                 &startup.StartupInfo,
                 &mut process_info,
             )
-            .map_err(|e| anyhow::anyhow!("failed to spawn {}: {}", path.display(), e))?;
+            .with_context(|| format!("failed to spawn {}", path.display()))?;
             Ok(process_info)
         })
     };

--- a/scripts/uuav/uuav-binaries.lock.json
+++ b/scripts/uuav/uuav-binaries.lock.json
@@ -81,7 +81,7 @@
       "suffix": [
         ".rs"
       ],
-      "sha256": "f4bb051caccc4da24678cf2c05087813c840ed2407c08f49b15aff991312ae29",
+      "sha256": "c2193180bf16d908580a4ff82b63660b36bbb12b557c66a339734084eefe4743",
       "entries": 10
     },
     "server_source": {
@@ -146,7 +146,7 @@
         ],
         "source_digest": "597277eebf8697f849e019fcb15492aef1d1a64a90bc082125377dd0f55c25c5",
         "source_files": 21,
-        "repo_commit": "785315ae54493c54877f65747070bc4df9f28dc6"
+        "repo_commit": "c436eb6533ec729157045aabbfbee2790fe76990"
       },
       "ffmpeg": {
         "provenance": "built-from-source",
@@ -219,7 +219,7 @@
         },
         {
           "path": "Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/macOS/libuuav.dylib",
-          "sha256": "19504315bd3fce4b3950e9d52ae25897bdebd2f421e8c771628112e9dd09c5e9",
+          "sha256": "60a3b18ca58c84419cee15c6fb25000009ef24bb3d259dd142a71c5c599833d1",
           "bytes": 1495744,
           "produced_by": "cargo"
         },
@@ -246,7 +246,7 @@
         "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
         "source_digest": "597277eebf8697f849e019fcb15492aef1d1a64a90bc082125377dd0f55c25c5",
         "source_files": 21,
-        "repo_commit": "785315ae54493c54877f65747070bc4df9f28dc6",
+        "repo_commit": "c436eb6533ec729157045aabbfbee2790fe76990",
         "toolchain": {
           "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
           "cargo": "cargo 1.97.1 (c980f4866 2026-06-30)",
@@ -308,20 +308,20 @@
         },
         {
           "path": "Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/x86_64/uuav.dll",
-          "sha256": "3406936a8dfe0c2477e70960f266babb14a20c213bcae8971edd629724e3d90c",
-          "bytes": 1326080,
+          "sha256": "8df1d6145b5f00b1d191d2cbb6378ca305411a3144098acc69efa4358cce8cdd",
+          "bytes": 1325568,
           "produced_by": "cargo"
         },
         {
           "path": "Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/x86_64/uuav_core.dll",
-          "sha256": "60adca10ba61595efbf0b81ce32a193115c41bb6557f6713f6056d79e800a286",
-          "bytes": 1244160,
+          "sha256": "26374a96cc263a684bde34a2ab3c509af2c12dbc88a6880c05017b20ed47ee14",
+          "bytes": 1243136,
           "produced_by": "cargo"
         },
         {
           "path": "Explorer/Assets/Plugins/UUAV/Packages/UUAV/Runtime/Plugins/x86_64/uuav-helper.exe",
-          "sha256": "e65e1eb93b4846dbc7c33a3e250f772c738950ca5638d5a728cec61029c5aab4",
-          "bytes": 1409024,
+          "sha256": "f61345dceeaa0824bc80e172b57df3e68dd2618da3ad6036660508fbe957fd1e",
+          "bytes": 1408000,
           "produced_by": "cargo"
         }
       ]


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Makes UUAV native-layer failures debuggable by rendering the **full anyhow error chain** wherever errors cross into plain strings, instead of only the outermost message.

- `uuav-client/src/lib.rs`: the three places that flatten `anyhow::Error` into user-visible strings now use the alternate format `{e:#}` (renders `outer: cause: cause`):
  - `start_session` — `failed to start uuav helper: ...` now carries the underlying cause for *every* failure inside `spawn_helper`, `Connection::establish` and the Windows sandbox setup (~40 `.context(...)` sites), not just the top-level step name;
  - `uuav_init` — `capture_probe` failures at init;
  - `uuav_render_event` — `present failed: ...`.
- `uuav-client/src/spawn.rs`: reverted to `with_context` at both spawn sites (macOS `Command::spawn`, Windows `CreateProcessAsUserW`) so the OS error stays attached as the chain's `source()` rather than being flattened into text at the spawn site.
- Relocked the prebuilt native binaries from CI run [33495481895](https://github.com/decentraland/unity-explorer/actions/runs/33495481895) (`uuav-binaries.lock.json` + macOS `libuuav.dylib` + all three Windows cargo artifacts). Gate A/Gate B and `UUAV Binary Verification` are green on the follow-up run.

## Why — and what it immediately found

Before, a macOS helper-spawn failure reported only `failed to start uuav helper: failed to spawn <path>` with the OS error dropped at the FFI boundary. With the chain rendered, the same failure reads:

```
[UUAV] init: failed to start uuav helper: failed to spawn .../Decentraland.app/Contents/PlugIns/uuav-helper: Permission denied (os error 13)
```

That `os error 13` exposed a real production bug: **the macOS launcher strips Unix file modes when extracting the build**, so `uuav-helper` ships without its executable bit — helper spawn (and therefore video playback) has never worked through DecentralandLauncherLight on macOS since UUAV first shipped in `v0.168.0-alpha`. The release artifact itself is correct (the tar inside `Decentraland_macos.zip` records `rwxr-xr-x`); only launcher-extracted installs are affected. Root-cause fix: decentraland/launcher-rust#342.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run 9930
```

**Expected result**: video playback works as before (no behavioral change; this PR only changes error message formatting). To see the improved diagnostics, break the helper deliberately (e.g. `chmod -x` on `Contents/PlugIns/uuav-helper` in the installed app on macOS) and open a scene with video: the error toast/log now includes the underlying OS error (`Permission denied (os error 13)`), instead of a bare `failed to start uuav helper`.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered (error-path only)
- [ ] For SDK features: Test scene is included (n/a)
