### PR TITLE
chore: instrument AltTester main-thread stalls

### DIFF
--- a/Explorer/Packages/manifest.json
+++ b/Explorer/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "arch.systemgroups.visualiser": "https://github.com/m3taphysics/Arch.SystemGroups.Visualiser.git?path=/Packages/arch.systemgroups.visualiser",
-    "com.alttester.sdk": "https://github.com/mikhail-dcl/AltTester-Unity-SDK.git?path=/Assets/AltTester#1983-unity-6000-5-getinstanceid-obsolete",
+    "com.alttester.sdk": "https://github.com/mikhail-dcl/AltTester-Unity-SDK.git?path=/Assets/AltTester#0aa90e29cb524f12b8f89f108906a4bd161b9638",
     "com.arch.systemgroups": "https://github.com/mikhail-dcl/Arch.SystemGroups.git?path=/Arch.SystemGroups",
     "com.atteneder.draco": "4.0.2",
     "com.atteneder.gltfast": "https://github.com/decentraland/unity-gltf.git",

--- a/Explorer/Packages/packages-lock.json
+++ b/Explorer/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "hash": "e368e96fa8145bfca6ad2947ca60c427d4a81d74"
     },
     "com.alttester.sdk": {
-      "version": "https://github.com/mikhail-dcl/AltTester-Unity-SDK.git?path=/Assets/AltTester#1983-unity-6000-5-getinstanceid-obsolete",
+      "version": "https://github.com/mikhail-dcl/AltTester-Unity-SDK.git?path=/Assets/AltTester#0aa90e29cb524f12b8f89f108906a4bd161b9638",
       "depth": 0,
       "source": "git",
       "dependencies": {
@@ -22,7 +22,7 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.ugui": "1.0.0"
       },
-      "hash": "3c644489030a026eaf49c02eade0127ee975dbd0"
+      "hash": "0aa90e29cb524f12b8f89f108906a4bd161b9638"
     },
     "com.arch.systemgroups": {
       "version": "https://github.com/mikhail-dcl/Arch.SystemGroups.git?path=/Arch.SystemGroups",


### PR DESCRIPTION
## What does this PR change?

Pin the AltTester fork to [0aa90e29](https://github.com/mikhail-dcl/AltTester-Unity-SDK/commit/0aa90e29cb524f12b8f89f108906a4bd161b9638), adding opt-in background main-thread stage diagnostics to distinguish screenshot capture/encoding from socket-send stalls. Based on Explorer 9d6e552 for comparison with the measured failing build; SDK Unity 6.5 compatibility remains intact and upstream PR1984 is unchanged. Diagnostic only; no stall fix claimed.

## Test Instructions

In PowerShell, set `$env:ALTTESTER_MAIN_THREAD_DIAGNOSTICS='1'`, then run this PR's Windows build with the InWorld suite. Inspect `%USERPROFILE%/AppData/LocalLow/Decentraland/Explorer/AltTesterMainThread.tsv` alongside the Player log and per-test performance report. During a stall, compare heartbeat age, active stage and pending frame wait; without the environment variable, no watchdog should start.

Validation: SDK's 15 source-linked diagnostic assertions passed; manifest and lock pin match. Unity build and CI reproduction pending.

## Quality Checklist

- [x] SDK diagnostic core tested locally; package pins validated
- [x] Enablement and interpretation documented in the SDK
- [x] Diagnostics default off; output bounded; no payload logging
- [ ] Windows player compilation and InWorld diagnostic run
