### PR TITLE
fix: repoint avatar preview renderer to renderfeatures main, and fix GeoffNoise.hlsl import error

### DIFF
--- a/Explorer/Assets/DCL/Landscape/Shaders/GeoffNoise.hlsl
+++ b/Explorer/Assets/DCL/Landscape/Shaders/GeoffNoise.hlsl
@@ -1,7 +1,10 @@
 ﻿#if !GEOFFNOISE_INCLUDED
 #define GEOFFNOISE_INCLUDED
 
-#if SHADER_TARGET
+// SHADER_TARGET is only defined while a shader is being compiled, so it cannot
+// distinguish HLSL from C# when Unity syntax-checks this .hlsl at asset import.
+// CSHARP_7_3_OR_NEWER is defined for every C# compilation and never in HLSL.
+#if !CSHARP_7_3_OR_NEWER
 #define internal
 #define private
 #define static
@@ -620,7 +623,7 @@ namespace Decentraland.Terrain
             float value = 0.0f;
             float3 derivative = float3(0.0f, 0.0f, 0.0f);
 
-            #if SHADER_TARGET
+            #if !CSHARP_7_3_OR_NEWER
                 // Pre-computed rotation matrices to avoid accumulation
                 static const float3x3 rotations[8] = {
                     float3x3(1.00f, 0.00f, 0.00f,  0.00f, 1.00f, 0.00f,  0.00f, 0.00f, 1.00f),
@@ -690,7 +693,7 @@ namespace Decentraland.Terrain
                 clamp(PositionIn.z, TerrainBounds.y, TerrainBounds.w));
         }
 
-        #if !SHADER_TARGET
+        #if CSHARP_7_3_OR_NEWER
         private static float SampleBilinearClamp(NativeArray<byte> texture, int2 textureSize, float2 uv)
         {
             uv = uv * textureSize - 0.5f;
@@ -707,7 +710,7 @@ namespace Decentraland.Terrain
         }
         #endif
 
-        #if !SHADER_TARGET
+        #if CSHARP_7_3_OR_NEWER
         private static float GetOccupancy(NativeArray<byte> occupancyMap, int2 occupancyMapSize, float3 PositionIn, RectInt bounds, int parcelSize)
         {
             float2 scale = 1f / ((float2(bounds.width, bounds.height) + 2f) * parcelSize);
@@ -785,7 +788,7 @@ namespace Decentraland.Terrain
             return terrain( float3(x, 0.0f, z), frequencyCS, octaves).yzw;
         }
 
-#if !SHADER_TARGET
+#if CSHARP_7_3_OR_NEWER
     }
 }
 #endif

--- a/avatar-preview-renderer/Packages/manifest.json
+++ b/avatar-preview-renderer/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.unity.render-pipelines.universal": "17.5.0",
     "com.unity.test-framework": "1.7.0",
     "com.unity.visualeffectgraph": "17.5.0",
-    "decentraland.renderfeatures": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures#chore/unity-6-5",
+    "decentraland.renderfeatures": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.adaptiveperformance": "1.0.0",
     "com.unity.modules.ai": "1.0.0",

