### PR TITLE
fix: anr pulse host resolution

### DIFF
--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/ENet/ENetTransport.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/ENet/ENetTransport.cs
@@ -142,7 +142,7 @@ namespace DCL.Multiplayer.Connections.Pulse.ENet
                                       .AttachExternalCancellation(ct)
                                       .Timeout(TimeSpan.FromMilliseconds(options.ConnectTimeoutMs));
             }
-            catch (SocketException e)
+            catch (Exception e) when (e is not OperationCanceledException)
             {
                 throw new PulseHostResolutionException(hostName, e);
             }

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/ENet/ENetTransport.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/ENet/ENetTransport.cs
@@ -5,6 +5,8 @@ using ENet;
 using Google.Protobuf;
 using Pulse.Transport;
 using System;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Utility;
@@ -90,7 +92,7 @@ namespace DCL.Multiplayer.Connections.Pulse.ENet
             }
         }
 
-        public async UniTask ConnectAsync(string ip, int port, CancellationToken ct)
+        public async UniTask ConnectAsync(string hostName, int port, CancellationToken ct)
         {
             if (!isLibInitialized)
             {
@@ -100,10 +102,12 @@ namespace DCL.Multiplayer.Connections.Pulse.ENet
                 isLibInitialized = true;
             }
 
+            string resolvedIp = await ResolveIPv4Async(hostName, ct);
+
             host = new Host();
 
             var address = new Address();
-            address.SetHost(ip);
+            address.SetHost(resolvedIp);
             address.Port = (ushort)port;
 
             host.Create(peerLimit: 1, channelLimit: ENetChannel.COUNT);
@@ -124,6 +128,32 @@ namespace DCL.Multiplayer.Connections.Pulse.ENet
             }
         }
 
+        private async UniTask<string> ResolveIPv4Async(string hostName, CancellationToken ct)
+        {
+            if (IPAddress.TryParse(hostName, out IPAddress? literal))
+                return literal.ToString();
+
+            IPAddress[] candidates;
+
+            try
+            {
+                candidates = await Dns.GetHostAddressesAsync(hostName)
+                                      .AsUniTask()
+                                      .AttachExternalCancellation(ct)
+                                      .Timeout(TimeSpan.FromMilliseconds(options.ConnectTimeoutMs));
+            }
+            catch (SocketException e)
+            {
+                throw new PulseHostResolutionException(hostName, e);
+            }
+
+            foreach (IPAddress candidate in candidates)
+                if (candidate.AddressFamily == AddressFamily.InterNetwork)
+                    return candidate.ToString();
+
+            throw new PulseHostResolutionException(hostName);
+        }
+
         internal async UniTask ForceDisconnectAsync()
         {
             lifeCycleCts.SafeCancelAndDispose();
@@ -138,6 +168,7 @@ namespace DCL.Multiplayer.Connections.Pulse.ENet
         public UniTask DisconnectAsync(DisconnectReason reason) =>
             DisconnectAsync(reason, false).AsUniTask();
 
+        /// <param name="reason">Reported to the peer as the disconnection cause</param>
         /// <param name="spinThread">If true: Wait on the same thread; if false - async Yield</param>
         private async Task DisconnectAsync(DisconnectReason reason, bool spinThread)
         {
@@ -192,6 +223,7 @@ namespace DCL.Multiplayer.Connections.Pulse.ENet
         ///     The listener loop must be gracefully finalized before other ENet manipulations to prevent race conditions
         /// </summary>
         /// <param name="servingHost">The currently serving host, the class field might be changed on disconnection/reconnection</param>
+        /// <param name="ct">Cancelled to exit the loop and release the host</param>
         private async UniTask ListenForIncomingDataAsync(Host servingHost, CancellationToken ct)
         {
             Volatile.Write(ref listenLoopIsActive, true);

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseHostResolutionException.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseHostResolutionException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace DCL.Multiplayer.Connections.Pulse
+{
+    public class PulseHostResolutionException : Exception
+    {
+        public PulseHostResolutionException(string hostName)
+            : base($"Cannot resolve '{hostName}' to an IPv4 address") { }
+
+        public PulseHostResolutionException(string hostName, Exception innerException)
+            : base($"Cannot resolve '{hostName}'", innerException) { }
+    }
+}

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseHostResolutionException.cs.meta
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseHostResolutionException.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f2509149d8d6c4b4f95807151e1e5a75

--- a/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseMultiplayerService.cs
+++ b/Explorer/Assets/DCL/Multiplayer/Connections/Pulse/PulseMultiplayerService.cs
@@ -129,7 +129,7 @@ namespace DCL.Multiplayer.Connections.Pulse
                     ReportHub.LogWarning(ReportCategory.MULTIPLAYER, $"Pulse connection failed terminally, no retry: {e.Message}");
                     return false;
                 }
-                catch (Exception e) when (e is TimeoutException or PulseHandshakeDisconnectedException)
+                catch (Exception e) when (e is TimeoutException or PulseHostResolutionException or PulseHandshakeDisconnectedException)
                 {
                     if (attempt >= maxAttempts)
                     {


### PR DESCRIPTION
## What does this PR change?

`ENetTransport.ConnectAsync` passed a hostname straight to `Address.SetHost`, which resolves it with a blocking `getaddrinfo`. The method had no `await` before that call, so the resolve ran on Unity's main thread and froze the client for as long as the OS resolver took — long enough to trip the 2.5 s ANR watchdog on slow networks.

A minidump attached to the ANR issue confirmed it: main thread parked in a wait with `dnsapi`, `rpcrt4` and `enet` on the stack, 4 s into avatar loading.

**Now the host is resolved asynchronously in the thread-pool and `SetHost` receives an IP literal, which needs no resolver.**

This fixes one cause of ANRs during load, not the whole issue — several unrelated causes share the same Sentry group, so it stays open after this merges (referenced without a closing keyword deliberately).

- Issue: [UNITY-EXPLORER-PBX](https://decentraland.sentry.io/issues/UNITY-EXPLORER-PBX)
- The event whose minidump confirmed this cause: [93f805e2](https://decentraland.sentry.io/issues/UNITY-EXPLORER-PBX/events/93f805e2ebe642a7ba02326442b348ad/)

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**: multiplayer works as before — other players visible, movement and chat sync.

## Quality Checklist
- [ ] Changes have been tested locally — **not verified by the author; needs the DNS-stall scenario above**
- [x] Documentation has been updated (if required) — n/a
- [x] Performance impact has been considered — one async resolve added to connect; no main-thread blocking work
- [x] For SDK features: Test scene is included — n/a
