### PR TITLE
fix: apply avatar modifier areas to scene avatars (NPCs)

### DIFF
--- a/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
@@ -1,5 +1,6 @@
 using Arch.SystemGroups;
 using DCL.ECSComponents;
+using DCL.Multiplayer.Profiles.Entities;
 using DCL.Optimization.Pools;
 using DCL.PluginSystem.World.Dependencies;
 using DCL.SDKComponents.AvatarShape.Systems;
@@ -15,13 +16,19 @@ namespace DCL.PluginSystem.World
     public class AvatarShapePlugin : IDCLWorldPlugin
     {
         private readonly Arch.Core.World globalWorld;
+        private readonly IComponentPoolsRegistry poolRegistry;
         private readonly IComponentPool<Transform> globalTransformPool;
         private readonly ILaunchMode launchMode;
         private readonly bool useAssetBundles;
 
+        // The RemoteAvatarCollider pool is registered by MultiplayerPlugin.InitializeAsync, which runs
+        // after this plugin's construction, so it can only be resolved once scene worlds are being built.
+        private IComponentPool<RemoteAvatarCollider>? avatarColliderPool;
+
         public AvatarShapePlugin(Arch.Core.World globalWorld, IComponentPoolsRegistry poolRegistry, ILaunchMode launchMode, bool useAssetBundles)
         {
             this.globalWorld = globalWorld;
+            this.poolRegistry = poolRegistry;
             this.launchMode = launchMode;
             this.useAssetBundles = useAssetBundles;
             this.globalTransformPool = poolRegistry.GetReferenceTypePool<Transform>();
@@ -35,7 +42,8 @@ namespace DCL.PluginSystem.World
         public void InjectToWorld(ref ArchSystemsWorldBuilder<Arch.Core.World> builder, in ECSWorldInstanceSharedDependencies sharedDependencies, in SystemsDependencies systemsDependencies, in PersistentEntities persistentEntities, List<IFinalizeWorldSystem> finalizeWorldSystems, List<ISceneIsCurrentListener> sceneIsCurrentListeners)
         {
             ResetDirtyFlagSystem<PBAvatarShape>.InjectToWorld(ref builder);
-            finalizeWorldSystems.Add(AvatarShapeHandlerSystem.InjectToWorld(ref builder, globalWorld, globalTransformPool, sharedDependencies.SceneData, launchMode.CurrentMode == LaunchMode.LocalSceneDevelopment && !useAssetBundles));
+            avatarColliderPool ??= poolRegistry.GetReferenceTypePool<RemoteAvatarCollider>();
+            finalizeWorldSystems.Add(AvatarShapeHandlerSystem.InjectToWorld(ref builder, globalWorld, globalTransformPool, avatarColliderPool, sharedDependencies.SceneData, launchMode.CurrentMode == LaunchMode.LocalSceneDevelopment && !useAssetBundles));
             UpdateAvatarShapeInterpolateMovementSystem.InjectToWorld(ref builder, globalWorld);
         }
     }

--- a/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
+++ b/Explorer/Assets/DCL/PluginSystem/World/AvatarShapePlugin.cs
@@ -21,8 +21,8 @@ namespace DCL.PluginSystem.World
         private readonly ILaunchMode launchMode;
         private readonly bool useAssetBundles;
 
-        // The RemoteAvatarCollider pool is registered by MultiplayerPlugin.InitializeAsync, which runs
-        // after this plugin's construction, so it can only be resolved once scene worlds are being built.
+        // MultiplayerPlugin.InitializeAsync registers this pool after this plugin is constructed,
+        // so unlike the transform pool it cannot be resolved in the constructor.
         private IComponentPool<RemoteAvatarCollider>? avatarColliderPool;
 
         public AvatarShapePlugin(Arch.Core.World globalWorld, IComponentPoolsRegistry poolRegistry, ILaunchMode launchMode, bool useAssetBundles)

--- a/Explorer/Assets/DCL/SDKComponents/AvatarModifierArea/Systems/AvatarModifierAreaHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarModifierArea/Systems/AvatarModifierAreaHandlerSystem.cs
@@ -203,15 +203,15 @@ namespace DCL.SDKComponents.AvatarModifierArea.Systems
 
         private void HideAvatar(Entity entity, Transform avatarTransform, HashSet<string> excludedIds)
         {
-            if (!globalWorld.TryGet(entity, out Profile? profile)) return;
+            globalWorld.TryGet(entity, out Profile? profile);
 
             ref AvatarShapeComponent avatarShape = ref globalWorld.TryGetRef<AvatarShapeComponent>(entity, out bool hasAvatarShape);
             if (!hasAvatarShape) return;
 
-            bool shouldHide = !excludedIds.Contains(profile!.UserId);
+            bool shouldHide = !IsExcluded(profile, excludedIds);
             avatarShape.HiddenByModifierArea = shouldHide;
 
-            if (shouldHide && profile.UserId == web3IdentityCache.Identity?.Address)
+            if (shouldHide && profile != null && profile.UserId == web3IdentityCache.Identity?.Address)
             {
                 localAvatarTransform = avatarTransform;
                 sceneRestrictionBusController.PushSceneRestriction(SceneRestriction.CreateAvatarHidden(SceneRestrictionsAction.Applied));
@@ -220,12 +220,12 @@ namespace DCL.SDKComponents.AvatarModifierArea.Systems
 
         private void HideNameTag(Entity entity, HashSet<string> excludedIds)
         {
-            if (!globalWorld.TryGet(entity, out Profile? profile)) return;
+            globalWorld.TryGet(entity, out Profile? profile);
 
             ref AvatarShapeComponent avatarShape = ref globalWorld.TryGetRef<AvatarShapeComponent>(entity, out bool hasAvatarShape);
             if (!hasAvatarShape) return;
 
-            avatarShape.NameTagHiddenByModifierArea = !excludedIds.Contains(profile!.UserId);
+            avatarShape.NameTagHiddenByModifierArea = !IsExcluded(profile, excludedIds);
         }
 
         private void ShowNameTag(Entity entity)
@@ -238,16 +238,16 @@ namespace DCL.SDKComponents.AvatarModifierArea.Systems
 
         private void DisableAvatarInteraction(Entity entity, HashSet<string> excludedIds)
         {
-            if (!globalWorld.TryGet(entity, out Profile? profile)) return;
+            globalWorld.TryGet(entity, out Profile? profile);
 
-            bool shouldDisable = !excludedIds.Contains(profile!.UserId);
+            bool shouldDisable = !IsExcluded(profile, excludedIds);
 
             if (shouldDisable)
             {
                 // Something like TryAdd
                 globalWorld.AddOrGet<IgnoreInteractionComponent>(entity);
 
-                if (profile.UserId == web3IdentityCache.Identity?.Address)
+                if (profile != null && profile.UserId == web3IdentityCache.Identity?.Address)
                 {
                     ownAvatarEntity = entity;
                     sceneRestrictionBusController.PushSceneRestriction(SceneRestriction.CreatePassportCannotBeOpened(SceneRestrictionsAction.Applied));
@@ -263,6 +263,14 @@ namespace DCL.SDKComponents.AvatarModifierArea.Systems
 
             if (ownAvatarEntity == entity)
                 sceneRestrictionBusController.PushSceneRestriction(SceneRestriction.CreatePassportCannotBeOpened(SceneRestrictionsAction.Removed));
+        }
+
+        // AlwaScene avatars (NPCs) have no Profile hence no UserId to match against excludeIds, so the
+        // area modifiers always apply to them.
+        private static bool IsExcluded(Profile? profile, HashSet<string> excludedIds)
+        {
+            string? userId = profile?.UserId;
+            return userId != null && excludedIds.Contains(userId);
         }
 
         private bool TryGetAvatarEntity(Transform transform, out Entity entity)

--- a/Explorer/Assets/DCL/SDKComponents/AvatarModifierArea/Systems/AvatarModifierAreaHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarModifierArea/Systems/AvatarModifierAreaHandlerSystem.cs
@@ -265,8 +265,8 @@ namespace DCL.SDKComponents.AvatarModifierArea.Systems
                 sceneRestrictionBusController.PushSceneRestriction(SceneRestriction.CreatePassportCannotBeOpened(SceneRestrictionsAction.Removed));
         }
 
-        // AlwaScene avatars (NPCs) have no Profile hence no UserId to match against excludeIds, so the
-        // area modifiers always apply to them.
+        // Scene avatars (NPCs) have no Profile hence no UserId to match against excludeIds, so the
+        // modifiers always apply to them.
         private static bool IsExcluded(Profile? profile, HashSet<string> excludedIds)
         {
             string? userId = profile?.UserId;

--- a/Explorer/Assets/DCL/SDKComponents/AvatarModifierArea/Tests/AvatarModifierAreaHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarModifierArea/Tests/AvatarModifierAreaHandlerSystemShould.cs
@@ -730,7 +730,7 @@ namespace DCL.SDKComponents.AvatarModifierArea.Tests
         [Test]
         public void ApplyModifiersToProfilelessAvatar()
         {
-            // No Profile is added to fakeAvatarEntity: this is the scene avatar (NPC) case.
+            // No Profile on fakeAvatarEntity — the scene avatar (NPC) case.
             var pbComponent = new PBAvatarModifierArea
             {
                 Area = new Vector3

--- a/Explorer/Assets/DCL/SDKComponents/AvatarModifierArea/Tests/AvatarModifierAreaHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarModifierArea/Tests/AvatarModifierAreaHandlerSystemShould.cs
@@ -726,5 +726,48 @@ namespace DCL.SDKComponents.AvatarModifierArea.Tests
 
             Assert.IsFalse(globalWorld.Get<AvatarShapeComponent>(fakeAvatarEntity).NameTagHiddenByModifierArea);
         }
+
+        [Test]
+        public void ApplyModifiersToProfilelessAvatar()
+        {
+            // No Profile is added to fakeAvatarEntity: this is the scene avatar (NPC) case.
+            var pbComponent = new PBAvatarModifierArea
+            {
+                Area = new Vector3
+                {
+                    X = 1.68f,
+                    Y = 2.96f,
+                    Z = 8.66f,
+                },
+                IsDirty = true,
+                Modifiers =
+                {
+                    AvatarModifierType.AmtHideAvatars,
+                    AvatarModifierType.AmtHideNametags,
+                },
+            };
+
+            world.Add(triggerAreaEntity, pbComponent);
+            system.Update(0);
+
+            sdkEntityTriggerArea.OnTriggerEnter(fakeAvatarShapeCollider);
+            SDKEntityTriggerAreaComponent component = world.Get<SDKEntityTriggerAreaComponent>(triggerAreaEntity);
+            component.SetMonoBehaviour(sdkEntityTriggerArea);
+            world.Set(triggerAreaEntity, component);
+
+            system.Update(0f);
+
+            AvatarShapeComponent avatarShape = globalWorld.Get<AvatarShapeComponent>(fakeAvatarEntity);
+            Assert.IsTrue(avatarShape.HiddenByModifierArea);
+            Assert.IsTrue(avatarShape.NameTagHiddenByModifierArea);
+
+            sdkEntityTriggerArea.OnTriggerExit(fakeAvatarShapeCollider);
+
+            system.Update(0f);
+
+            avatarShape = globalWorld.Get<AvatarShapeComponent>(fakeAvatarEntity);
+            Assert.IsFalse(avatarShape.HiddenByModifierArea);
+            Assert.IsFalse(avatarShape.NameTagHiddenByModifierArea);
+        }
     }
 }

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
@@ -10,6 +10,7 @@ using DCL.Character.Components;
 using DCL.CharacterMotion.Components;
 using DCL.Diagnostics;
 using DCL.ECSComponents;
+using DCL.Multiplayer.Profiles.Entities;
 using DCL.Optimization.Pools;
 using ECS.Abstract;
 using ECS.Groups;
@@ -37,14 +38,16 @@ namespace ECS.Unity.AvatarShape.Systems
 
         private readonly World globalWorld;
         private readonly IComponentPool<Transform> globalTransformPool;
+        private readonly IComponentPool<RemoteAvatarCollider> avatarColliderPool;
         private readonly ISceneData sceneData;
         private readonly bool loadAssetsFromLocalScene;
 
         public AvatarShapeHandlerSystem(World world, World globalWorld, IComponentPool<Transform> globalTransformPool,
-            ISceneData sceneData, bool loadAssetsFromLocalScene) : base(world)
+            IComponentPool<RemoteAvatarCollider> avatarColliderPool, ISceneData sceneData, bool loadAssetsFromLocalScene) : base(world)
         {
             this.globalWorld = globalWorld;
             this.globalTransformPool = globalTransformPool;
+            this.avatarColliderPool = avatarColliderPool;
             this.sceneData = sceneData;
             this.loadAssetsFromLocalScene = loadAssetsFromLocalScene;
         }
@@ -76,8 +79,19 @@ namespace ECS.Unity.AvatarShape.Systems
             globalTransform.localRotation = Quaternion.identity;
             globalTransform.localScale = Vector3.one;
 
+            // Avatar trigger areas (AvatarModifierArea, PBTriggerArea) are fed by physics events only,
+            // so without an own collider the SDK avatar would be invisible to all of them. It sits as a
+            // sibling of the AvatarBase to satisfy the FindAvatarUtils.AvatarWithTransform hierarchy match.
+            RemoteAvatarCollider avatarCollider = avatarColliderPool.Get();
+            avatarCollider.name = $"Collider {pbAvatarShape.Id}";
+            avatarCollider.transform.SetParent(globalTransform, false);
+            avatarCollider.transform.localPosition = Vector3.zero;
+            avatarCollider.transform.localRotation = Quaternion.identity;
+            avatarCollider.transform.localScale = Vector3.one;
+
             var globalWorldEntity = globalWorld.Create(
                 pbAvatarShape, partitionComponent,
+                avatarCollider,
                 new CharacterTransform(globalTransform),
                 new CharacterInterpolationMovementComponent(
                     transformComponent.Transform.position,
@@ -259,6 +273,14 @@ namespace ECS.Unity.AvatarShape.Systems
         private void MarkGlobalWorldEntityForDeletion(Entity globalEntity)
         {
             if (globalEntity == Entity.Null) return;
+
+            // The collider must leave the avatar's transform before that transform returns to its own
+            // pool, otherwise the pooled transform keeps a stale collider child.
+            if (globalWorld.TryGet(globalEntity, out RemoteAvatarCollider? avatarCollider))
+            {
+                avatarColliderPool.Release(avatarCollider!);
+                globalWorld.Remove<RemoteAvatarCollider>(globalEntity);
+            }
 
             Transform transform = globalWorld.Get<CharacterTransform>(globalEntity).Transform;
 

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Systems/AvatarShapeHandlerSystem.cs
@@ -79,9 +79,9 @@ namespace ECS.Unity.AvatarShape.Systems
             globalTransform.localRotation = Quaternion.identity;
             globalTransform.localScale = Vector3.one;
 
-            // Avatar trigger areas (AvatarModifierArea, PBTriggerArea) are fed by physics events only,
-            // so without an own collider the SDK avatar would be invisible to all of them. It sits as a
-            // sibling of the AvatarBase to satisfy the FindAvatarUtils.AvatarWithTransform hierarchy match.
+            // Without its own collider the avatar is invisible to avatar trigger areas (only physics
+            // events feed them). It must stay a sibling of the AvatarBase:
+            // FindAvatarUtils.AvatarWithTransform matches avatars by that hierarchy.
             RemoteAvatarCollider avatarCollider = avatarColliderPool.Get();
             avatarCollider.name = $"Collider {pbAvatarShape.Id}";
             avatarCollider.transform.SetParent(globalTransform, false);
@@ -274,8 +274,8 @@ namespace ECS.Unity.AvatarShape.Systems
         {
             if (globalEntity == Entity.Null) return;
 
-            // The collider must leave the avatar's transform before that transform returns to its own
-            // pool, otherwise the pooled transform keeps a stale collider child.
+            // Released before the avatar's transform returns to its own pool, otherwise the pooled
+            // transform keeps a stale collider child.
             if (globalWorld.TryGet(globalEntity, out RemoteAvatarCollider? avatarCollider))
             {
                 avatarColliderPool.Release(avatarCollider!);

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Tests/AvatarShapeHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Tests/AvatarShapeHandlerSystemShould.cs
@@ -17,6 +17,7 @@ using ECS.StreamableLoading.Common.Components;
 using CommunicationData.URLHelpers;
 using DCL.Ipfs;
 using DCL.Diagnostics;
+using DCL.Multiplayer.Profiles.Entities;
 using ECS.StreamableLoading.Common;
 using UnityEngine.TestTools;
 
@@ -33,7 +34,7 @@ namespace ECS.Unity.AvatarShape.Tests
             pool.Get().Returns(new GameObject().transform);
             ISceneData sceneData = Substitute.For<ISceneData>();
             sceneData.SceneLoadingConcluded.Returns(true);
-            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData, false);
+            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, CreateAvatarColliderPool(), sceneData, false);
 
             entity = world.Create(PartitionComponent.TOP_PRIORITY);
             AddTransformToEntity(entity);
@@ -41,6 +42,13 @@ namespace ECS.Unity.AvatarShape.Tests
 
         private Entity entity;
         private World globalWorld;
+
+        private static IComponentPool<RemoteAvatarCollider> CreateAvatarColliderPool()
+        {
+            IComponentPool<RemoteAvatarCollider> pool = Substitute.For<IComponentPool<RemoteAvatarCollider>>();
+            pool.Get().Returns(_ => new GameObject("avatar collider").AddComponent<RemoteAvatarCollider>());
+            return pool;
+        }
 
         [Test]
         public void ForwardSDKAvatarShapeInstantiationToGlobalWorldSystems()
@@ -57,6 +65,24 @@ namespace ECS.Unity.AvatarShape.Tests
             Assert.AreEqual(1, world.CountEntities(new QueryDescription().WithAll<PBAvatarShape, SDKAvatarShapeComponent>()));
             Assert.AreEqual(1, globalWorld.CountEntities(new QueryDescription().WithAll<PBAvatarShape>()));
             globalWorld.Query(new QueryDescription().WithAll<PBAvatarShape, CharacterTransform>(), (ref PBAvatarShape comp) => Assert.AreEqual(pbAvatarShapeComponent.Name, comp.Name));
+        }
+
+        [Test]
+        public void AttachAvatarColliderToGlobalWorldEntity()
+        {
+            world.Add(entity, new PBAvatarShape { Name = "Cthulhu" });
+
+            system.Update(0);
+
+            // Without a collider the avatar is invisible to every avatar trigger area
+            // (AvatarModifierArea, PBTriggerArea): only physics events feed them.
+            Entity globalEntity = world.Get<SDKAvatarShapeComponent>(entity).GlobalWorldEntity;
+            Assert.IsTrue(globalWorld.Has<RemoteAvatarCollider>(globalEntity));
+
+            // FindAvatarUtils.AvatarWithTransform matches avatars by hierarchy: the collider and the
+            // AvatarBase must be siblings under the avatar's global transform.
+            RemoteAvatarCollider avatarCollider = globalWorld.Get<RemoteAvatarCollider>(globalEntity);
+            Assert.AreEqual(globalWorld.Get<CharacterTransform>(globalEntity).Transform, avatarCollider.transform.parent);
         }
 
         [Test]
@@ -154,7 +180,7 @@ namespace ECS.Unity.AvatarShape.Tests
                          });
 
             sceneData.SceneContent.Returns(sceneContent);
-            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData, true);
+            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, CreateAvatarColliderPool(), sceneData, true);
 
             // Avatar Shape
             var pbAvatarShapeComponent = new PBAvatarShape { Name = "Cthulhu", BodyShape = BodyShape.MALE.ToString() };
@@ -246,7 +272,7 @@ namespace ECS.Unity.AvatarShape.Tests
             sceneData.SceneContent.Returns(sceneContent);
             sceneData.SceneEntityDefinition.Returns(new SceneEntityDefinition { id = "sceneId" });
 
-            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData, false);
+            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, CreateAvatarColliderPool(), sceneData, false);
 
             // Avatar Shape
             var pbAvatarShapeComponent = new PBAvatarShape { Name = "Cthulhu", BodyShape = BodyShape.MALE.ToString() };
