### PR TITLE
fix(ci): resolve build zip artifact ids via the run-scoped endpoint

### DIFF
--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -193,20 +193,21 @@ jobs:
           # Query the run-scoped endpoint: the repo-wide /actions/artifacts list is
           # newest-first and page-limited, so a zip uploaded by a fast platform long
           # before the slow one finishes can fall off the first page and lose its
-          # "Download .zip" link in the comment.
-          WINDOWS_ARTIFACT_ID=$(gh api "/repos/$OWNER/$REPO/actions/runs/${PREVIOUS_JOB_ID}/artifacts?per_page=100" \
-            --jq ".artifacts.[] |
-            select(.expired==false) |
-            select(.name==\"Decentraland_windows64\") |
-            .id")
+          # "Download .zip" link in the comment. The run list spans all re-run
+          # attempts, so a same-name artifact can appear once per attempt —
+          # max_by keeps only the newest and guarantees a single-line id.
+          RUN_ARTIFACTS=$(gh api "/repos/$OWNER/$REPO/actions/runs/${PREVIOUS_JOB_ID}/artifacts?per_page=100")
+          newest_artifact_id() {
+            jq -r --arg name "$1" \
+              '[.artifacts[] | select(.expired==false and .name==$name)] | max_by(.created_at) | .id // empty' \
+              <<< "$RUN_ARTIFACTS"
+          }
+
+          WINDOWS_ARTIFACT_ID=$(newest_artifact_id "Decentraland_windows64")
           echo "Windows Artifact ID: $WINDOWS_ARTIFACT_ID"
           echo "WINDOWS_ARTIFACT_ID=$WINDOWS_ARTIFACT_ID" >> "$GITHUB_ENV"
 
-          MAC_ARTIFACT_ID=$(gh api "/repos/$OWNER/$REPO/actions/runs/${PREVIOUS_JOB_ID}/artifacts?per_page=100" \
-            --jq ".artifacts.[] |
-            select(.expired==false) |
-            select(.name==\"Decentraland_macos\") |
-            .id")
+          MAC_ARTIFACT_ID=$(newest_artifact_id "Decentraland_macos")
           echo "Mac Artifact ID: $MAC_ARTIFACT_ID"
           echo "MAC_ARTIFACT_ID=$MAC_ARTIFACT_ID" >> "$GITHUB_ENV"
 

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -190,18 +190,20 @@ jobs:
           echo "Previous Suite ID: $SUITE_ID"
           echo "SUITE_ID=$SUITE_ID" >> "$GITHUB_ENV"
 
-          WINDOWS_ARTIFACT_ID=$(gh api "/repos/$OWNER/$REPO/actions/artifacts" \
+          # Query the run-scoped endpoint: the repo-wide /actions/artifacts list is
+          # newest-first and page-limited, so a zip uploaded by a fast platform long
+          # before the slow one finishes can fall off the first page and lose its
+          # "Download .zip" link in the comment.
+          WINDOWS_ARTIFACT_ID=$(gh api "/repos/$OWNER/$REPO/actions/runs/${PREVIOUS_JOB_ID}/artifacts?per_page=100" \
             --jq ".artifacts.[] |
-            select(.workflow_run.id==${PREVIOUS_JOB_ID}) |
             select(.expired==false) |
             select(.name==\"Decentraland_windows64\") |
             .id")
           echo "Windows Artifact ID: $WINDOWS_ARTIFACT_ID"
           echo "WINDOWS_ARTIFACT_ID=$WINDOWS_ARTIFACT_ID" >> "$GITHUB_ENV"
 
-          MAC_ARTIFACT_ID=$(gh api "/repos/$OWNER/$REPO/actions/artifacts" \
+          MAC_ARTIFACT_ID=$(gh api "/repos/$OWNER/$REPO/actions/runs/${PREVIOUS_JOB_ID}/artifacts?per_page=100" \
             --jq ".artifacts.[] |
-            select(.workflow_run.id==${PREVIOUS_JOB_ID}) |
             select(.expired==false) |
             select(.name==\"Decentraland_macos\") |
             .id")


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

Fixes the CI status comment sometimes missing the **Download .zip** link for Windows (observed on #9908).

The `pr-comment-artifact-url.yml` workflow resolved the `Decentraland_windows64` / `Decentraland_macos` artifact ids from the **repo-wide** `/actions/artifacts` list — which is newest-first, capped at the default page size of 30, and not paginated — filtering by run id client-side in `jq`. The comment fires when the whole build run completes, i.e. gated on the slowest platform. On #9908 the Windows build finished 26m in while Mac took 1h 22m; by run completion, 45 newer artifacts from concurrent runs had pushed the Windows zip off the first page, so `WINDOWS_ARTIFACT_ID` resolved empty and `compose_row` (by design) dropped the link, leaving only the S3 one.

This PR switches both lookups to the run-scoped endpoint (`/actions/runs/<run-id>/artifacts?per_page=100`), which only contains that run's ~10 artifacts and is immune to repo-wide churn. This mirrors what the sibling `ucb-build-links` action already does.

## Test Instructions

Not testable via a client build — this changes a `workflow_run`-triggered workflow, which always executes the definition from the default branch, so the fix only takes effect **after merge to `dev`**.

**Steps (standard run)**:
N/A — no client change; `metaforge explorer run` does not apply.

**Expected result**:
N/A

**Steps (fresh account)**:
N/A

**Expected result**:
N/A

**Automation** (if applicable):
N/A

### Prerequisites
- [ ] None — verification happens on PRs opened after this merges

### Test Steps
1. After merge, pick any PR whose Windows Unity Cloud build finishes well before the Mac one (the common case) on a day with concurrent CI activity.
2. Wait for the build run to complete and the 🚦 CI Status comment's build section to update.
3. Verify the **Windows** row contains both `Download .zip` (GitHub artifact) and `.zip via S3` links, and that the `Download .zip` link points to this run's `Decentraland_windows64` artifact.
4. Verify the **Mac** row is unchanged (both links present).

### Additional Testing Notes
- The equivalent dry-run check was done against PR #9908's build run 33652525633: the run-scoped query returns both zip artifact ids correctly, while the old repo-wide query missed the Windows one.
- The Mac lookup had the same flaw but rarely lost the race (its artifact is always fresh when the run ends); it is fixed the same way.

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)