### PR TITLE
fix: handle multi-parcel scene as home

### DIFF
--- a/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/HomeMarkerInstaller.cs
+++ b/Explorer/Assets/DCL/MapRenderer/ComponentsFactory/HomeMarkerInstaller.cs
@@ -13,50 +13,51 @@ using Utility;
 
 namespace DCL.MapRenderer.ComponentsFactory
 {
-	internal struct HomeMarkerInstaller
-	{
-		public async UniTask<IMapLayerController> InstallAsync(
-			Dictionary<MapLayer, IMapLayerController> writer,
-			List<IZoomScalingLayer> zoomScalingWriter,
-			MapRendererConfiguration configuration,
-			ICoordsUtils coordsUtils,
-			IMapCullingController cullingController,
-			INavmapBus navmapBus,
-			IPlacesAPIService placesAPIService,
-			IMapRendererSettings mapSettings,
-			IAssetsProvisioner assetsProvisioner,
-			HomePlaceEventBus homePlaceEventBus,
-			IEventBus analyticsEventBus,
-			CancellationToken cancellationToken)
-		{
-			HomeMarkerObject prefab = (await assetsProvisioner.ProvideMainAssetAsync(mapSettings.HomeMarker, ct: cancellationToken)).Value;
+    internal struct HomeMarkerInstaller
+    {
+        public async UniTask<IMapLayerController> InstallAsync(
+            Dictionary<MapLayer, IMapLayerController> writer,
+            List<IZoomScalingLayer> zoomScalingWriter,
+            MapRendererConfiguration configuration,
+            ICoordsUtils coordsUtils,
+            IMapCullingController cullingController,
+            INavmapBus navmapBus,
+            IPlacesAPIService placesAPIService,
+            IMapRendererSettings mapSettings,
+            IAssetsProvisioner assetsProvisioner,
+            HomePlaceEventBus homePlaceEventBus,
+            IEventBus analyticsEventBus,
+            CancellationToken cancellationToken)
+        {
+            HomeMarkerObject prefab = (await assetsProvisioner.ProvideMainAssetAsync(mapSettings.HomeMarker, ct: cancellationToken)).Value;
 
-			var homeMarkerController = new HomeMarkerController(
-				CreateMarker,
-				configuration.HomeMarkerRoot,
-				coordsUtils,
-				cullingController,
-				navmapBus,
-				placesAPIService,
-				analyticsEventBus
-			);
-			homePlaceEventBus.Controller = homeMarkerController;
+            var homeMarkerController = new HomeMarkerController(
+                CreateMarker,
+                configuration.HomeMarkerRoot,
+                coordsUtils,
+                cullingController,
+                navmapBus,
+                placesAPIService,
+                analyticsEventBus
+            );
 
-			homeMarkerController.Initialize();
+            homePlaceEventBus.SetController(homeMarkerController);
 
-			writer.Add(MapLayer.HomeMarker, homeMarkerController);
-			zoomScalingWriter.Add(homeMarkerController);
-			
-			return homeMarkerController;
+            homeMarkerController.Initialize();
 
-			IHomeMarker CreateMarker(Transform parent)
-			{
-				HomeMarkerObject markerObject = Object.Instantiate(prefab, parent);
-				coordsUtils.SetObjectScale(markerObject);
-				markerObject.SetSortingOrder(MapRendererDrawOrder.HOME_MARKER);
+            writer.Add(MapLayer.HomeMarker, homeMarkerController);
+            zoomScalingWriter.Add(homeMarkerController);
 
-				return new HomeMarker(markerObject);
-			}
-		}
-	}
+            return homeMarkerController;
+
+            IHomeMarker CreateMarker(Transform parent)
+            {
+                HomeMarkerObject markerObject = Object.Instantiate(prefab, parent);
+                coordsUtils.SetObjectScale(markerObject);
+                markerObject.SetSortingOrder(MapRendererDrawOrder.HOME_MARKER);
+
+                return new HomeMarker(markerObject);
+            }
+        }
+    }
 }

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/HomeMarker/HomePlaceEventBus.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/HomeMarker/HomePlaceEventBus.cs
@@ -9,7 +9,7 @@ namespace DCL.MapRenderer.MapLayers.HomeMarker
     {
         public Vector2Int? CurrentHomeCoordinates => controller?.CurrentCoordinates;
         public string? CurrentHomeWorldName => controller?.CurrentWorldName;
-        public bool IsWorldHome => controller != null && controller!.IsWorldHome;
+        public bool IsWorldHome => controller is { IsWorldHome: true };
 
         private HomeMarkerController? controller;
 
@@ -57,6 +57,6 @@ namespace DCL.MapRenderer.MapLayers.HomeMarker
         }
 
         public void DisplayPlacesInfoPanel(Vector2Int coords) =>
-            controller!.DisplayPlacesInfoPanelAsync(coords).Forget();
+            controller?.DisplayPlacesInfoPanelAsync(coords).Forget();
     }
 }

