### PR TITLE
ci(inworld): grant id-token to the InWorld caller

### DIFF
--- a/.github/workflows/in-world-tests.yml
+++ b/.github/workflows/in-world-tests.yml
@@ -189,12 +189,14 @@ jobs:
     # explorer-automation that touch it cannot change release validation here.
     uses: decentraland/explorer-automation/.github/workflows/run-inworld-suite.yml@main
     # Must be a superset of run-inworld-suite.yml's own `permissions:`, or the
-    # call dies at startup. The write is the CI status comment section it
-    # upserts (or the standalone comment it falls back to); this is the only
-    # job that needs one, hence per job rather than at the top of the file.
+    # call dies at startup. pull-requests:write is the CI status comment section
+    # it upserts (or the standalone comment it falls back to); id-token:write is
+    # the AWS OIDC the reusable assumes to provision the fixture. This is the
+    # only job that needs them, hence per job rather than at the top of the file.
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     with:
       build_url: ${{ needs.resolve.outputs.build_url }}
       filter: ${{ inputs.filter || '' }}


### PR DESCRIPTION
## What & why

Release/hotfix PRs into `main` have been failing the **In-World Tests** check with `startup_failure` (the workflow never starts, no jobs, no InWorld gate).

Cause: [explorer-automation#74](https://github.com/decentraland/explorer-automation/pull/74) added `id-token: write` to `run-inworld-suite.yml`'s permissions (AWS OIDC used to provision the E2E fixture). GitHub requires a reusable-workflow caller to grant a **superset** of the callee's permissions, or the call dies at startup. This caller only granted `contents: read` + `pull-requests: write`, so since that merged, every release PR's InWorld run fails to start.

This grants `id-token: write` on the calling job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)