### PR TITLE
feat: pre-commit hook that trims excessive AI comments with Claude

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Tracked pre-commit hook. Git does not run hooks from the repo automatically; enable this
+# directory once per clone with:
+#
+#     bash scripts/install-git-hooks.sh        (sets `git config core.hooksPath .githooks`)
+#
+# Runs the Claude-based comment clean-up over the staged C# files when the commit adds comment
+# lines, shows the proposed trims and asks whether to keep them (see
+# scripts/lint/clean-up-excessive-ai-comments.sh for modes, options and exit codes).
+#
+# Bypass for one commit: `git commit --no-verify` or `SKIP_AI_COMMENT_CLEANUP=1 git commit ...`.
+# Missing Claude Code CLI never blocks the commit.
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+bash "$ROOT/scripts/lint/clean-up-excessive-ai-comments.sh" interactive --staged
+rc=$?
+
+if [ "$rc" -eq 2 ]; then
+    echo "pre-commit: commit aborted by the comment clean-up." >&2
+    exit 1
+fi
+
+# Any other outcome (kept, discarded, nothing to do, tooling missing) lets the commit through.
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ Before writing or modifying any code, follow the code-standards skill for naming
 
 A `Stop` hook (`.claude/settings.json` → [`scripts/lint/lint-changed.sh`](scripts/lint/lint-changed.sh)) runs ReSharper InspectCode over the C# files changed in the session **using the exact same scripts, flags, and `.editorconfig` rules as CI** (`scripts/lint/{download-resharper,run-inspectcode,filter-warnings}.sh`, shared with `.github/workflows/test.yml`). Resolve any issues it reports in files you changed before finishing — they are real CI lint findings. If the ReSharper CLI isn't installed it prints how to get it (`bash scripts/lint/download-resharper.sh`) and does not block. It only inspects when `.cs` files changed.
 
+A tracked `pre-commit` hook ([`.githooks/pre-commit`](.githooks/pre-commit), enabled per clone via `bash scripts/install-git-hooks.sh`) runs [`scripts/lint/clean-up-excessive-ai-comments.sh`](scripts/lint/clean-up-excessive-ai-comments.sh) when a commit adds comment lines to C# files. It asks Claude to trim excessive comments introduced by the branch and to enforce the comment rule in § 11 below, then lets the committer keep or discard the edits. The script's `go` mode does the same non-interactively; run it with `--help` for the argument reference.
+
 ---
 
 ## Project Code Standards for Claude Reviews

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -72,6 +72,20 @@ By default LODs are currently disabled in Explorer Alpha because they are too bi
 
 2. To get LODs working you just need to extract the above into the following folder: `StreamingAssets/AssetBundles/lods`
 