@@ -330,7 +356,7 @@ namespace ECS.Unity.AvatarShape.Tests
                         .Returns(false);
 
             sceneData.SceneContent.Returns(sceneContent);
-            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData, true);
+            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, CreateAvatarColliderPool(), sceneData, true);
 
             // Avatar Shape
             var pbAvatarShapeComponent = new PBAvatarShape { Name = "Cthulhu", BodyShape = BodyShape.MALE.ToString() };
@@ -372,7 +398,7 @@ namespace ECS.Unity.AvatarShape.Tests
                          });
 
             sceneData.SceneContent.Returns(sceneContent);
-            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData, true);
+            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, CreateAvatarColliderPool(), sceneData, true);
 
             // Avatar Shape
             var pbAvatarShapeComponent = new PBAvatarShape { Name = "Cthulhu", BodyShape = BodyShape.MALE.ToString(), ExpressionTriggerId = emoteId };
@@ -421,7 +447,7 @@ namespace ECS.Unity.AvatarShape.Tests
                          });
 
             sceneData.SceneContent.Returns(sceneContent);
-            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData, true);
+            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, CreateAvatarColliderPool(), sceneData, true);
 
             // Avatar Shape
             var pbAvatarShapeComponent = new PBAvatarShape { Name = "Cthulhu", BodyShape = BodyShape.MALE.ToString() };
