### PR TITLE
fix: use custom base domain for abgen read-through

### DIFF
--- a/.github/actions/ci-status-comment/build-run-attempted.sh
+++ b/.github/actions/ci-status-comment/build-run-attempted.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Answers one question for pr-comment-artifact-url.yml: did this "Unity Cloud
+# Build" run actually attempt a build, or was it a deliberate no-op?
+#
+# build-unitycloud.yml subscribes to pull_request `labeled`/`unlabeled` because
+# four labels (force-build, clean-build, windows-only, macos-only) re-trigger a
+# build. GitHub cannot filter label events by name in `on:`, so *every* label
+# add/remove starts a run; the prebuild job's `if` then filters it out and the
+# run finishes `success` with nothing built. The same shape happens for a draft
+# without force-build and for the perf_test label.
+#
+# Such a run says nothing about the build, so the comment's build section must
+# be left exactly as the last real run left it. Without this probe the no-op run
+# reads as "a build ran and produced no artifacts" and overwrites a green build
+# (download links included) with "Build skipped - no changes detected".
+#
+# The signal is the Prebuild job: `skipped` means the run was filtered out.
+# Absent with no jobs at all means the run was cancelled by concurrency before
+# any job materialised - also a no-op.
+#
+# Prints `true` (a build was attempted; the section may be written) or `false`
+# (no-op; leave the section alone) on stdout.
+#
+# Endpoints omit the leading slash so Git Bash (MSYS) does not rewrite them into
+# Windows filesystem paths when the script is run locally.
+#
+# Usage: RUN_ID=<id> OWNER=<owner> REPO=<repo> [WAIT_SECONDS=300] [POLL_SECONDS=5] \
+#          bash build-run-attempted.sh
+#
+# WAIT_SECONDS is for the `requested` caller, which asks before the run has
+# started: 0 (the default) answers from the run's current state, which is all a
+# `completed` caller needs.
+set -euo pipefail
+
+: "${RUN_ID:?RUN_ID is required}"
+: "${OWNER:?OWNER is required}"
+: "${REPO:?REPO is required}"
+WAIT_SECONDS="${WAIT_SECONDS:-0}"
+POLL_SECONDS="${POLL_SECONDS:-5}"
+
+# The job that decides whether anything gets built. Renaming it in
+# build-unitycloud.yml without updating this breaks the probe, so a completed
+# run that has jobs but not this one is a hard error rather than a silent
+# "no-op" that would freeze the build section forever.
+PREBUILD_JOB_NAME='Prebuild'
+
+log() { echo "[build-run-attempted] $*" >&2; }
+
+deadline=$(( $(date +%s) + WAIT_SECONDS ))
+
+while :; do
+  jobs_json=$(gh api "repos/$OWNER/$REPO/actions/runs/$RUN_ID/jobs?per_page=100")
+
+  prebuild=$(jq -c --arg name "$PREBUILD_JOB_NAME" \
+    'first(.jobs[] | select(.name == $name)) // empty' <<< "$jobs_json")
+
+  if [ -n "$prebuild" ]; then
+    status=$(jq -r '.status' <<< "$prebuild")
+    conclusion=$(jq -r '.conclusion // ""' <<< "$prebuild")
+    log "$PREBUILD_JOB_NAME: status=$status conclusion=${conclusion:-null}"
+
+    if [ "$conclusion" = "skipped" ]; then
+      log "prebuild was filtered out (label/draft/perf_test event) - no build attempted"
+      echo false
+      exit 0
+    fi
+
+    # Anything past `queued` means the build decision is being made for real.
+    if [ "$status" != "queued" ]; then
+      echo true
+      exit 0
+    fi
+  else
+    job_count=$(jq '.jobs | length' <<< "$jobs_json")
+    run_status=$(gh api "repos/$OWNER/$REPO/actions/runs/$RUN_ID" --jq '.status')
+    log "no $PREBUILD_JOB_NAME job yet (jobs=$job_count, run status=$run_status)"
+
+    if [ "$job_count" -gt 0 ]; then
+      names=$(jq -r '[.jobs[].name] | join(", ")' <<< "$jobs_json")
+      echo "::error::Run $RUN_ID has jobs but none named '$PREBUILD_JOB_NAME' (found: $names). Update PREBUILD_JOB_NAME in $(basename "${BASH_SOURCE[0]}") to match build-unitycloud.yml." >&2
+      exit 2
+    fi
+
+    if [ "$run_status" = "completed" ]; then
+      log "run finished without starting a job (cancelled while queued) - no build attempted"
+      echo false
+      exit 0
+    fi
+  fi
+
+  now=$(date +%s)
+  if [ "$now" -ge "$deadline" ]; then
+    # Still queued past the wait budget. Assume a build is coming, which keeps
+    # the pre-probe behaviour (reset the section to Pending) for this case.
+    log "still queued after ${WAIT_SECONDS}s - assuming a build is coming"
+    echo true
+    exit 0
+  fi
+
+  sleep "$POLL_SECONDS"
+done