+## Git hooks
+
+Versioned hooks live in [`.githooks/`](../.githooks/). Git does not run them from a checkout on its own, so enable them once per clone:
+
+```bash
+bash scripts/install-git-hooks.sh   # sets git config core.hooksPath .githooks
+```
+
+Currently installed:
+
+- **`pre-commit`** — when a commit adds comment lines to C# files, runs [`scripts/lint/clean-up-excessive-ai-comments.sh`](../scripts/lint/clean-up-excessive-ai-comments.sh) in interactive mode. It asks Claude Code to trim excessive comments introduced by the branch (the repo rule: a comment describes only the code it annotates, never callers or other scopes), shows the proposed edits as a diff and asks to keep, discard, or abort. Requires the `claude` CLI; without it the hook prints a hint and lets the commit through. Bypass one commit with `git commit --no-verify` or `SKIP_AI_COMMENT_CLEANUP=1`.
+
+The same script has a non-interactive `go` mode for batch clean-ups and agents. Run it with `--help` for the full argument reference.
+
 ## Build Automation & CI
 
 For documentation on GitHub workflows, the Python build handler, and Unity Cloud setup, see [Build & CI](build-and-ci.md).

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Enable the repo's tracked git hooks (.githooks/) for this clone.
+#
+# Git never runs hooks straight from a checkout: it only looks in .git/hooks (untracked) or in
+# the directory named by `core.hooksPath`. This script points `core.hooksPath` at .githooks so
+# the versioned hooks run, and marks them executable. Run it once per clone:
+#
+#     bash scripts/install-git-hooks.sh
+#
+# Undo with:  git config --unset core.hooksPath
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+
+echo "Git hooks enabled: core.hooksPath -> .githooks"
+for hook in .githooks/*; do
+    echo "  $(basename "$hook")"
+done
+
+if ! command -v "${CLAUDE_BIN:-claude}" >/dev/null 2>&1; then
+    echo "Note: Claude Code CLI not found on PATH. The pre-commit comment clean-up will skip until it is installed." >&2
+fi

--- a/scripts/lint/clean-up-excessive-ai-comments.sh
+++ b/scripts/lint/clean-up-excessive-ai-comments.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# clean-up-excessive-ai-comments.sh
+#
+# Uses Claude Code to trim excessive comments introduced by the current PR and to enforce the
+# repo rule that a comment must only describe the code it annotates, never the behaviour of
+# callers or other scopes it does not own (CLAUDE.md § Anti-Patterns, "Comments that narrate
+# caller/external behavior"). Only comments added or changed on this branch are in scope;
+# Claude is told not to touch code, formatting, or pre-existing comments.
+#
+# Usage:
+#   bash scripts/lint/clean-up-excessive-ai-comments.sh [MODE] [OPTIONS]
+#
+# Modes:
+#   interactive   Run Claude, show its proposed edits as a diff, then ask what to do:
+#                 keep them, discard them, or abort. Default when stdin is a terminal.
+#                 This is the mode the pre-commit hook uses (.githooks/pre-commit).
+#   go            Launch-and-go: run Claude and keep its edits without asking. Default when
+#                 stdin is not a terminal. For scripted use (agents, CI, batch clean-ups).
+#
+# Options:
+#   --base <ref>        Ref the PR is compared against. Default: origin/dev, falling back to dev.
+#   --staged            Restrict the scope to files staged for the current commit and skip
+#                       entirely when the staged diff adds no comment lines. Set by the hook.
+#                       Without it, every C# file changed on the branch (committed, staged or
+#                       unstaged) is in scope.
+#   --model <model>     Model passed to Claude Code (default: Claude Code's own default).
+#   --prompt-file <f>   Replace the built-in prompt with the contents of <f>.
+#   -h, --help          Print this header and exit.
+#
+# Environment:
+#   SKIP_AI_COMMENT_CLEANUP=1   Do nothing and exit 0 (the hook also honours `git commit --no-verify`).
+#   CLAUDE_BIN                  Path to the claude executable (default: `claude` on PATH).
+#
+# Exit codes:
+#   0  finished (edits kept, edits discarded, or nothing to do); the hook lets the commit proceed
+#   1  usage or environment error (not inside a git repo, bad arguments)
+#   2  interactive mode: the user chose to abort; the hook stops the commit
+#
+# Claude Code is optional: when it is not installed the script prints an install hint and exits 0
+# so a missing tool never blocks a commit.
+set -uo pipefail
+
+usage() { sed -n '2,/^set -uo pipefail/{ /^set -uo pipefail/d; s/^# \{0,1\}//; p; }' "$0"; }
+
+[ "${SKIP_AI_COMMENT_CLEANUP:-0}" = "1" ] && exit 0
+
+mode=""
+base=""
+staged=0
+model=""
+prompt_file=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        interactive|go) mode="$1" ;;
+        --base) base="${2:?--base needs a ref}"; shift ;;
+        --staged) staged=1 ;;
+        --model) model="${2:?--model needs a value}"; shift ;;
+        --prompt-file) prompt_file="${2:?--prompt-file needs a path}"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "clean-up-excessive-ai-comments: unknown argument '$1'" >&2; usage >&2; exit 1 ;;
+    esac
+    shift
+done
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "clean-up-excessive-ai-comments: not inside a git repository" >&2; exit 1; }
+cd "$ROOT"
+
+if [ -z "$mode" ]; then
+    if [ -t 0 ] || [ -e /dev/tty ]; then mode="interactive"; else mode="go"; fi
+fi
+
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+if ! command -v "$CLAUDE_BIN" >/dev/null 2>&1; then
+    {
+        echo "clean-up-excessive-ai-comments: Claude Code CLI not found - skipping the comment clean-up."
+        echo "Install it from https://docs.claude.com/en/docs/claude-code or set CLAUDE_BIN."
+    } >&2
+    exit 0
+fi
+
+# Resolve the base ref the PR is compared against.
+if [ -z "$base" ]; then
+    for candidate in origin/dev dev; do
+        if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then base="$candidate"; break; fi
+    done
+fi
+[ -z "$base" ] && { echo "clean-up-excessive-ai-comments: cannot resolve a base ref, pass --base <ref>" >&2; exit 1; }
+merge_base="$(git merge-base "$base" HEAD 2>/dev/null)" || { echo "clean-up-excessive-ai-comments: no merge base with '$base'" >&2; exit 1; }
+
+# Scope: C# files introduced or changed by the PR.
+if [ "$staged" -eq 1 ]; then
+    # Only worth running when the commit itself adds comment lines.
+    if ! git diff --cached -U0 --diff-filter=ACM -- '*.cs' | grep -Eq '^\+\s*(//|/\*|\*)'; then
+        exit 0
+    fi
+    files="$(git diff --cached --name-only --diff-filter=ACM -- '*.cs')"
+else
+    files="$(
+        {
+            git diff --name-only --diff-filter=ACM "$merge_base" -- '*.cs'
+            git diff --name-only --diff-filter=ACM --cached -- '*.cs'
+        } | sort -u
+    )"
+fi
+files="$(printf '%s\n' "$files" | sed '/^$/d' | while IFS= read -r f; do [ -f "$f" ] && printf '%s\n' "$f"; done)"
+[ -z "$files" ] && exit 0
+
+# Build the prompt.
+if [ -n "$prompt_file" ]; then
+    prompt="$(cat "$prompt_file")"
+else
+    prompt="$(cat <<EOF
+Clean up excessive comments that were introduced by the current PR.
+
+Scope: only comment lines that this PR added or changed, in the files listed below. The PR diff is
+\`git diff $merge_base -- <file>\` (the merge base with $base). Everything that pre-dates the PR is out of scope.
+
+Enforce the repo rule from CLAUDE.md § Anti-Patterns: a comment must state only what the annotated
+code itself does or guarantees. Remove or rewrite any comment that explains the behaviour of a scope
+it does not own - callers, upper layers, other systems, or what "will" happen elsewhere.
+
+Also apply:
+- Delete comments that merely restate the code next to them.
+- Collapse multi-line narration into one concise line; keep only the non-obvious fact (an invariant,
+  a workaround, an issue reference like #1234).
+- Keep XML doc comments on public members, but shorten verbose ones to one summary line.
+- In tests keep bare Arrange / Act / Assert markers if the file uses them, without explanations.
+
+Constraints:
+- Edit only comment text. Do not change code, identifiers, blank lines outside comments, or formatting.
+- Do not touch comments that pre-date the PR, and do not touch files that are not listed.
+- Do not stage, commit, or run any git command that modifies state.
+- Edit the files in place, then answer with one line per edited file describing what was trimmed,
+  or the single word "nothing" if no comment needed a change.
+
+Files:
+$(printf '%s\n' "$files" | sed 's/^/- /')
+EOF
+)"
+fi
+
+# Snapshot the in-scope files so Claude's edits can be shown and reverted precisely.
+backup="$(mktemp -d)"
+trap 'rm -rf "$backup"' EXIT
+while IFS= read -r f; do
+    mkdir -p "$backup/$(dirname "$f")"
+    cp "$f" "$backup/$f"
+done <<<"$files"
+
+status_before="$(git status --porcelain)"
+
+echo "clean-up-excessive-ai-comments: asking Claude to review comments in $(printf '%s\n' "$files" | wc -l | tr -d ' ') file(s) against $base..." >&2
+
+claude_args=(-p "$prompt" --permission-mode acceptEdits --output-format text
+    --allowedTools "Read" "Edit" "MultiEdit" "Grep" "Glob" "Bash(git diff:*)" "Bash(git merge-base:*)" "Bash(git log:*)")
+[ -n "$model" ] && claude_args+=(--model "$model")
+
+summary="$("$CLAUDE_BIN" "${claude_args[@]}" 2>&1)"
+rc=$?
+if [ $rc -ne 0 ]; then
+    echo "clean-up-excessive-ai-comments: claude exited with $rc - leaving files untouched." >&2
+    printf '%s\n' "$summary" >&2
+    while IFS= read -r f; do cp "$backup/$f" "$f"; done <<<"$files"
+    exit 0
+fi
+
+changed=()
+while IFS= read -r f; do
+    cmp -s "$backup/$f" "$f" || changed+=("$f")
+done <<<"$files"
+
+# Anything Claude touched outside the scope is reported, never silently kept or reverted.
+status_after="$(git status --porcelain)"
+if [ "$status_before" != "$status_after" ]; then
+    unexpected="$(diff <(printf '%s\n' "$status_before") <(printf '%s\n' "$status_after") | grep '^>' | sed 's/^> ...//' | grep -vxF -f <(printf '%s\n' "$files") || true)"
+    [ -n "$unexpected" ] && { echo "clean-up-excessive-ai-comments: WARNING - files changed outside the scope, review them:" >&2; printf '%s\n' "$unexpected" | sed 's/^/  /' >&2; }
+fi
+
+if [ ${#changed[@]} -eq 0 ]; then
+    echo "clean-up-excessive-ai-comments: no comment changes proposed." >&2
+    exit 0
+fi
+
+show_diff() {
+    for f in "${changed[@]}"; do
+        diff -u --label "a/$f" --label "b/$f" "$backup/$f" "$f"
+    done
+}
+
+restore() { for f in "${changed[@]}"; do cp "$backup/$f" "$f"; done; }
+
+# Re-stage files whose staged content Claude changed so the commit picks the trimmed version up.
+restage() {
+    [ "$staged" -eq 1 ] || return 0
+    for f in "${changed[@]}"; do git add -- "$f"; done
+}
+
+if [ "$mode" = "go" ]; then
+    echo "clean-up-excessive-ai-comments: Claude trimmed comments in ${#changed[@]} file(s):" >&2
+    printf '%s\n' "$summary" >&2
+    show_diff >&2
+    restage
+    exit 0
+fi
+
+# Interactive: git hooks run without a terminal on stdin, so talk to the user via /dev/tty.
+if [ ! -t 0 ] && [ -e /dev/tty ]; then exec </dev/tty; fi
+
+{
+    echo
+    echo "clean-up-excessive-ai-comments: Claude proposes these comment changes (${#changed[@]} file(s)):"
+    echo
+    show_diff
+    echo
+    printf '%s\n' "$summary"
+    echo
+} >&2
+
+while :; do
+    printf '[k]eep edits and continue, [d]iscard edits and continue, [a]bort commit? [k/d/a] ' >&2
+    if ! IFS= read -r answer; then answer="d"; fi
+    case "$answer" in
+        k|K|"") restage; echo "clean-up-excessive-ai-comments: edits kept." >&2; exit 0 ;;
+        d|D) restore; echo "clean-up-excessive-ai-comments: edits discarded." >&2; exit 0 ;;
+        a|A) restore; echo "clean-up-excessive-ai-comments: aborted." >&2; exit 2 ;;
+        *) ;;
+    esac
+done

--- a/scripts/lint/clean-up-excessive-ai-comments.sh
+++ b/scripts/lint/clean-up-excessive-ai-comments.sh
@@ -67,7 +67,7 @@ ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "clean-up-excessiv
 cd "$ROOT"
 
 if [ -z "$mode" ]; then
-    if [ -t 0 ] || [ -e /dev/tty ]; then mode="interactive"; else mode="go"; fi
+    if [ -t 0 ]; then mode="interactive"; else mode="go"; fi
 fi
 
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
@@ -108,6 +108,7 @@ files="$(printf '%s\n' "$files" | sed '/^$/d' | while IFS= read -r f; do [ -f "$
 
 # Build the prompt.
 if [ -n "$prompt_file" ]; then
+    [ -f "$prompt_file" ] || { echo "clean-up-excessive-ai-comments: prompt file not found: $prompt_file" >&2; exit 1; }
     prompt="$(cat "$prompt_file")"
 else
     prompt="$(cat <<EOF


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
AI-assisted PRs tend to land with verbose comments that narrate what callers or other layers do, which the repo rule in `CLAUDE.md` § 11 ("Comments that narrate caller/external behavior") forbids. Reviewers currently catch this by hand. This PR adds a tracked pre-commit hook that offers to trim such comments before they are committed.

**New script: `scripts/lint/clean-up-excessive-ai-comments.sh`**
- Runs Claude Code (`claude -p`) with a prompt that scopes it to comments added or changed by the current branch (diff against `origin/dev`), tells it to enforce the CLAUDE.md rule, collapse multi-line narration to one line, drop comments that restate code, and never touch code, formatting or pre-existing comments.
- Two modes:
  - `interactive` (used by the hook): shows Claude's edits as a unified diff, then asks `[k]eep / [d]iscard / [a]bort`. Talks to the user through `/dev/tty` because hooks have no stdin.
  - `go` (launch-and-go): keeps the edits without asking, for agents, batch clean-ups and CI.
- `--staged` restricts the scope to the files of the current commit and skips outright when the staged diff adds no comment lines, so ordinary commits pay nothing.
- Claude's edits are computed against a snapshot of the in-scope files, so discard/abort restore exactly what it changed; edits outside the scope are reported as a warning.
- Missing `claude` CLI prints an install hint and exits 0. `SKIP_AI_COMMENT_CLEANUP=1` and `git commit --no-verify` bypass it. Arguments, environment and exit codes are documented in the file header (`--help` prints it).

**New hook: `.githooks/pre-commit`** runs the script in interactive mode with `--staged`; only an explicit abort stops the commit.

**How the hook is attached.** Git never executes hooks from a checkout: it only looks at the untracked `.git/hooks/` or at `core.hooksPath`. The chosen approach is a versioned `.githooks/` directory plus a one-time per-clone opt-in, `bash scripts/install-git-hooks.sh`, which sets `core.hooksPath` and marks the hooks executable. This keeps the hook reviewable in the repo, makes opting in a single command, and avoids a third-party hook manager (husky/lefthook/pre-commit) that this Unity repo has no toolchain for. Documented in `docs/setup.md` § Git hooks and referenced from `CLAUDE.md`.

## Test Instructions

**Steps (standard run)**: N/A, tooling only; no Explorer build is affected.

**Steps (fresh account)**: N/A

**Automation**: N/A

### Prerequisites
- [ ] Claude Code CLI installed and authenticated (`claude --version`)
- [ ] Git Bash / a POSIX shell (default on macOS, Git for Windows on Windows)

### Test Steps
1. `bash scripts/install-git-hooks.sh` and confirm it prints `core.hooksPath -> .githooks`.
2. `bash scripts/lint/clean-up-excessive-ai-comments.sh --help` and confirm the header is printed.
3. On a branch that adds no C# comments, `git commit` a small change: the hook must stay silent and the commit must go through.
4. Add a verbose multi-line comment to any `.cs` file that describes what a caller does, stage it and `git commit`: after Claude runs (about 1-3 minutes) a diff with the trimmed comment appears and the `[k/d/a]` prompt is shown.
5. Answer `d`: the file is restored and the commit proceeds with the original comment. Repeat and answer `k`: the trimmed version is re-staged and committed. Repeat and answer `a`: the commit is aborted and the file restored.
6. `SKIP_AI_COMMENT_CLEANUP=1 git commit ...` and `git commit --no-verify` both skip the hook.
7. Batch mode: `bash scripts/lint/clean-up-excessive-ai-comments.sh go` on a branch with comment-heavy changes applies the trims directly and prints the diff.

### Additional Testing Notes
- Verified end to end on the bug-sweep branch at `ce12f8af34` (before its manual comment trim): `go` mode edited 8 files, changed only comment lines, and produced the same kind of one-line rewrites a reviewer asked for. Runtime about 3 minutes.
- Only `*.cs` files are in scope by default.
- When a GUI git client runs the hook without a terminal, the `read` fails and the script defaults to discarding Claude's edits, so the commit is never blocked silently.

## Quality Checklist
- [x] Changes have been tested locally
- [x] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.