@@ -480,7 +506,7 @@ namespace ECS.Unity.AvatarShape.Tests
                          });
 
             sceneData.SceneContent.Returns(sceneContent);
-            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, sceneData, true);
+            system = new AvatarShapeHandlerSystem(world, globalWorld, pool, CreateAvatarColliderPool(), sceneData, true);
 
             // Avatar Shape
             var pbAvatarShapeComponent = new PBAvatarShape { Name = "Cthulhu", BodyShape = BodyShape.MALE.ToString() };

--- a/Explorer/Assets/DCL/SDKComponents/AvatarShape/Tests/AvatarShapeHandlerSystemShould.cs
+++ b/Explorer/Assets/DCL/SDKComponents/AvatarShape/Tests/AvatarShapeHandlerSystemShould.cs
@@ -74,13 +74,9 @@ namespace ECS.Unity.AvatarShape.Tests
 
             system.Update(0);
 
-            // Without a collider the avatar is invisible to every avatar trigger area
-            // (AvatarModifierArea, PBTriggerArea): only physics events feed them.
             Entity globalEntity = world.Get<SDKAvatarShapeComponent>(entity).GlobalWorldEntity;
             Assert.IsTrue(globalWorld.Has<RemoteAvatarCollider>(globalEntity));
 
-            // FindAvatarUtils.AvatarWithTransform matches avatars by hierarchy: the collider and the
-            // AvatarBase must be siblings under the avatar's global transform.
             RemoteAvatarCollider avatarCollider = globalWorld.Get<RemoteAvatarCollider>(globalEntity);
             Assert.AreEqual(globalWorld.Get<CharacterTransform>(globalEntity).Transform, avatarCollider.transform.parent);
         }


