### PR TITLE
fix: fail startup when own profile cannot be resolved instead of adding a null Profile

### DIFF
--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadPlayerAvatarStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/LoadPlayerAvatarStartupOperation.cs
@@ -7,6 +7,7 @@ using DCL.Profiles.Self;
 using DCL.RealmNavigation;
 using DCL.Utilities;
 using ECS.Prioritization.Components;
+using System;
 using System.Threading;
 
 namespace DCL.UserInAppInitializationFlow
@@ -31,6 +32,11 @@ namespace DCL.UserInAppInitializationFlow
         {
             float finalizationProgress = loadingStatus.SetCurrentStage(LoadingStatus.LoadingStage.ProfileLoading);
             Profile? profile = await selfProfile.ProfileAsync(ct);
+
+            // Fetch failures surface as null; a null Profile component would make every profile system throw each frame.
+            if (profile == null)
+                throw new InvalidOperationException("Own profile could not be resolved, the player entity cannot be initialized");
+
             args.Report.SetProgress(finalizationProgress);
 
             // Add the profile into the player entity so it will create the avatar in world
@@ -41,14 +47,14 @@ namespace DCL.UserInAppInitializationFlow
             if (world.Has<Profile>(playerEntity))
             {
                 // Make all systems update again since the previous profile was already stored and processed, but we now updated it
-                profile!.IsDirty = true;
+                profile.IsDirty = true;
                 world.Set(playerEntity, profile);
             }
             else
-                world.Add(playerEntity, profile!);
+                world.Add(playerEntity, profile);
 
             // Trigger the local player picture download
-            ProfileUtils.CreateProfilePicturePromise(profile!, world, PartitionComponent.TOP_PRIORITY);
+            ProfileUtils.CreateProfilePicturePromise(profile, world, PartitionComponent.TOP_PRIORITY);
 
             // Eventually it will lead to the Avatar Resolution or the entity destruction
             // if the avatar is already downloaded by the authentication screen it will be resolved immediately

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/StartPulseMultiplayerStartupOperation.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/StartupOperations/StartPulseMultiplayerStartupOperation.cs
@@ -3,6 +3,7 @@ using DCL.Diagnostics;
 using DCL.Multiplayer.Connections.Pulse;
 using DCL.Profiles;
 using DCL.Profiles.Self;
+using System;
 using System.Threading;
 
 namespace DCL.UserInAppInitializationFlow
@@ -59,7 +60,11 @@ namespace DCL.UserInAppInitializationFlow
             }
 
             Profile? profile = await selfProfile.ProfileAsync(ct);
-            profilePropagation.Propagate(profile!);
+
+            if (profile == null)
+                throw new InvalidOperationException("Own profile could not be resolved, nothing to propagate to Pulse");
+
+            profilePropagation.Propagate(profile);
             await UniTask.SwitchToMainThread();
         }
     }

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/LoadPlayerAvatarStartupOperationShould.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/LoadPlayerAvatarStartupOperationShould.cs
@@ -5,11 +5,13 @@ using DCL.Profiles;
 using DCL.Profiles.Self;
 using DCL.RealmNavigation;
 using DCL.Utilities;
