### PR TITLE
fix: stop Sentry's managed ANR watchdog running alongside DclAnrIntegration

### DIFF
--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryBuildTimeConfiguration.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryBuildTimeConfiguration.cs
@@ -29,7 +29,10 @@ namespace DCL.Diagnostics.Sentry
             DclAnrIntegration anrIntegration = new DclAnrIntegration(monoInstance);
             options.AddIntegration(anrIntegration);
 
-            // Sentry 4.9.0 deprecated DisableAnrIntegration() in favour of this property.
+            // DclAnrIntegration above is the only ANR reporter we want. This property gates the
+            // NATIVE app-hang detector only -- Sentry's managed C# watchdog is switched off via
+            // AnrDetectionEnabled in SentryOptions.asset, because ScriptableSentryUnityOptions adds
+            // that integration before this configuration runs.
             options.EnableAppHangTracking = false;
 
 #if UNITY_EDITOR

--- a/Explorer/Assets/Resources/Sentry/SentryOptions.asset
+++ b/Explorer/Assets/Resources/Sentry/SentryOptions.asset
@@ -57,7 +57,7 @@ MonoBehaviour:
   <SampleRate>k__BackingField: 1
   <ShutdownTimeout>k__BackingField: 2000
   <MaxQueueItems>k__BackingField: 30
-  <AnrDetectionEnabled>k__BackingField: 1
+  <AnrDetectionEnabled>k__BackingField: 0
   <AnrTimeout>k__BackingField: 5000
   <CaptureFailedRequests>k__BackingField: 1
   <FailedRequestStatusCodes>k__BackingField: f401000057020000


### PR DESCRIPTION
## What does this PR change?

Fixes a regression that reached `dev` with the Unity 6.5 upgrade (#9871, squashed as `78705998b4`).

That PR bumped `io.sentry.unity` 4.0.0 → 4.9.0, which deprecated `DisableAnrIntegration()`. The call was replaced with `options.EnableAppHangTracking = false` on the strength of the deprecation message. **The two are not equivalent.**

| | what it does |
|---|---|
| `DisableAnrIntegration()` | literally `options.RemoveIntegration<AnrIntegration>()` — removed Sentry's **managed C#** watchdog |
| `EnableAppHangTracking` | only feeds `NativeAppHangTrackingEnabled` — the **native** app-hang detector in `sentry-native` / `sentry-cocoa` |

`ScriptableSentryUnityOptions` adds `AnrIntegration` when `AnrDetectionEnabled` is set, and it does so **before** `OptionsConfiguration` runs — so `Configure()` never had a chance to prevent it, only to remove it after the fact. With the removal gone, Sentry's watchdog has been running **alongside** `DclAnrIntegration`: two watchdog threads and duplicate ANR events.

`EnableAppHangTracking` is also not serialized in `SentryOptions.asset`, so it was already `false` by compiled default — the replacement line was a no-op as well as the wrong lever.

### The fix

Clear `AnrDetectionEnabled` in `SentryOptions.asset` so the integration is never added in the first place. That avoids re-introducing the obsolete API — the property is `[Obsolete]` in code, but setting the serialized field raises no `CS0618` — and `PersistIntoAssetFile` only writes `Enabled`/`Release`/`Dsn`/`Environment`, so it will not silently revert the flag.

`EnableAppHangTracking = false` is kept deliberately: we do not want Sentry's native app-hang detector either, since `DclAnrIntegration` already reports ANRs with minidumps and callstacks. The comment now says what the property actually gates.

## Test Instructions

**Expected result**: exactly one ANR report per hang, from `DclAnrIntegration` (mechanism `MainThreadWatchdog`), with a minidump attached. Before this change a hang could produce two events.

### Test Steps
1. Run a build with Sentry enabled and a DSN configured.
2. Induce a main-thread hang longer than the 5 s threshold.
3. In Sentry, confirm a single ANR issue arrives, tagged with the `MainThreadWatchdog` mechanism, and that no second issue arrives from Sentry's own ANR integration.
4. Confirm normal error reporting and breadcrumbs still work.

### Additional Testing Notes

Verified by reading `getsentry/sentry-unity` at tag `4.9.0`: `SentryUnityOptionsExtensions.cs:108`, `SentryUnityOptions.cs:243-260`, `ScriptableSentryUnityOptions.cs:127` and `:304-310`. **Not** verified at runtime — no ANR was reproduced against a build, so the "duplicate events" consequence is derived from the source path rather than observed.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included