### PR DESCRIPTION
## What does this PR change

Scene avatars (NPCs created with `AvatarShape`) were ignored by `AvatarModifierArea`: hide-avatars, hide-nametags and disable-passports zones affected players but not NPCs.

## Technical description

Two stacked causes:

1. **No collider.** Only remote players get a `RemoteAvatarCollider` (via `RemoteEntities`), so `SDKEntityTriggerArea` never produced enter/exit events for SDK avatars. `AvatarShapeHandlerSystem` now attaches a pooled `RemoteAvatarCollider` to every SDK avatar — as a sibling of the `AvatarBase`, so `FindAvatarUtils.AvatarWithTransform` matches it — and releases it back to the pool on entity deletion. The pool is resolved lazily in `AvatarShapePlugin.InjectToWorld`, because `MultiplayerPlugin.InitializeAsync` registers it after world plugins are constructed.
2. **Profile early-return.** `HideAvatar` / `HideNameTag` / `DisableAvatarInteraction` returned early when the entity had no `Profile`. A missing profile now means "not excludable": `excludeIds` can only contain user ids, so the modifiers always apply to NPCs.

Known side effect: `PBTriggerArea` with a `CL_PLAYER` mask can now also detect scene avatars. `CameraModeArea` is unaffected (`targetOnlyMainPlayer`).

New tests: `AttachAvatarColliderToGlobalWorldEntity` (red before the fix) and `ApplyModifiersToProfilelessAvatar`.

## How to test

1. In a scene with an NPC (`AvatarShape`) and an `AvatarModifierArea`, walk in and out of the area together with the NPC:
   - `HIDE_NAMETAGS`: the NPC name disappears inside and comes back outside.
   - `HIDE_AVATARS`: the NPC body disappears inside and comes back outside.
2. Regression: the local player and remote players keep the current modifier-area behavior, including `excludeIds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