--- a/Explorer/Assets/DCL/MapRenderer/MapLayers/HomeMarker/HomePlaceEventBus.cs
+++ b/Explorer/Assets/DCL/MapRenderer/MapLayers/HomeMarker/HomePlaceEventBus.cs
@@ -5,43 +5,58 @@ using Utility;
 
 namespace DCL.MapRenderer.MapLayers.HomeMarker
 {
-	public class HomePlaceEventBus
-	{
-		internal HomeMarkerController Controller;
+    public class HomePlaceEventBus
+    {
+        public Vector2Int? CurrentHomeCoordinates => controller?.CurrentCoordinates;
+        public string? CurrentHomeWorldName => controller?.CurrentWorldName;
+        public bool IsWorldHome => controller != null && controller!.IsWorldHome;
 
-		public Vector2Int? CurrentHomeCoordinates => Controller.CurrentCoordinates;
-		public string? CurrentHomeWorldName => Controller.CurrentWorldName;
-		public bool IsWorldHome => Controller.IsWorldHome;
+        private HomeMarkerController? controller;
 
-		public void SetAsHome(Vector2Int coordinates)
-		{
-			Controller.SetMarker(coordinates);
-		}
+        public void SetController(HomeMarkerController ctrl) =>
+            this.controller = ctrl;
 
-		public void SetAsHome(string worldName)
-		{
-			Controller.SetWorldMarker(worldName);
-		}
+        public void SetAsHome(Vector2Int coordinates) =>
+            controller?.SetMarker(coordinates);
 
-		public void UnsetHome()
-		{
-			if (Controller.IsWorldHome)
-				Controller.SetWorldMarker(null);
-			else
-				Controller.SetMarker(null);
-		}
+        public void SetAsHome(string worldName) =>
+            controller?.SetWorldMarker(worldName);
 
-		public bool IsHome(PlacesData.PlaceInfo placeInfo)
-		{
-			if (!string.IsNullOrEmpty(placeInfo.world_name))
-				return CurrentHomeWorldName == placeInfo.world_name;
+        public void UnsetHome()
+        {
+            if (controller == null)
+                return;
 
-			if (VectorUtilities.TryParseVector2Int(placeInfo.base_position, out var coordinates))
-				return CurrentHomeCoordinates == coordinates;
+            if (controller.IsWorldHome)
+                controller.SetWorldMarker(null);
+            else
+                controller.SetMarker(null);
+        }
 
-			return false;
-		}
+        public bool IsHome(PlacesData.PlaceInfo placeInfo)
+        {
+            if (!string.IsNullOrEmpty(placeInfo.world_name))
+                return CurrentHomeWorldName == placeInfo.world_name;
 
-		public void DisplayPlacesInfoPanel(Vector2Int coords) => Controller.DisplayPlacesInfoPanelAsync(coords).Forget();
-	}
+            if (IsWorldHome || !CurrentHomeCoordinates.HasValue)
+                return false;
+
+            Vector2Int homeCoordinates = CurrentHomeCoordinates.Value;
+
+            // Home is stored as a single parcel, so any parcel of the place must count for the whole place.
+            if (placeInfo.Positions is { Length: > 0 })
+            {
+                foreach (Vector2Int position in placeInfo.Positions)
+                    if (position == homeCoordinates)
+                        return true;
+
+                return false;
+            }
+
+            return VectorUtilities.TryParseVector2Int(placeInfo.base_position, out Vector2Int coordinates) && coordinates == homeCoordinates;
+        }
+
+        public void DisplayPlacesInfoPanel(Vector2Int coords) =>
+            controller!.DisplayPlacesInfoPanelAsync(coords).Forget();
+    }
 }

--- a/Explorer/Assets/DCL/MapRenderer/Tests/HomeMarker/HomeMarkerControllerShould.cs
+++ b/Explorer/Assets/DCL/MapRenderer/Tests/HomeMarker/HomeMarkerControllerShould.cs
@@ -70,7 +70,7 @@ namespace DCL.MapRenderer.Tests.HomeMarker
 				placesAPIService,
 				eventBus
 			);
-			homePlaceEventBus.Controller = controller;
+			homePlaceEventBus.SetController(controller);
 
 			// Clear prefs keys (safe because player prefs are replaced for test duration)
 			if (DCLPlayerPrefs.HasVectorKey(DCLPrefKeys.MAP_HOME_MARKER_DATA))
@@ -313,6 +313,51 @@ namespace DCL.MapRenderer.Tests.HomeMarker
             homePlaceEventBus.SetAsHome("testworld.dcl.eth");
 
             var placeInfo = new PlacesData.PlaceInfo(Vector2Int.zero) { world_name = "otherworld.dcl.eth" };
