### PR TITLE
fix: keep friend request notifications alive after the first update

### DIFF
--- a/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
+++ b/Explorer/Assets/DCL/AuthenticationScreenFlow/Tests/ProfileFetchingAuthStateShould.cs
@@ -173,6 +173,8 @@ namespace DCL.AuthenticationScreenFlow.Tests
 
             public event Action<Profile>? ProfilePropagated;
 
+            public Profile? OwnProfile => null;
+
             public async UniTask<Profile?> ProfileAsync(CancellationToken ct)
             {
                 CapturedTokens.Add(ct);
@@ -198,6 +200,8 @@ namespace DCL.AuthenticationScreenFlow.Tests
             public int Calls { get; private set; }
 
             public event Action<Profile>? ProfilePropagated;
+
+            public Profile? OwnProfile => null;
 
             public UniTask<Profile?> ProfileAsync(CancellationToken ct)
             {

--- a/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
+++ b/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
@@ -109,8 +109,15 @@ namespace DCL.Friends
                                 // This stream is ack-driven: the server sends the next update only after this one
                                 // is consumed, so a hung await here silently starves every subsequent update.
                                 // Prefer the cached profile and bound the fallback fetch
-                                Profile? myProfile = selfProfile.OwnProfile
-                                                     ?? await selfProfile.ProfileAsync(ct).Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
+                                Profile? myProfile = selfProfile.OwnProfile;
+
+                                if (myProfile == null)
+                                {
+                                    myProfile = await selfProfile.ProfileAsync(ct).Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
+
+                                    // The fetch may resume on a background thread; the broadcast below requires the main thread
+                                    await UniTask.SwitchToMainThread(ct);
+                                }
 
                                 if (myProfile == null)
                                 {

--- a/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
+++ b/Explorer/Assets/DCL/Friends/RPCFriendsService.cs
@@ -65,6 +65,10 @@ namespace DCL.Friends
                 {
                     try
                     {
+                        // Stream updates arrive on the transport's background thread, while the broadcasts
+                        // below reach UI subscribers that require the main thread
+                        await UniTask.SwitchToMainThread(ct);
+
                         switch (response.UpdateCase)
                         {
                             case FriendshipUpdate.UpdateOneofCase.Accept:
@@ -102,13 +106,23 @@ namespace DCL.Friends
                                     break;
                                 }
 
-                                Profile? myProfile = await selfProfile.ProfileAsync(ct);
+                                // This stream is ack-driven: the server sends the next update only after this one
+                                // is consumed, so a hung await here silently starves every subsequent update.
+                                // Prefer the cached profile and bound the fallback fetch
+                                Profile? myProfile = selfProfile.OwnProfile
+                                                     ?? await selfProfile.ProfileAsync(ct).Timeout(TimeSpan.FromSeconds(FOREGROUND_TIMEOUT_SECONDS));
+
+                                if (myProfile == null)
+                                {
+                                    ReportHub.LogWarning(ReportCategory.FRIENDS, "Ignoring incoming friend request: own profile is not resolved");
+                                    break;
+                                }
 
                                 var fr = new FriendRequest(
                                     request.Id,
                                     DateTimeOffset.FromUnixTimeMilliseconds(request.CreatedAt).DateTime,
                                     requesterProfile.Value,
-                                    myProfile!.Compact,
+                                    myProfile.Compact,
                                     request.HasMessage ? request.Message : string.Empty);
 
                                 eventBus.BroadcastFriendRequestReceived(fr);

--- a/Explorer/Assets/DCL/Notifications/NewNotification/NewNotificationController.cs
+++ b/Explorer/Assets/DCL/Notifications/NewNotification/NewNotificationController.cs
@@ -150,58 +150,72 @@ namespace DCL.Notifications.NewNotification
             if (viewInstance == null)
                 return;
 
-            while (notificationQueue.Count > 0)
+            isDisplaying = true;
+
+            try
             {
-                isDisplaying = true;
-                INotification notification = notificationQueue.Dequeue();
-                displayingNotificationType = notification.Type;
-
-                switch (notification.Type)
+                while (notificationQueue.Count > 0)
                 {
-                    case NotificationType.INTERNAL_ARRIVED_TO_DESTINATION:
-                    case NotificationType.INTERNAL_SERVER_ERROR:
-                    case NotificationType.INTERNAL_SCENE_CLIPBOARD_WRITE:
-                        await ProcessArrivedNotificationAsync(notification);
-                        break;
-                    case NotificationType.COMMUNITY_VOICE_CHAT_STARTED:
-                        if (FeaturesRegistry.Instance.IsEnabled(FeatureId.CommunityVoiceChat))
-                            await ProcessCommunityVoiceChatStartedNotificationAsync(notification);
+                    INotification notification = notificationQueue.Dequeue();
+                    displayingNotificationType = notification.Type;
 
-                        break;
-                    case NotificationType.BADGE_GRANTED:
-                        await ProcessBadgeNotificationAsync(notification);
-                        break;
-                    case NotificationType.SOCIAL_SERVICE_FRIENDSHIP_REQUEST:
-                    case NotificationType.SOCIAL_SERVICE_FRIENDSHIP_ACCEPTED:
-                        await ProcessFriendsNotificationAsync(notification);
-                        break;
-                    case NotificationType.CREDITS_GOAL_COMPLETED:
-                        await ProcessMarketplaceCreditsNotificationAsync(notification);
-                        break;
-                    case NotificationType.INTERNAL_DEFAULT_SUCCESS:
-                        await ProcessArrivedNotificationAsync(notification, false);
-                        break;
-                    case NotificationType.TRANSFER_RECEIVED:
-                        await ProcessGiftNotificationAsync(notification);
-                        break;
-                    case NotificationType.TIP_RECEIVED:
-                        await ProcessTipReceivedNotificationAsync(notification);
-                        break;
-                    case NotificationType.BAN_WARNING:
-                    case NotificationType.BANNED:
-                    case NotificationType.BAN_LIFTED:
-                        await ProcessPersistentNotificationAsync(notification);
-                        break;
-                    default:
-                        await ProcessDefaultNotificationAsync(notification);
-                        break;
+                    try
+                    {
+                        switch (notification.Type)
+                        {
+                            case NotificationType.INTERNAL_ARRIVED_TO_DESTINATION:
+                            case NotificationType.INTERNAL_SERVER_ERROR:
+                            case NotificationType.INTERNAL_SCENE_CLIPBOARD_WRITE:
+                                await ProcessArrivedNotificationAsync(notification);
+                                break;
+                            case NotificationType.COMMUNITY_VOICE_CHAT_STARTED:
+                                if (FeaturesRegistry.Instance.IsEnabled(FeatureId.CommunityVoiceChat))
+                                    await ProcessCommunityVoiceChatStartedNotificationAsync(notification);
+
+                                break;
+                            case NotificationType.BADGE_GRANTED:
+                                await ProcessBadgeNotificationAsync(notification);
+                                break;
+                            case NotificationType.SOCIAL_SERVICE_FRIENDSHIP_REQUEST:
+                            case NotificationType.SOCIAL_SERVICE_FRIENDSHIP_ACCEPTED:
+                                await ProcessFriendsNotificationAsync(notification);
+                                break;
+                            case NotificationType.CREDITS_GOAL_COMPLETED:
+                                await ProcessMarketplaceCreditsNotificationAsync(notification);
+                                break;
+                            case NotificationType.INTERNAL_DEFAULT_SUCCESS:
+                                await ProcessArrivedNotificationAsync(notification, false);
+                                break;
+                            case NotificationType.TRANSFER_RECEIVED:
+                                await ProcessGiftNotificationAsync(notification);
+                                break;
+                            case NotificationType.TIP_RECEIVED:
+                                await ProcessTipReceivedNotificationAsync(notification);
+                                break;
+                            case NotificationType.BAN_WARNING:
+                            case NotificationType.BANNED:
+                            case NotificationType.BAN_LIFTED:
+                                await ProcessPersistentNotificationAsync(notification);
+                                break;
+                            default:
+                                await ProcessDefaultNotificationAsync(notification);
+                                break;
+                        }
+                    }
+                    catch (OperationCanceledException) { }
+
+                    // A notification that fails to display must not kill the loop: the queue keeps
+                    // being consumed and later notifications still show
+                    catch (Exception e) { ReportHub.LogException(e, ReportCategory.UI); }
+
+                    // The natural-expiry counterpart to the reset in StopAnimation, which covers early dismissal.
+                    displayingNotificationType = null;
                 }
-
-                // The natural-expiry counterpart to the reset in StopAnimation, which covers early dismissal.
-                displayingNotificationType = null;
             }
-
-            isDisplaying = false;
+            finally
+            {
+                isDisplaying = false;
+            }
         }
 
         private async UniTask ProcessGiftNotificationAsync(INotification notification)

--- a/Explorer/Assets/DCL/Notifications/NewNotification/NewNotificationController.cs
+++ b/Explorer/Assets/DCL/Notifications/NewNotification/NewNotificationController.cs
@@ -4,7 +4,6 @@ using DCL.NotificationsBus;
 using DCL.NotificationsBus.NotificationTypes;
 using DCL.FeatureFlags;
 using DCL.UI;
-using DCL.WebRequests;
 using DG.Tweening;
 using MVC;
 using System;

--- a/Explorer/Assets/DCL/Profiles/Self/ISelfProfile.cs
+++ b/Explorer/Assets/DCL/Profiles/Self/ISelfProfile.cs
@@ -8,6 +8,11 @@ namespace DCL.Profiles.Self
     {
         public event Action<Profile>? ProfilePropagated;
 
+        /// <summary>
+        ///     The own profile resolved from the cache. Can be null if the profile hasn't been fetched yet.
+        /// </summary>
+        Profile? OwnProfile { get; }
+
         UniTask<Profile?> ProfileAsync(CancellationToken ct);
         UniTask<Profile?> UpdateProfileAsync(CancellationToken ct, bool updateAvatarInWorld = true);
         UniTask<Profile?> UpdateProfileAsync(Profile profile, CancellationToken ct, bool updateAvatarInWorld = true);


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes #9830: after the first friend request, the notification toast and badge stop appearing until the client is restarted.

Three independent failure points combined to cause this:

- **`RPCFriendsService` stream starvation.** The friendship-updates RPC stream is ack-driven: the server only sends the next update after the current one is consumed. The consumer loop awaited an unbounded self-profile fetch (`ProfileAsync`) that could hang forever (a pending same-id request in `RealmProfileRepository` blocks all later fetches of that id), silently starving every subsequent update with no exception and no log. The loop now resolves the own profile cache-first via `ISelfProfile.OwnProfile`, falls back to a fetch bounded by a timeout, and skips the update with a warning if the profile cannot be resolved.
- **`RPCFriendsService` off-main-thread broadcasts.** Stream items arrive on the transport's background thread; only the Request case happened to reach the main thread (by accident, through a `SwitchToMainThread` in a `finally` inside the profile repository). Accept/Cancel/Reject/Delete broadcast off-thread and the resulting `UnityException` was swallowed into the disabled FRIENDS log category. Every friendship update now switches to the main thread before broadcasting to UI subscribers.
- **`NewNotificationController` had no failure isolation.** One notification that threw during display exited the loop with `isDisplaying` stuck at `true`, silently dropping every later toast. Each notification is now processed inside its own try/catch (cancellation ignored, other exceptions reported via `ReportHub`), and `isDisplaying` is reset in a `finally` so the loop can always restart.

Supporting change: `ISelfProfile` now exposes the cached `OwnProfile` getter (the implementation already had it), and the auth-screen test fakes implement it.

Not touched (known follow-up): the connectivity and block streams in the same file share the off-main-thread broadcast pattern.

## Test Instructions

You need two accounts: your main one in the Explorer, and a second one (for example in the web client) to send friend requests from.

### Test Steps
1. Log in to the Explorer with account A and stay logged in.
2. From account B, send a friend request to A.
3. Check that A sees the notification toast and the notification badge.
4. From account B, cancel the request and send it again (or use a third account to send a new one).
5. Check that A sees a toast and badge for this second request too. Before this fix, only the first request ever produced a notification; everything after it was silent.
6. Repeat a couple more times, including accepting one of the requests, and confirm every request and the acceptance keep producing notifications.

**Expected result**: every friend request shows a notification, not just the first one, without restarting the client.

### Additional Testing Notes
- Let the client sit idle for a few minutes between requests; notifications should still arrive.
- Also worth a quick pass over other notification types (badges, tips, gifts) to confirm toasts still display normally.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does, especially useful for first-time contributors.