--- a/avatar-preview-renderer/Packages/packages-lock.json
+++ b/avatar-preview-renderer/Packages/packages-lock.json
@@ -195,11 +195,11 @@
       }
     },
     "decentraland.renderfeatures": {
-      "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures#chore/unity-6-5",
+      "version": "git@github.com:decentraland/unity-explorer-packages.git?path=/RenderGraphs/RenderFeatures",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "4426b066d2c5e44c5938d395739384be58c5e81b"
+      "hash": "04b022e939c25c339fbdec5a30e11b2d3e851237"
     },
     "com.unity.modules.accessibility": {
       "version": "1.0.0",


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Two leftovers from the Unity 6.5 upgrade (#9871), both found on `dev` after it merged. Unrelated to each other, bundled at request — 3 files, 11 insertions.

### 1. Avatar Preview Renderer still pinned to a deleted branch

The upgrade pinned `decentraland.renderfeatures` to `#chore/unity-6-5` in `avatar-preview-renderer/Packages/manifest.json` so the renderer could consume the 6.5 fixes before they landed. That branch merged as `unity-explorer-packages#62` and was auto-deleted; Explorer's pin was moved back to `main`, the renderer's was not.

It resolves today **only** by luck: the locked hash `4426b066` is an ancestor of `main` (behind by 3), so UPM checks it out by SHA from `packages-lock.json`. Evidence it currently works — the renderer build on `dev` at `78705998` succeeded at 12:29Z, 80 minutes after the branch was deleted at 11:09Z. It breaks as soon as `packages-lock.json` is regenerated or dropped, because UPM then has to resolve the branch ref and gets a 404.

Dropping the pin and relocking onto `04b022e9` makes the entry byte-identical to Explorer's, so both projects consume the same RenderFeatures. It also picks up `1691b33d` (*gate skybox cubemap regeneration on change or interval*), the one functional commit the renderer was behind. **That commit is inert here** — the renderer wires only `AvatarOutline` and `ObjectHighlight` and never references `SkyboxEnvironmentProbe`.

### 2. `GeoffNoise.hlsl` parses its C# branch at asset import

```
Assets/DCL/Landscape/Shaders/GeoffNoise.hlsl:(14): Error: Shader syntax error. Expected '{' but found '.'.
```

`GeoffNoise.hlsl` is a dual-target source — HLSL for the mountain shaders, C# for a CPU mirror — and selected its branch with `#if SHADER_TARGET`. That macro only exists while a shader is actually being compiled. Unity 6.5 parses `.hlsl` files during asset import, where no shader macros are defined, so the preprocessor fell through to the C# branch and the parser hit line 14:

```hlsl
namespace Decentraland.Terrain
```

`namespace` is an HLSL keyword, so the parser wanted `{` and found the dot of the qualified name.

The fix keys off `CSHARP_7_3_OR_NEWER`, which Unity defines for every C# compilation and never in HLSL, so the branch resolves identically with or without shader context. All five guards are inverted to match.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**: terrain and mountains render as on `dev` — no flat, black, or missing mountain geometry. The console shows **no** `GeoffNoise.hlsl` shader syntax error.

**Steps (Avatar Preview Renderer)**: open the **Preview** URL from the `Avatar Preview Renderer — Vercel Preview is ready!` comment on this PR.

**Expected result**: the avatar renders toon-shaded (**not magenta**) with correct outlines — the outline and highlight features come from the repointed package.

### Prerequisites
- [ ] Open `Explorer/` in Unity 6000.5.9f1 at least once — the shader fix is an **import-time** error, so it only shows on a project open / reimport, not in a built player
- [ ] For the Avatar Preview Renderer, use the Preview link posted on this PR in a WebGPU-capable browser

### Test Steps
1. Open `Explorer/` in the editor. Console has no `GeoffNoise.hlsl` error.
2. Right-click `Assets/DCL/Landscape/Shaders/GeoffNoise.hlsl` → **Reimport**. Still no error.
3. Enter a Genesis City parcel with visible mountains. Terrain height, normals, and mountain silhouettes match `dev`.
4. Open the Avatar Preview Renderer preview URL. Avatar is toon-shaded, outlines correct.
5. `?mode=configurator&username=test` — the configurator renderer also loads (it wires both features).

### Additional Testing Notes

**Verification actually performed** — please read before approving:

- **Neither change was run through a Unity editor by me.** The shader fix is verified at the preprocessor level: evaluating the file's directives shows the original with no macros defined does select the C# branch (reproducing the reported error), the patched file selects the HLSL branch, and the patched file's import-time output is **byte-identical** to the original's output under `SHADER_TARGET=50`. So shader compilation cannot change — but "the import error is gone in the editor" is inferred, not observed. Step 1 above is the check that matters.
- **The renderfeatures repoint is a content change, not just a cosmetic repin.** `1691b33d` alters `SkyboxToCubemapRendererFeature.cs` (+20/-10). I confirmed the renderer's two URP renderer assets reference only `AvatarOutline` and `ObjectHighlight`, and that `SkyboxEnvironmentProbe` appears nowhere in `avatar-preview-renderer/`, so the change should be inert — but the renderer's Web output is built by CI, not locally, so the Preview is the first real exercise.
- The C# half of `GeoffNoise.hlsl` is **dead**: there is no `.cs` counterpart, nothing compiles the file as C#, and nothing references `GeoffNoise` from C#. This PR preserves it rather than deleting it, since removing ~120 lines of someone's intended CPU/GPU parity source is a separate decision. Worth a follow-up.

## Quality Checklist
- [ ] Changes have been tested locally
- [x] Documentation has been updated (if required) — n/a
- [x] Performance impact has been considered — none; shader output is byte-identical and the package change is inert
- [x] For SDK features: Test scene is included — n/a
