### PR TITLE
chore: pin AltTester fork with driver transport hardening

### DIFF
--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "arch.systemgroups.visualiser": "https://github.com/m3taphysics/Arch.SystemGroups.Visualiser.git?path=/Packages/arch.systemgroups.visualiser",
-    "com.alttester.sdk": "https://github.com/mikhail-dcl/AltTester-Unity-SDK.git?path=/Assets/AltTester#1983-unity-6000-5-getinstanceid-obsolete",
+    "com.alttester.sdk": "https://github.com/mikhail-dcl/AltTester-Unity-SDK.git?path=/Assets/AltTester#3b2540f507264eeb675bc7787400af485f7e6986",
     "com.arch.systemgroups": "https://github.com/mikhail-dcl/Arch.SystemGroups.git?path=/Arch.SystemGroups",
     "com.atteneder.draco": "4.0.2",
     "com.atteneder.gltfast": "https://github.com/decentraland/unity-gltf.git",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "hash": "e368e96fa8145bfca6ad2947ca60c427d4a81d74"
     },
     "com.alttester.sdk": {
-      "version": "https://github.com/mikhail-dcl/AltTester-Unity-SDK.git?path=/Assets/AltTester#1983-unity-6000-5-getinstanceid-obsolete",
+      "version": "https://github.com/mikhail-dcl/AltTester-Unity-SDK.git?path=/Assets/AltTester#3b2540f507264eeb675bc7787400af485f7e6986",
       "depth": 0,
       "source": "git",
       "dependencies": {
@@ -22,7 +22,7 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.ugui": "1.0.0"
       },
-      "hash": "3c644489030a026eaf49c02eade0127ee975dbd0"
+      "hash": "3b2540f507264eeb675bc7787400af485f7e6986"
     },
     "com.arch.systemgroups": {
       "version": "https://github.com/mikhail-dcl/Arch.SystemGroups.git?path=/Arch.SystemGroups",


### PR DESCRIPTION
## What does this PR change?

Pin `com.alttester.sdk` in the manifest and lockfile to fork commit [`3b2540f5`](https://github.com/mikhail-dcl/AltTester-Unity-SDK/commit/3b2540f507264eeb675bc7787400af485f7e6986). It includes the Unity 6000.5 compatibility and NLog initialization fixes from [AltTester #1984](https://github.com/alttester/AltTester-Unity-SDK/pull/1984), plus a separate transport-hardening commit.

The [transport-only diff](https://github.com/mikhail-dcl/AltTester-Unity-SDK/compare/3c644489030a026eaf49c02eade0127ee975dbd0...3b2540f507264eeb675bc7787400af485f7e6986) fixes reconnect state, requires driver registration, reports failed sends, and isolates command responses across connections. The branch backing #1984 remains unchanged at `3c644489`; these changes are not added to that contribution.

This updates the Unity package only. The external explorer-automation runner still consumes its separate `AltTester-Driver` NuGet package. This PR does not claim to resolve the original intermittent Explorer stall.

## Test Instructions

1. Open `Explorer/` using the Unity version in `Explorer/ProjectSettings/ProjectVersion.txt` and allow Package Manager to resolve dependencies.
2. Verify `com.alttester.sdk` resolves to `3b2540f507264eeb675bc7787400af485f7e6986`, with no AltTester compilation or NLog initialization errors.
3. Launch an instrumented client, connect AltTester Desktop, and smoke-test an object lookup and input command. Confirm the existing Unity compatibility behavior is preserved.

Transport regression checks, from the AltTester fork at the pinned commit:

```powershell
$env:DOTNET_ROLL_FORWARD = 'Major'
dotnet test 'Bindings~/dotnet/AltDriver.Tests/AltDriver.Tests.csproj' --filter 'FullyQualifiedName~TestDriverTransport|FullyQualifiedName~TestAltBaseCommand'
dotnet build 'Bindings~/dotnet/AltDriver/AltDriver.csproj' --configuration Release
```

Completed: 15 tests passed on the full Unity-upgrade base; Release builds for netstandard2.0 and net5.0 passed with zero warnings/errors. Manifest/lockfile consistency, unchanged package dependencies, and upgrade ancestry were verified. Unity import and instrumented-client smoke testing remain pending.

## Quality Checklist

- [x] Local SDK tests/builds and dependency-pin checks passed.
- [x] Only the manifest and lockfile are changed in Explorer.
- [x] Upgrade fixes are retained and AltTester #1984 is unchanged.
- [x] Scope and validation limitations are documented above.
- [ ] Unity import and instrumented-client smoke test completed.