--- a/.github/actions/ci-status-comment/test-build-run-attempted.sh
+++ b/.github/actions/ci-status-comment/test-build-run-attempted.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Functional tests for build-run-attempted.sh against a stubbed gh that serves
+# canned /jobs and /runs responses from files — no network, no repo. Each
+# scenario can hand out a different response per poll iteration (jobs.1.json,
+# jobs.2.json, ...) to exercise the wait loop. Run from anywhere:
+#   bash .github/actions/ci-status-comment/test-build-run-attempted.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROBE="$SCRIPT_DIR/build-run-attempted.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- gh stub ----------------------------------------------------------------
+# Serves $SCENARIO/<kind>.<call-number>.json, falling back to the highest
+# numbered file at or below the current call, so a scenario that wants one
+# steady answer just writes <kind>.1.json.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = api ] || { echo "gh stub: unsupported subcommand $1" >&2; exit 64; }
+path="$2"
+case "$path" in
+  */jobs*) kind=jobs ;;
+  *)       kind=run ;;
+esac
+counter="$SCENARIO/.calls.$kind"
+n=1
+[ -f "$counter" ] && n=$(( $(cat "$counter") + 1 ))
+echo "$n" > "$counter"
+file=""
+for try in $(seq "$n" -1 1); do
+  if [ -f "$SCENARIO/$kind.$try.json" ]; then file="$SCENARIO/$kind.$try.json"; break; fi
+done
+[ -n "$file" ] || { echo "gh stub: no canned $kind response for call $n" >&2; exit 65; }
+if [ "${3:-}" = "--jq" ]; then jq -r "$4" < "$file"; else cat "$file"; fi
+STUB
+chmod +x "$WORK/bin/gh"
+export PATH="$WORK/bin:$PATH"
+
+# --- helpers ----------------------------------------------------------------
+FAILURES=0
+PASSES=0
+
+jobs_json() { # jobs_json '<name>:<status>:<conclusion>' ...
+  local out='{"jobs":[' first=1 spec name status conclusion
+  for spec in "$@"; do
+    IFS=: read -r name status conclusion <<< "$spec"
+    [ $first -eq 1 ] || out+=','
+    first=0
+    if [ -z "$conclusion" ]; then
+      out+="{\"name\":\"$name\",\"status\":\"$status\",\"conclusion\":null}"
+    else
+      out+="{\"name\":\"$name\",\"status\":\"$status\",\"conclusion\":\"$conclusion\"}"
+    fi
+  done
+  echo "$out]}"
+}
+
+new_scenario() {
+  SCENARIO="$WORK/$1"
+  mkdir -p "$SCENARIO"
+  export SCENARIO
+}
+
+# expect <name> <expected-stdout> <expected-exit>
+expect() {
+  local name="$1" want="$2" want_code="$3" got code=0
+  got=$(RUN_ID=42 OWNER=o REPO=r WAIT_SECONDS="${WAIT:-0}" POLL_SECONDS=0 \
+        bash "$PROBE" 2>"$SCENARIO/stderr") || code=$?
+  if [ "$got" = "$want" ] && [ "$code" -eq "$want_code" ]; then
+    echo "  ok   $name"
+    PASSES=$((PASSES + 1))
+  else
+    echo "  FAIL $name: want stdout='$want' exit=$want_code, got stdout='$got' exit=$code"
+    sed 's/^/         /' "$SCENARIO/stderr"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "test-build-run-attempted.sh"
+
+# 1. The reported bug: a label event filtered prebuild out. PRs 9999 / 9929.
+new_scenario skipped-prebuild
+jobs_json 'Prebuild:completed:skipped' 'Build:completed:skipped' \
+  'Build Gate (Windows + macOS):completed:success' > "$SCENARIO/jobs.1.json"
+expect "prebuild skipped => false" false 0
+
+# 2. A real run.
+new_scenario real-run
+jobs_json 'Prebuild:completed:success' 'Build (macos):completed:success' \
+  'Build (windows64):completed:success' > "$SCENARIO/jobs.1.json"
+expect "prebuild succeeded => true" true 0
+
+# 3. Prebuild itself failed — a real attempt, so the section must be updated.
+new_scenario failed-prebuild
+jobs_json 'Prebuild:completed:failure' > "$SCENARIO/jobs.1.json"
+expect "prebuild failed => true" true 0
+
+# 4. Cancelled by concurrency before any job started. PR 9955's label run.
+new_scenario cancelled-while-queued
+echo '{"jobs":[]}' > "$SCENARIO/jobs.1.json"
+echo '{"status":"completed"}' > "$SCENARIO/run.1.json"
+expect "no jobs + run completed => false" false 0
+
+# 5. Asked before the run started: no jobs yet, then prebuild picks up.
+new_scenario waits-for-start
+echo '{"jobs":[]}' > "$SCENARIO/jobs.1.json"
+echo '{"status":"queued"}' > "$SCENARIO/run.1.json"
+jobs_json 'Prebuild:in_progress:' > "$SCENARIO/jobs.2.json"
+WAIT=60 expect "waits through empty job list => true" true 0
+
+# 6. Asked before the run started, and it turns out to be a label no-op.
+new_scenario waits-then-skipped
+jobs_json 'Prebuild:queued:' > "$SCENARIO/jobs.1.json"
+jobs_json 'Prebuild:completed:skipped' > "$SCENARIO/jobs.2.json"
+WAIT=60 expect "waits through queued prebuild => false" false 0
+
+# 7. Drift guard: prebuild renamed in build-unitycloud.yml.
+new_scenario renamed-prebuild
+jobs_json 'Preflight:completed:success' > "$SCENARIO/jobs.1.json"
+echo '{"status":"completed"}' > "$SCENARIO/run.1.json"
+expect "jobs but no Prebuild => hard error" "" 2
+
+# 8. Out of wait budget with prebuild still queued: keep the old behaviour.
+new_scenario queued-past-deadline
+jobs_json 'Prebuild:queued:' > "$SCENARIO/jobs.1.json"
+expect "queued past deadline => true" true 0
+
+echo
+if [ "$FAILURES" -gt 0 ]; then
+  echo "$FAILURES failed, $PASSES passed"
+  exit 1
+fi
+echo "all $PASSES passed"

--- a/.github/workflows/ci-scripts-tests.yml
+++ b/.github/workflows/ci-scripts-tests.yml
@@ -3,9 +3,10 @@
 name: CI Scripts Tests
 
 # Tests for the CI plumbing itself: build.py's pure helpers (including the
-# URL_RE drift guard against ucb-build-links) and the unified status comment's
-# upsert script against a stubbed gh. Cheap and network-free, so it runs on
-# any PR touching these paths.
+# URL_RE drift guard against ucb-build-links), the unified status comment's
+# upsert script and the no-op-build-run probe that decides whether a Unity
+# Cloud Build run may write that comment, all against a stubbed gh. Cheap and
+# network-free, so it runs on any PR touching these paths.
 on:
   pull_request:
     paths:
@@ -32,3 +33,6 @@ jobs:
 
       - name: Functional tests (upsert-ci-status.sh, stubbed gh)
         run: bash .github/actions/ci-status-comment/test-upsert-ci-status.sh
+
+      - name: Functional tests (build-run-attempted.sh, stubbed gh)
+        run: bash .github/actions/ci-status-comment/test-build-run-attempted.sh

--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -10,6 +10,15 @@ name: Comment Artifact URL on PR
 #                starts, so last build's download links never linger as stale.
 # 'completed' -> fill the section back in: Success (with artifact links) /
 #                Failed / Skipped (no changes under Explorer/).
+#
+# Both are gated on build-run-attempted.sh. build-unitycloud.yml also runs for
+# events that build nothing on purpose — any pull_request labeled/unlabeled
+# (only four label names re-trigger a build, and `on:` cannot filter by name),
+# a draft without force-build, the perf_test label — and such a run finishes
+# `success` with no artifacts, which is indistinguishable here from a real run
+# that had nothing to build. Writing the section for one of those replaces a
+# green build and its download links with "Build skipped", so a run that
+# attempted no build leaves every section untouched.
 on:
   workflow_run:
     types:
@@ -58,7 +67,24 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
+      # 'requested' fires before the run has decided anything, and a label event
+      # starts a run that builds nothing (see build-run-attempted.sh). Resetting
+      # to Pending for one of those throws away the previous build's download
+      # links, so wait for Prebuild to pick the run up before writing.
+      - name: Check whether this run will build
+        id: attempted
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          WAIT_SECONDS: '300'
+        run: |
+          attempted=$(bash .github/actions/ci-status-comment/build-run-attempted.sh)
+          echo "build-attempted=$attempted" >> "$GITHUB_OUTPUT"
+
       - name: Reset build section to pending
+        if: steps.attempted.outputs.build-attempted == 'true'
         uses: ./.github/actions/ci-status-comment
         with:
           pr-number: ${{ needs.pre-validation.outputs.pr-number }}
@@ -76,7 +102,30 @@ jobs:
     outputs:
       build-ran: ${{ steps.check.outputs.build-ran }}
       player-artifacts: ${{ steps.check.outputs.player-artifacts }}
+      build-attempted: ${{ steps.attempted.outputs.build-attempted }}
     steps:
+      # A run that built nothing on purpose (label/unlabel event, draft without
+      # force-build, perf_test) says nothing about the build and must leave the
+      # section as the last real run left it — otherwise it reads as "a build ran
+      # and produced no artifacts" and overwrites a green build with "Skipped".
+      - name: Checkout CI status action
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/ci-status-comment
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Check whether this run attempted a build
+        id: attempted
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          attempted=$(bash .github/actions/ci-status-comment/build-run-attempted.sh)
+          echo "build-attempted=$attempted" >> "$GITHUB_OUTPUT"
+
       - name: Check if build jobs actually ran
         id: check
         env:
@@ -114,7 +163,7 @@ jobs:
 
   comment-skipped:
     needs: [pre-validation, check-build-ran]
-    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.player-artifacts == 'false'
+    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.player-artifacts == 'false' && needs.check-build-ran.outputs.build-attempted == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CI status action
@@ -139,8 +188,8 @@ jobs:
   # build job's live writer may have left an In-progress badge and rows up —
   # without this the comment claims a build is running forever.
   comment-cancelled:
-    needs: pre-validation
-    if: github.event.action == 'completed' && github.event.workflow_run.conclusion == 'cancelled' && needs.pre-validation.outputs.pr-number != ''
+    needs: [pre-validation, check-build-ran]
+    if: github.event.action == 'completed' && github.event.workflow_run.conclusion == 'cancelled' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.build-attempted == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CI status action
@@ -163,7 +212,7 @@ jobs:
 
   comment-success:
     needs: [pre-validation, check-build-ran]
-    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.player-artifacts == 'true'
+    if: github.event.workflow_run.conclusion == 'success' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.player-artifacts == 'true' && needs.check-build-ran.outputs.build-attempted == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CI status action
@@ -449,7 +498,7 @@ jobs:
 
   comment-failed:
     needs: [pre-validation, check-build-ran]
-    if: github.event.workflow_run.conclusion == 'failure' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.build-ran == 'true'
+    if: github.event.workflow_run.conclusion == 'failure' && needs.pre-validation.outputs.pr-number != '' && needs.check-build-ran.outputs.build-ran == 'true' && needs.check-build-ran.outputs.build-attempted == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CI status action

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/AbgenSidecarShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/AbgenSidecarShould.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.TestTools;
 
+// ReSharper disable InconsistentNaming
 namespace ECS.StreamableLoading.AssetBundles.Tests
 {
     /// <summary>
@@ -33,7 +34,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
 
             string cacheRoot = Path.Combine(Path.GetTempPath(), "abgen-sidecar-test-" + Guid.NewGuid().ToString("N")[..8]);
 
-            AbgenSidecar? created = AbgenSidecar.TryCreate(AbgenSidecar.ReserveBaseUrl(), "org", cacheRoot);
+            AbgenSidecar? created = AbgenSidecar.TryCreate(AbgenSidecar.ReserveBaseUrl(), "decentraland.org", cacheRoot);
             Assert.IsNotNull(created, "no abgen binary was resolved");
             AbgenSidecar sidecar = created!;
             Assert.IsTrue(await sidecar.StartAsync(CancellationToken.None), "sidecar did not become healthy");
@@ -89,7 +90,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
             Assert.AreEqual(0, dead.responseCode, "sidecar still listening after Dispose");
         }
 
-        // Server schema: abgen /manifest/{entity}_{platform}.json response.
+        // Server schema: decentraland/abgen crate/src/manifest.rs#/write_corpus_manifest — the /manifest/{entity}_{platform}.json body; "files" is always written.
         [Serializable]
         private class ManifestDto
         {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/AbgenSidecarShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/AbgenSidecarShould.cs
@@ -90,6 +90,7 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
             Assert.AreEqual(0, dead.responseCode, "sidecar still listening after Dispose");
         }
 
+        // Server schema: abgen /manifest/{entity}_{platform}.json response.
         [Serializable]
         private class ManifestDto
         {

--- a/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/AbgenSidecarShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/ECS/Unity/StreamableLoading/AssetBundles/Tests/AbgenSidecarShould.cs
@@ -90,7 +90,6 @@ namespace ECS.StreamableLoading.AssetBundles.Tests
             Assert.AreEqual(0, dead.responseCode, "sidecar still listening after Dispose");
         }
 
-        // Server schema: decentraland/abgen crate/src/manifest.rs#/write_corpus_manifest — the /manifest/{entity}_{platform}.json body; "files" is always written.
         [Serializable]
         private class ManifestDto
         {

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecar.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecar.cs
@@ -114,7 +114,7 @@ namespace Global.Dynamic
         ///     path-derived hashes, which never change.
         ///     </para>
         /// </summary>
-        public static AbgenSidecar? TryCreate(string baseUrl, string environmentDomain, string? cacheRoot = null, string? realmRootOverride = null, bool jitContentDigest = false)
+        public static AbgenSidecar? TryCreate(string baseUrl, string baseDomain, string? cacheRoot = null, string? realmRootOverride = null, bool jitContentDigest = false)
         {
             string? exe = TryFindPinnedExecutable() ?? (File.Exists(StreamingAssetsExecutablePath) ? StreamingAssetsExecutablePath : null);
 
@@ -123,8 +123,8 @@ namespace Global.Dynamic
 
             return new AbgenSidecar(baseUrl,
                 exe,
-                realmRootOverride?.TrimEnd('/') ?? $"https://peer.decentraland.{environmentDomain}",
-                $"https://ab-cdn.decentraland.{environmentDomain}",
+                realmRootOverride?.TrimEnd('/') ?? $"https://peer.{baseDomain}",
+                $"https://ab-cdn.{baseDomain}",
                 cacheRoot ?? Path.Combine(Application.persistentDataPath, realmRootOverride == null ? AbgenBundleDiskCache.SIDECAR_DIR : AbgenBundleDiskCache.SIDECAR_LSD_DIR),
                 jitContentDigest);
         }

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecarBootstrap.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/AbgenSidecarBootstrap.cs
@@ -1,6 +1,5 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
-using DCL.Multiplayer.Connections.DecentralandUrls;
 using ECS.StreamableLoading.AssetBundles;
 using System;
 using System.Threading;
@@ -15,7 +14,7 @@ namespace Global.Dynamic
     /// </summary>
     public sealed class AbgenSidecarBootstrap : IDisposable
     {
-        private readonly DecentralandEnvironment environment;
+        private readonly string baseDomain;
         private readonly CancellationTokenSource lifeCycleCancellationTokenSource = new ();
 
         private AbgenSidecar? sidecar;
@@ -29,9 +28,9 @@ namespace Global.Dynamic
         /// </summary>
         public UniTask WarmUpTask { get; private set; } = UniTask.CompletedTask;
 
-        public AbgenSidecarBootstrap(DecentralandEnvironment environment)
+        public AbgenSidecarBootstrap(string baseDomain)
         {
-            this.environment = environment;
+            this.baseDomain = baseDomain;
         }
 
         public void Dispose()
@@ -51,9 +50,7 @@ namespace Global.Dynamic
 
             try
             {
-                string environmentDomain = environment.ToString().ToLower();
-
-                AbgenSidecar? created = AbgenSidecar.TryCreate(BaseUrl, environmentDomain,
+                AbgenSidecar? created = AbgenSidecar.TryCreate(BaseUrl, baseDomain,
                     realmRootOverride: realmRoot, jitContentDigest: true);
 
                 if (created == null)
@@ -64,7 +61,7 @@ namespace Global.Dynamic
                     if (!await AbgenSidecar.EnsurePinnedBinaryAsync(ct))
                         return false;
 
-                    created = AbgenSidecar.TryCreate(BaseUrl, environmentDomain,
+                    created = AbgenSidecar.TryCreate(BaseUrl, baseDomain,
                         realmRootOverride: realmRoot, jitContentDigest: true);
 
                     if (created == null) return false;

--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/MainSceneLoader.cs
@@ -353,7 +353,8 @@ namespace Global.Dynamic
                     ? IRealmNavigator.LOCALHOST
                     : launchSettings.customRealm;
 
-                abgenSidecar = new AbgenSidecarBootstrap(decentralandEnvironment);
+                string baseDomain = DecentralandUrlsSource.ResolveBaseDomain(decentralandEnvironment, customBaseDomain);
+                abgenSidecar = new AbgenSidecarBootstrap(baseDomain);
 
                 if (await abgenSidecar.StartAsync(realmRoot).AttachExternalCancellation(ct))
                     cliOptimizedAssetsUrl = abgenSidecar.BaseUrl;

--- a/docs/abgen-sidecar.md
+++ b/docs/abgen-sidecar.md
@@ -31,8 +31,9 @@ mode no sidecar object is ever constructed.
 
 The sidecar's base URL becomes the optimized-assets source
 (`AssetBundlesCDN` / `LodGeneratorCDN` / `AssetBundleRegistry`): the server JIT-converts the local
-scene and answers everything else — wearables, emotes, LODs, registry records — from the
-production upstream via its built-in ab-cdn read-through and registry pass-through, so no lane
+scene and answers everything else — wearables, emotes, LODs, registry records — from the base
+domain's upstream (`ab-cdn.<base domain>`, with the registry abgen derives beside it) via its
+built-in ab-cdn read-through and registry pass-through, so no lane
 loses content. The loading flow is untouched: bundles stream over loopback via
 `DownloadHandlerAssetBundle` directly into native memory (no managed copies), requested on the
 standard v25+ hash-in-path lane (`{version}/{sceneID}/{hash}`). Deps digests are skipped in LSD


### PR DESCRIPTION
## What does this PR change?

The embedded abgen sidecar derived its upstream CDN from the `DecentralandEnvironment` enum. With `--base-domain interconnected.online`, the enum is `Custom`, so the sidecar attempted to read through `https://ab-cdn.decentraland.custom` and locally rebuilt every cache miss.

This change passes the already-resolved base domain into the sidecar and composes `peer.<base-domain>` / `ab-cdn.<base-domain>` from it, consistent with `DecentralandUrlsSource`. Default environments remain `peer.decentraland.org` / `ab-cdn.decentraland.org`; custom deployments now use their own domain.

## Test Instructions

- A reachable custom deployment, for example `interconnected.online`.

### Test Steps

1. Launch local scene development with `--base-domain interconnected.online` and local asset bundles enabled.
2. Load Genesis Plaza with a cold or empty abgen bundle cache.
3. Inspect the player/sidecar log while asset bundles are requested.

Generally if no asset bundles are working, it gets stuck at ~57% for a while (as long as generating the ab for plaza takes)

### Expected result

- The sidecar log reports `upstream ab-cdn read-through ENABLED` with `https://ab-cdn.interconnected.online`
- There are no DNS failures for `ab-cdn.decentraland.custom` in the local machine.
- Bundles present on the custom CDN are fetched instead of rebuilt locally, load time is noticeable faster than without.