+using DCL.Utility.Types;
 using ECS.TestSuite;
 using NSubstitute;
 using NUnit.Framework;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace DCL.UserInAppInitializationFlow.Tests
 {
@@ -89,6 +91,26 @@ namespace DCL.UserInAppInitializationFlow.Tests
             operation.ExecuteAsync(MakeParams(playerEntity), cts.Token).GetAwaiter().GetResult();
 
             Assert.AreSame(newProfile, world.Get<Profile>(playerEntity));
+        }
+
+        [Test]
+        public void FailWithoutAddingProfileWhenProfileCannotBeResolved()
+        {
+            // Arrange
+            selfProfile.ProfileAsync(Arg.Any<CancellationToken>())
+                .Returns(UniTask.FromResult<Profile?>(null));
+
+            LogAssert.Expect(LogType.Exception, "InvalidOperationException: Own profile could not be resolved, the player entity cannot be initialized");
+
+            Entity playerEntity = world.Create();
+            var operation = new LoadPlayerAvatarStartupOperation(loadingStatus, selfProfile, avatarBaseProxy);
+
+            // Act
+            EnumResult<TaskError> result = operation.ExecuteAsync(MakeParams(playerEntity), cts.Token).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.IsFalse(result.Success, "A missing own profile must fail the operation instead of continuing with a null profile");
+            Assert.IsFalse(world.Has<Profile>(playerEntity), "A null Profile component would make every profile system throw each frame");
         }
 
         private IStartupOperation.Params MakeParams(Entity playerEntity)

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/LoadPlayerAvatarStartupOperationShould.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/LoadPlayerAvatarStartupOperationShould.cs
@@ -18,12 +18,12 @@ namespace DCL.UserInAppInitializationFlow.Tests
     [TestFixture]
     public class LoadPlayerAvatarStartupOperationShould
     {
-        private World world;
-        private ILoadingStatus loadingStatus;
-        private ISelfProfile selfProfile;
-        private ObjectProxy<AvatarBase> avatarBaseProxy;
-        private GameObject avatarGameObject;
-        private CancellationTokenSource cts;
+        private World world = null!;
+        private ILoadingStatus loadingStatus = null!;
+        private ISelfProfile selfProfile = null!;
+        private ObjectProxy<AvatarBase> avatarBaseProxy = null!;
+        private GameObject avatarGameObject = null!;
+        private CancellationTokenSource cts = null!;
 
         [OneTimeSetUp]
         public void OneTimeSetUp() =>

--- a/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/StartPulseMultiplayerStartupOperationShould.cs
+++ b/Explorer/Assets/DCL/UserInAppInitializationFlow/Tests/StartPulseMultiplayerStartupOperationShould.cs
@@ -7,6 +7,7 @@ using DCL.Profiles.Self;
 using DCL.Utilities;
 using DCL.Utility.Types;
 using ECS;
+using ECS.TestSuite;
 using NSubstitute;
 using NUnit.Framework;
 using System.Threading;
@@ -28,6 +29,14 @@ namespace DCL.UserInAppInitializationFlow.Tests
         private IRealmData realmData = null!;
         private ILocalSceneEntityIdSource entityIdSource = null!;
         private CancellationTokenSource cts = null!;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp() =>
+            EcsTestsUtils.SetUpFeaturesRegistry();
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown() =>
+            EcsTestsUtils.TearDownFeaturesRegistry();
 
         [SetUp]
         public void SetUp()
@@ -89,6 +98,9 @@ namespace DCL.UserInAppInitializationFlow.Tests
             entityIdSource.EntityAsync(Arg.Any<CancellationToken>())
                           .Returns(UniTask.FromResult(Result<LocalSceneEntity>.SuccessResult(new LocalSceneEntity(ENTITY_ID, Vector2Int.zero))));
 
+            var profile = Profile.NewRandomProfile("0x8a5b1234567890abcdef1234567890abcdef1234");
+            selfProfile.ProfileAsync(Arg.Any<CancellationToken>()).Returns(UniTask.FromResult<Profile?>(profile));
+
             var pulseRealm = new PulseRealm(realmData, entityIdSource);
             StartPulseMultiplayerStartupOperation operation = Operation(activation, pulseRealm);
 
@@ -100,6 +112,7 @@ namespace DCL.UserInAppInitializationFlow.Tests
             Assert.That(pulseRealm.Value, Is.EqualTo("lsd:" + ENTITY_ID));
             _ = service.Received(1).ConnectAsync(Arg.Any<CancellationToken>(), Arg.Any<int>());
             Assert.IsTrue(activation.IsActive);
+            profilePropagation.Received(1).Propagate(profile);
         }
 
         [Test]


### PR DESCRIPTION
# Pull Request Description

## What does this PR change?
Fixes #10012 (UNITY-EXPLORER-Q0J) and its sibling UNITY-EXPLORER-PYF.

When the own-profile fetch fails at startup (seen in LSD), the repository convenience overload swallows the exception and `SelfProfile.ProfileAsync` returns `null`. `LoadPlayerAvatarStartupOperation` force-unwrapped it into `world.Add(playerEntity, profile!)`, leaving a null `Profile` component on the player entity. From then on `ResolveProfilePictureSystem` and `ResetDirtyFlagSystem<Profile>` threw a `NullReferenceException` every frame.

- `LoadPlayerAvatarStartupOperation`: throw before touching the world when the profile is null, so the flow reports a proper failure. Null-forgiving operators removed.
- `StartPulseMultiplayerStartupOperation`: same guard before propagating the profile to Pulse.
- Regression test `FailWithoutAddingProfileWhenProfileCannotBeResolved`.


### Test Steps
1. Smoke test, no error about missing profile


## Quality Checklist
- [ ] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [x] Performance impact has been considered
- [ ] For SDK features: Test scene is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)