+            Assert.IsFalse(homePlaceEventBus.IsHome(placeInfo));
+        }
+
+        [Test]
+        public void IdentifyPlaceAsHomeWhenHomeIsOnNonBaseParcel()
+        {
+            // Arrange
+            controller.Initialize();
+            homePlaceEventBus.SetAsHome(new Vector2Int(2, 3));
+
+            var placeInfo = new PlacesData.PlaceInfo(Vector2Int.zero)
+            {
+                Positions = new[] { Vector2Int.zero, new Vector2Int(1, 0), new Vector2Int(2, 3) },
+            };
+
+            // Act & Assert
+            Assert.IsTrue(homePlaceEventBus.IsHome(placeInfo));
+        }
+
+        [Test]
+        public void NotIdentifyPlaceAsHomeWhenHomeIsOutsideItsParcels()
+        {
+            // Arrange
+            controller.Initialize();
+            homePlaceEventBus.SetAsHome(new Vector2Int(5, 5));
+
+            var placeInfo = new PlacesData.PlaceInfo(Vector2Int.zero)
+            {
+                Positions = new[] { Vector2Int.zero, new Vector2Int(1, 0) },
+            };
+
+            // Act & Assert
+            Assert.IsFalse(homePlaceEventBus.IsHome(placeInfo));
+        }
+
+        [Test]
+        public void NotIdentifyParcelPlaceAsHomeWhenHomeIsWorld()
+        {
+            // Arrange
+            controller.Initialize();
+            homePlaceEventBus.SetAsHome("testworld.dcl.eth");
+
+            var placeInfo = new PlacesData.PlaceInfo(Vector2Int.zero);
+
+            // Act & Assert
             Assert.IsFalse(homePlaceEventBus.IsHome(placeInfo));
         }
 	}

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -87,6 +87,7 @@ namespace DCL.Minimap
         private SceneRestrictionsController? sceneRestrictionsController;
         private bool isOwnPlayerBanned;
         private ToggleContextMenuControlSettings? homeToggleSettings;
+        private PlacesData.PlaceInfo? currentPlaceInfo;
         private string previousRealmName = string.Empty;
 
         public IReadOnlyDictionary<MapLayer, IMapLayerParameter> LayersParameters { get; } = new Dictionary<MapLayer, IMapLayerParameter>
@@ -257,10 +258,20 @@ namespace DCL.Minimap
                 isHome = string.Equals(homeWorldName, realmData.RealmName, StringComparison.OrdinalIgnoreCase);
             }
             else
-                isHome = !homePlaceEventBus.IsWorldHome && homePlaceEventBus.CurrentHomeCoordinates == previousParcelPosition;
+            {
+                PlacesData.PlaceInfo? place = GetPlaceCoveringHome();
+
+                isHome = place != null
+                    ? homePlaceEventBus.IsHome(place)
+                    : !homePlaceEventBus.IsWorldHome && homePlaceEventBus.CurrentHomeCoordinates == previousParcelPosition;
+            }
 
             homeToggleSettings?.SetInitialValue(isHome);
         }
+
+        // Roads are a single place spanning the whole map, so they keep the per-parcel behaviour.
+        private PlacesData.PlaceInfo? GetPlaceCoveringHome() =>
+            currentPlaceInfo != null && !TeleportUtils.IsRoad(currentPlaceInfo.title) ? currentPlaceInfo : null;
 
         private void ShowContextMenu()
         {
@@ -277,16 +288,23 @@ namespace DCL.Minimap
                 if (realmData.ScenesAreFixed)
                     homePlaceEventBus.SetAsHome(realmData.RealmName);
                 else
-                    homePlaceEventBus.SetAsHome(previousParcelPosition);
+                    homePlaceEventBus.SetAsHome(ResolveHomeParcel());
             }
             else
-            {
                 homePlaceEventBus.UnsetHome();
-            }
 
             // Opening context menu loses focus of minimap, so for pin to showup immediately we have to simulate
             // gaining focus again.
             OnFocus();
+        }
+
+        private Vector2Int ResolveHomeParcel()
+        {
+            PlacesData.PlaceInfo? place = GetPlaceCoveringHome();
+
+            return place != null && VectorUtilities.TryParseVector2Int(place.base_position, out Vector2Int basePosition)
+                ? basePosition
+                : previousParcelPosition;
         }
 
         private void OnFavoriteButtonClicked(bool value)
@@ -440,6 +458,7 @@ namespace DCL.Minimap
                 return;
 
             previousParcelPosition = playerParcelPosition;
+            currentPlaceInfo = null;
 
             if (realmData.Configured)
                 previousRealmName = realmData.RealmName;
@@ -476,6 +495,7 @@ namespace DCL.Minimap
             else
             {
                 PlacesData.PlaceInfo? placeInfo = await GetPlaceInfoAsync(parcelPosition, ct);
+                currentPlaceInfo = placeInfo;
 
                 if (placeInfo != null)
                 {


### PR DESCRIPTION
# Pull Request Description

Fixes #8618 

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR addresses the issue of setting as Home a parcel contained in a multi-parcel scene.

Before, the toggle on the minimap was on only in the exact coordinate. Now, if the coordinate is of a multi-parcel scene, home will be recognized on the entire scene.


### Test Steps
1. Follow the repro step in the linked issue
2. Read the last comment in the linked issue and repro that case as well (multi-parcel scene)
3. Make sure the feature works as expected

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
