### PR TITLE
DO NOT MERGE: sign auth-server requests with the ephemeral key

### DIFF
--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.EthRequest.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.EthRequest.cs
@@ -15,6 +15,9 @@ namespace DCL.Web3.Authenticators
             public object[] @params;
 #pragma warning restore UAC1001
 
+            // Unix time in milliseconds covered by the signed auth chain together with method and params.
+            public long timestamp;
+
             public AuthLink[] authChain;
         }
     }

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/Dapp/DappWeb3EthereumApi.cs
@@ -350,11 +350,17 @@ namespace DCL.Web3.Authenticators
 
                 await ConnectToAuthApiAsync();
 
+                // The ephemeral key signs method, params and timestamp so the server can tell this request apart from a reused delegation.
+                long timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                string signedPayload = $"{request.method}:{JsonConvert.SerializeObject(request.@params, Formatting.None)}:{timestamp}".ToLowerInvariant();
+                using AuthChain signedChain = identityCache.Identity!.Sign(signedPayload);
+
                 SignatureIdResponse authenticationResponse = await RequestEthMethodWithSignatureAsync(new AuthorizedEthApiRequest
                 {
                     method = request.method,
                     @params = request.@params,
-                    authChain = identityCache.Identity!.AuthChain.ToArray(),
+                    timestamp = timestamp,
+                    authChain = signedChain.ToArray(),
                 }, ct);
 
                 DateTime signatureExpiration = DateTime.UtcNow.AddMinutes(5);


### PR DESCRIPTION
Wallet requests sent to auth-server over the socket (`DappWeb3EthereumApi.SendWithConfirmationAsync`) now carry a `timestamp` and an auth chain signed by the ephemeral key over `method:params:timestamp`, so the server can tell a fresh request from a reused delegation. `AuthorizedEthApiRequest` gains the `timestamp` field.

Depends on decentraland/auth-server#145: the current server rejects the extra field, so this must not ship before the server does. The server re-serializes `params` with `JSON.stringify`; this code uses Newtonsoft compact serialization, which has to stay byte-identical for the payloads scenes send. Not compiled in Unity here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
