### PR TITLE
hotfix: parallelize scene manifest fetches and limit deps-digest fetch to SDK7 scenes

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
@@ -150,7 +150,7 @@ namespace ECS.SceneLifeCycle.SceneDefinition
             // SDK7 scenes only: everything else (SDK6 scenes, roads) never instantiates as a scene — it is
             // permanently represented by LODs from the LOD pipeline (see VisualSceneStateResolver) — so it
             // never requests its own bundles and its digest map would go unread.
-            if (sceneEntityDefinition.metadata?.runtimeVersion == "7")
+            if (sceneEntityDefinition.metadata.runtimeVersion == "7")
                 await SceneAssetBundleDigestsLoader.EnsureDepsDigestsAsync(World, sceneEntityDefinition, partition, ct, isLocalSceneDevelopment);
         }
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneLifeCycle/SceneDefinition/Systems/LoadSceneDefinitionListSystem.cs
@@ -122,21 +122,36 @@ namespace ECS.SceneLifeCycle.SceneDefinition
 
             analytics.OnRequestFinished(intention.TargetCollection.Count);
 
-            foreach (SceneEntityDefinition sceneEntityDefinition in intention.TargetCollection)
+            // One round-trip of wall-clock instead of one per scene: on a fully reconverted (v49+) city every
+            // scene in the batch fetches its manifest, and awaiting them one-by-one held the whole batch —
+            // and the destination scene queued behind it — for ~400ms × N.
+            using (ListPool<UniTask>.Get(out List<UniTask> manifestTasks))
             {
-                //Fallback needed for when the asset-bundle-registry does not have the asset bundle manifest.
-                //Could be removed once the asset bundle manifest registry has been battle tested.
-                //With local asset bundles the manual LSD manifest is skipped so the real manifest is fetched
-                //from the local asset-bundle server; failures there are expected (whole-scene raw-GLTF degrade).
-                await AssetBundleManifestFallbackHelper.CheckAssetBundleManifestFallbackAsync(World, sceneEntityDefinition, partition, ct, useManualManifest: isLocalSceneDevelopment && !useLocalAssetBundles, skipException: isLocalSceneDevelopment);
+                foreach (SceneEntityDefinition sceneEntityDefinition in intention.TargetCollection)
+                    manifestTasks.Add(EnsureManifestDataAsync(sceneEntityDefinition, partition, ct));
 
-                // v49+ scene ABs ship a per-file deps digest in their manifest. Fetch it (deduped via the promise cache)
-                // so the AB / GLTF / disk caches can differentiate scenes that share a hash but resolve different deps.
-                await SceneAssetBundleDigestsLoader.EnsureDepsDigestsAsync(World, sceneEntityDefinition, partition, ct, isLocalSceneDevelopment);
+                await UniTask.WhenAll(manifestTasks);
             }
 
             return new StreamableLoadingResult<SceneDefinitions>(
                 new SceneDefinitions(intention.TargetCollection));
+        }
+
+        private async UniTask EnsureManifestDataAsync(SceneEntityDefinition sceneEntityDefinition, IPartitionComponent partition, CancellationToken ct)
+        {
+            //Fallback needed for when the asset-bundle-registry does not have the asset bundle manifest.
+            //Could be removed once the asset bundle manifest registry has been battle tested.
+            //With local asset bundles the manual LSD manifest is skipped so the real manifest is fetched
+            //from the local asset-bundle server; failures there are expected (whole-scene raw-GLTF degrade).
+            await AssetBundleManifestFallbackHelper.CheckAssetBundleManifestFallbackAsync(World, sceneEntityDefinition, partition, ct, useManualManifest: isLocalSceneDevelopment && !useLocalAssetBundles, skipException: isLocalSceneDevelopment);
+
+            // v49+ scene ABs ship a per-file deps digest in their manifest. Fetch it (deduped via the promise cache)
+            // so the AB / GLTF / disk caches can differentiate scenes that share a hash but resolve different deps.
+            // SDK7 scenes only: everything else (SDK6 scenes, roads) never instantiates as a scene — it is
+            // permanently represented by LODs from the LOD pipeline (see VisualSceneStateResolver) — so it
+            // never requests its own bundles and its digest map would go unread.
+            if (sceneEntityDefinition.metadata?.runtimeVersion == "7")
+                await SceneAssetBundleDigestsLoader.EnsureDepsDigestsAsync(World, sceneEntityDefinition, partition, ct, isLocalSceneDevelopment);
         }
 
         private void RemoveDuplicates(List<SceneEntityDefinition> list)


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?

**Problem.** With a fully reconverted (v49+) city — as served by the abgen pipeline (`--abgen-pipeline` / the `alfa-abgen-pipeline` FF) — every scene definition in a loading batch fetches its asset-bundle manifest to resolve the per-file deps digests, because every reconverted manifest reports v1002 (≥ v49). `LoadSceneDefinitionListSystem` awaited those fetches **one scene at a time**, so a batch of surrounding scenes cost ~400ms × N of pure wall-clock before the batch — and the destination scene queued behind it — could resolve. Teleporting into Antrom (144,-7) took **~10s instead of ~2s** (22 serial manifest requests; loading screen frozen at 20%). On production this was latent: only ~4% of scenes around that area are v49+ today, but the same stall would progressively appear as reconversions land.

**Fix (two changes in one file):**
1. The per-scene chain (manifest-version fallback → deps-digest fetch, order preserved within each scene) now runs **in parallel** across the batch via `UniTask.WhenAll` — one round-trip of wall-clock instead of one per scene.
2. The deps-digest fetch is **skipped for non-SDK7 definitions**. SDK6 scenes and roads never instantiate as scenes — `VisualSceneStateResolver` pins them to `ShowingLod` permanently (roads use the pooled road assets) — so they never request their own bundles and their digest map is never read. Around Antrom this drops the fetch count from 22 to 3.

Verified against live infra: CDN latency is not a factor (abgen-cdn and ab-cdn respond identically, ~0.4s cold / ~0.35s warm) — the stall was purely count × serialization.

## Test Instructions

**Steps (standard run)**:
```bash
metaforge explorer run XXXX  # ← replace with this PR number
```

**Expected result**:
Teleport times to Antrom and Meta GamiMall are roughly the same with and without `--abgen-pipeline` (no multi-second freeze at ~20% with the flag).

### Prerequisites
- [ ] Two runs of the same build: one launched normally, one launched with `--abgen-pipeline`
- [ ] A timer (rough stopwatch precision is enough — the regression being ruled out is seconds, not ms)

### Test Steps
1. Launch the client **without** `--abgen-pipeline`, spawn at Genesis Plaza
2. `/goto 144,-7` (Antrom) — measure time from teleport start to loading screen gone
3. `/goto 1,95` (Meta GamiMall) — measure the same way
4. Relaunch the client **with** `--abgen-pipeline` and repeat steps 2–3
5. Compare: times with the flag should be in the same range as without it (~2-3s per teleport). Before this fix, the flagged run took ~10s to Antrom with the loading screen stuck at ~20%

### Additional Testing Notes
- Both destinations render normally after the teleport in both modes; surrounding scenes and LODs stream in as usual

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)