### PR TITLE
feat: sdk teleportTo realm coords support

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/RestrictedActionsAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/RestrictedActionsAPIImplementation.cs
@@ -109,12 +109,9 @@ namespace CrdtEcsBridge.RestrictedActions
             if (!sceneStateProvider.IsCurrent)
                 return;
 
-            // A realm on the request makes this a realm change that lands on the parcel afterwards: parcel
-            // coordinates only address one realm's grid, so the switch has to complete before the parcel is
-            // used. The change-realm prompt's target-parcel path already sequences both.
+            // Realm present → route through the change-realm consent prompt, carrying the optional parcel.
             if (!string.IsNullOrEmpty(realm))
             {
-                // Empty message → the prompt renders its default confirmation text; teleportTo carries none.
                 ChangeRealmAsync(string.Empty, realm, coords).Forget();
                 return;
             }

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/RestrictedActionsAPIImplementation.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/RestrictedActionsAPIImplementation.cs
@@ -104,12 +104,28 @@ namespace CrdtEcsBridge.RestrictedActions
             }
         }
 
-        public void TryTeleportTo(Vector2Int coords)
+        public void TryTeleportTo(Vector2Int? coords, string? realm)
         {
             if (!sceneStateProvider.IsCurrent)
                 return;
 
-            TeleportAsync(coords).Forget();
+            // A realm on the request makes this a realm change that lands on the parcel afterwards: parcel
+            // coordinates only address one realm's grid, so the switch has to complete before the parcel is
+            // used. The change-realm prompt's target-parcel path already sequences both.
+            if (!string.IsNullOrEmpty(realm))
+            {
+                // Empty message → the prompt renders its default confirmation text; teleportTo carries none.
+                ChangeRealmAsync(string.Empty, realm, coords).Forget();
+                return;
+            }
+
+            if (!coords.HasValue)
+            {
+                ReportHub.LogWarning(ReportCategory.RESTRICTED_ACTIONS, "TeleportTo: request carries neither worldCoordinates nor realm");
+                return;
+            }
+
+            TeleportAsync(coords.Value).Forget();
         }
 
         public bool TryChangeRealm(string message, string realm)
@@ -279,10 +295,10 @@ namespace CrdtEcsBridge.RestrictedActions
             await mvcManager.ShowAsync(TeleportPromptController.IssueCommand(new TeleportPromptController.Params(coords)));
         }
 
-        private async UniTask ChangeRealmAsync(string message, string realm)
+        private async UniTask ChangeRealmAsync(string message, string realm, Vector2Int? position = null)
         {
             await UniTask.SwitchToMainThread();
-            await mvcManager.ShowAsync(ChangeRealmPromptController.IssueCommand(new ChangeRealmPromptController.Params(message, realm)));
+            await mvcManager.ShowAsync(ChangeRealmPromptController.IssueCommand(new ChangeRealmPromptController.Params(message, realm, position)));
         }
 
         private async UniTask OpenNftDialogAsync(string chain, string contractAddress, string tokenId)

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/RestrictedActionsAPIImplementationShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/RestrictedActionsAPIImplementationShould.cs
@@ -169,6 +169,7 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
 
             // Assert
             mvcManager.Received(1).ShowAsync(ChangeRealmPromptController.IssueCommand(new ChangeRealmPromptController.Params(string.Empty, TEST_REALM)));
+            mvcManager.DidNotReceive().ShowAsync(Arg.Any<ShowCommand<TeleportPromptController.Params>>());
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/RestrictedActionsAPIImplementationShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/RestrictedActionsAPIImplementationShould.cs
@@ -169,7 +169,7 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
 
             // Assert
             mvcManager.Received(1).ShowAsync(ChangeRealmPromptController.IssueCommand(new ChangeRealmPromptController.Params(string.Empty, TEST_REALM)));
-            mvcManager.DidNotReceive().ShowAsync(Arg.Any<ShowCommand<TeleportPromptController.Params>>());
+            mvcManager.DidNotReceive().ShowAsync(Arg.Any<ShowCommand<TeleportPromptView, TeleportPromptController.Params>>());
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/RestrictedActionsAPIImplementationShould.cs
+++ b/Explorer/Assets/DCL/Infrastructure/CrdtEcsBridge/JsModulesImplementation/RestrictedActions/Tests/RestrictedActionsAPIImplementationShould.cs
@@ -18,6 +18,7 @@ using NSubstitute;
 using NUnit.Framework;
 using SceneRunner.Scene;
 using SceneRuntime.ScenePermissions;
+using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -136,10 +137,49 @@ namespace CrdtEcsBridge.RestrictedActions.Tests
             Vector2Int testCoords = new Vector2Int(10, 20);
 
             // Act
-            restrictedActionsAPIImplementation.TryTeleportTo(testCoords);
+            restrictedActionsAPIImplementation.TryTeleportTo(testCoords, null);
 
             // Assert
             mvcManager.Received(1).ShowAsync(TeleportPromptController.IssueCommand(new TeleportPromptController.Params(testCoords)));
+        }
+
+        [Test]
+        public void TeleportToParcelInAnotherRealm()
+        {
+            // Arrange
+            Vector2Int testCoords = new Vector2Int(10, 20);
+            const string TEST_REALM = "TestRealm";
+
+            // Act
+            restrictedActionsAPIImplementation.TryTeleportTo(testCoords, TEST_REALM);
+
+            // Assert
+            mvcManager.Received(1).ShowAsync(ChangeRealmPromptController.IssueCommand(new ChangeRealmPromptController.Params(string.Empty, TEST_REALM, testCoords)));
+            mvcManager.DidNotReceive().ShowAsync(TeleportPromptController.IssueCommand(new TeleportPromptController.Params(testCoords)));
+        }
+
+        [Test]
+        public void TeleportToRealmDefaultSpawnWithoutCoordinates()
+        {
+            // Arrange
+            const string TEST_REALM = "TestRealm";
+
+            // Act
+            restrictedActionsAPIImplementation.TryTeleportTo(null, TEST_REALM);
+
+            // Assert
+            mvcManager.Received(1).ShowAsync(ChangeRealmPromptController.IssueCommand(new ChangeRealmPromptController.Params(string.Empty, TEST_REALM)));
+        }
+
+        [Test]
+        public void IgnoreTeleportWithNeitherCoordinatesNorRealm()
+        {
+            // Act
+            LogAssert.Expect(LogType.Warning, new Regex("TeleportTo"));
+            restrictedActionsAPIImplementation.TryTeleportTo(null, null);
+
+            // Assert
+            Assert.That(mvcManager.ReceivedCalls(), Is.Empty);
         }
 
         [Test]

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/RestrictedActionsApi/IRestrictedActionsAPI.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/RestrictedActionsApi/IRestrictedActionsAPI.cs
@@ -12,7 +12,12 @@ namespace DCL.SceneRuntime.Apis.RestrictedActionsApi
 
         UniTask<bool> TryMovePlayerToAsync(Vector3 newRelativePosition, Vector3? cameraTarget, Vector3? avatarTarget, float duration, CancellationToken ct);
 
-        void TryTeleportTo(Vector2Int newCoords);
+        /// <summary>
+        ///     Teleports the player. <paramref name="newCoords" /> absent targets the realm's default spawn (only
+        ///     meaningful together with <paramref name="realm" />); <paramref name="realm" /> absent addresses the
+        ///     parcel in the realm the player is already in.
+        /// </summary>
+        void TryTeleportTo(Vector2Int? newCoords, string? realm);
 
         bool TryChangeRealm(string message, string realm);
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/RestrictedActionsApi/IRestrictedActionsAPI.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/RestrictedActionsApi/IRestrictedActionsAPI.cs
@@ -15,7 +15,7 @@ namespace DCL.SceneRuntime.Apis.RestrictedActionsApi
         /// <summary>
         ///     Teleports the player. <paramref name="newCoords" /> absent targets the realm's default spawn (only
         ///     meaningful together with <paramref name="realm" />); <paramref name="realm" /> absent addresses the
-        ///     parcel in the realm the player is already in.
+        ///     parcel in the realm the player is already in. Both absent is rejected (warning logged, no-op).
         /// </summary>
         void TryTeleportTo(Vector2Int? newCoords, string? realm);
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/RestrictedActionsApi/IRestrictedActionsAPI.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/RestrictedActionsApi/IRestrictedActionsAPI.cs
@@ -13,11 +13,11 @@ namespace DCL.SceneRuntime.Apis.RestrictedActionsApi
         UniTask<bool> TryMovePlayerToAsync(Vector3 newRelativePosition, Vector3? cameraTarget, Vector3? avatarTarget, float duration, CancellationToken ct);
 
         /// <summary>
-        ///     Teleports the player. <paramref name="newCoords" /> absent targets the realm's default spawn (only
+        ///     Teleports the player. <paramref name="coords" /> absent targets the realm's default spawn (only
         ///     meaningful together with <paramref name="realm" />); <paramref name="realm" /> absent addresses the
         ///     parcel in the realm the player is already in. Both absent is rejected (warning logged, no-op).
         /// </summary>
-        void TryTeleportTo(Vector2Int? newCoords, string? realm);
+        void TryTeleportTo(Vector2Int? coords, string? realm);
 
         bool TryChangeRealm(string message, string realm);
 

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/RestrictedActionsApi/RestrictedActionsAPIWrapper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/RestrictedActionsApi/RestrictedActionsAPIWrapper.cs
@@ -47,8 +47,8 @@ namespace DCL.SceneRuntime.Apis.RestrictedActionsApi
         }
 
         [UsedImplicitly]
-        public void TeleportTo(int x, int y) =>
-            api.TryTeleportTo(new Vector2Int(x, y));
+        public void TeleportTo(int? x, int? y, string? realm) =>
+            api.TryTeleportTo(x.HasValue && y.HasValue ? new Vector2Int(x.Value, y.Value) : null, realm);
 
         [UsedImplicitly]
         public bool ChangeRealm(string message, string realm) =>

--- a/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/UserActions/UserActionsWrapper.cs
+++ b/Explorer/Assets/DCL/Infrastructure/SceneRuntime/Apis/Modules/UserActions/UserActionsWrapper.cs
@@ -30,7 +30,7 @@ namespace SceneRuntime.Apis.Modules.UserActions
             try
             {
                 var coordinates = new ParcelCoordinates(destination);
-                restrictedActionsAPI.TryTeleportTo(coordinates.AsVector2Int());
+                restrictedActionsAPI.TryTeleportTo(coordinates.AsVector2Int(), null);
             }
             catch (Exception e) { ReportHub.LogWarning(ReportCategory.ENGINE, $"Error while trying to teleport to {destination}: {e.Message} {e}"); }
         }

--- a/Explorer/Assets/Protocol/DecentralandProtocol/RestrictedActions.gen.cs
+++ b/Explorer/Assets/Protocol/DecentralandProtocol/RestrictedActions.gen.cs
@@ -34,66 +34,67 @@ namespace Decentraland.Kernel.Apis {
             "X3RhcmdldBgCIAEoCzIcLmRlY2VudHJhbGFuZC5jb21tb24uVmVjdG9yM0gA",
             "iAEBEjgKDWF2YXRhcl90YXJnZXQYAyABKAsyHC5kZWNlbnRyYWxhbmQuY29t",
             "bW9uLlZlY3RvcjNIAYgBARIVCghkdXJhdGlvbhgEIAEoAkgCiAEBQhAKDl9j",
-            "YW1lcmFfdGFyZ2V0QhAKDl9hdmF0YXJfdGFyZ2V0QgsKCV9kdXJhdGlvbiJM",
-            "ChFUZWxlcG9ydFRvUmVxdWVzdBI3ChF3b3JsZF9jb29yZGluYXRlcxgBIAEo",
-            "CzIcLmRlY2VudHJhbGFuZC5jb21tb24uVmVjdG9yMiJ7ChNUcmlnZ2VyRW1v",
-            "dGVSZXF1ZXN0EhgKEHByZWRlZmluZWRfZW1vdGUYASABKAkSQQoEbWFzaxgC",
-            "IAEoDjIuLmRlY2VudHJhbGFuZC5zZGsuY29tcG9uZW50cy5jb21tb24uQXZh",
-            "dGFyTWFza0gAiAEBQgcKBV9tYXNrIkUKEkNoYW5nZVJlYWxtUmVxdWVzdBIN",
-            "CgVyZWFsbRgBIAEoCRIUCgdtZXNzYWdlGAIgASgJSACIAQFCCgoIX21lc3Nh",
-            "Z2UiJQoWT3BlbkV4dGVybmFsVXJsUmVxdWVzdBILCgN1cmwYASABKAkiIwoU",
-            "T3Blbk5mdERpYWxvZ1JlcXVlc3QSCwoDdXJuGAEgASgJIhcKFVVuYmxvY2tQ",
-            "b2ludGVyUmVxdWVzdCIwChNDb21tc0FkYXB0ZXJSZXF1ZXN0EhkKEWNvbm5l",
-            "Y3Rpb25fc3RyaW5nGAEgASgJIo8BChhUcmlnZ2VyU2NlbmVFbW90ZVJlcXVl",
-            "c3QSCwoDc3JjGAEgASgJEhEKBGxvb3AYAiABKAhIAIgBARJBCgRtYXNrGAMg",
-            "ASgOMi4uZGVjZW50cmFsYW5kLnNkay5jb21wb25lbnRzLmNvbW1vbi5BdmF0",
-            "YXJNYXNrSAGIAQFCBwoFX2xvb3BCBwoFX21hc2siIgoPU3VjY2Vzc1Jlc3Bv",
-            "bnNlEg8KB3N1Y2Nlc3MYASABKAgiFgoUVHJpZ2dlckVtb3RlUmVzcG9uc2Ui",
-            "JwoUTW92ZVBsYXllclRvUmVzcG9uc2USDwoHc3VjY2VzcxgBIAEoCCIUChJU",
-            "ZWxlcG9ydFRvUmVzcG9uc2UiJgoWQ29weVRvQ2xpcGJvYXJkUmVxdWVzdBIM",
-            "CgR0ZXh0GAEgASgJIg8KDUVtcHR5UmVzcG9uc2UiEgoQU3RvcEVtb3RlUmVx",
-            "dWVzdCJTChVPcGVuRXhwbG9yZXJVaVJlcXVlc3QSOgoCdWkYASABKA4yLi5k",
-            "ZWNlbnRyYWxhbmQuc2RrLmNvbXBvbmVudHMuY29tbW9uLkV4cGxvcmVyVWki",
-            "XQoWT3BlbkV4cGxvcmVyVWlSZXNwb25zZRJDCgtvcGVuX3Jlc3VsdBgBIAEo",
-            "DjIuLmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5PcGVuRXhwbG9yZXJVaVJl",
-            "c3VsdCqmAQoUT3BlbkV4cGxvcmVyVWlSZXN1bHQSDwoLVU5TUEVDSUZJRUQQ",
-            "ABIKCgZPUEVORUQQARIUChBXQVNfQUxSRUFEWV9PUEVOEAISHgoaUkVKRUNU",
-            "RURfTk9UX0NVUlJFTlRfU0NFTkUQAxIdChlSRUpFQ1RFRF9GRUFUVVJFX0RJ",
-            "U0FCTEVEEAQSHAoYUkVKRUNURURfTk9fVVNFUl9HRVNUVVJFEAUy7AkKGFJl",
-            "c3RyaWN0ZWRBY3Rpb25zU2VydmljZRJvCgxNb3ZlUGxheWVyVG8SLS5kZWNl",
-            "bnRyYWxhbmQua2VybmVsLmFwaXMuTW92ZVBsYXllclRvUmVxdWVzdBouLmRl",
-            "Y2VudHJhbGFuZC5rZXJuZWwuYXBpcy5Nb3ZlUGxheWVyVG9SZXNwb25zZSIA",
-            "EmkKClRlbGVwb3J0VG8SKy5kZWNlbnRyYWxhbmQua2VybmVsLmFwaXMuVGVs",
-            "ZXBvcnRUb1JlcXVlc3QaLC5kZWNlbnRyYWxhbmQua2VybmVsLmFwaXMuVGVs",
-            "ZXBvcnRUb1Jlc3BvbnNlIgASbwoMVHJpZ2dlckVtb3RlEi0uZGVjZW50cmFs",
-            "YW5kLmtlcm5lbC5hcGlzLlRyaWdnZXJFbW90ZVJlcXVlc3QaLi5kZWNlbnRy",
-            "YWxhbmQua2VybmVsLmFwaXMuVHJpZ2dlckVtb3RlUmVzcG9uc2UiABJoCgtD",
-            "aGFuZ2VSZWFsbRIsLmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5DaGFuZ2VS",
-            "ZWFsbVJlcXVlc3QaKS5kZWNlbnRyYWxhbmQua2VybmVsLmFwaXMuU3VjY2Vz",
-            "c1Jlc3BvbnNlIgAScAoPT3BlbkV4dGVybmFsVXJsEjAuZGVjZW50cmFsYW5k",
-            "Lmtlcm5lbC5hcGlzLk9wZW5FeHRlcm5hbFVybFJlcXVlc3QaKS5kZWNlbnRy",
-            "YWxhbmQua2VybmVsLmFwaXMuU3VjY2Vzc1Jlc3BvbnNlIgASbAoNT3Blbk5m",
-            "dERpYWxvZxIuLmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5PcGVuTmZ0RGlh",
-            "bG9nUmVxdWVzdBopLmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5TdWNjZXNz",
-            "UmVzcG9uc2UiABJ2ChhTZXRDb21tdW5pY2F0aW9uc0FkYXB0ZXISLS5kZWNl",
-            "bnRyYWxhbmQua2VybmVsLmFwaXMuQ29tbXNBZGFwdGVyUmVxdWVzdBopLmRl",
-            "Y2VudHJhbGFuZC5rZXJuZWwuYXBpcy5TdWNjZXNzUmVzcG9uc2UiABJ0ChFU",
-            "cmlnZ2VyU2NlbmVFbW90ZRIyLmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5U",
-            "cmlnZ2VyU2NlbmVFbW90ZVJlcXVlc3QaKS5kZWNlbnRyYWxhbmQua2VybmVs",
-            "LmFwaXMuU3VjY2Vzc1Jlc3BvbnNlIgASbgoPQ29weVRvQ2xpcGJvYXJkEjAu",
-            "ZGVjZW50cmFsYW5kLmtlcm5lbC5hcGlzLkNvcHlUb0NsaXBib2FyZFJlcXVl",
-            "c3QaJy5kZWNlbnRyYWxhbmQua2VybmVsLmFwaXMuRW1wdHlSZXNwb25zZSIA",
-            "EmQKCVN0b3BFbW90ZRIqLmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5TdG9w",
-            "RW1vdGVSZXF1ZXN0GikuZGVjZW50cmFsYW5kLmtlcm5lbC5hcGlzLlN1Y2Nl",
-            "c3NSZXNwb25zZSIAEnUKDk9wZW5FeHBsb3JlclVpEi8uZGVjZW50cmFsYW5k",
-            "Lmtlcm5lbC5hcGlzLk9wZW5FeHBsb3JlclVpUmVxdWVzdBowLmRlY2VudHJh",
-            "bGFuZC5rZXJuZWwuYXBpcy5PcGVuRXhwbG9yZXJVaVJlc3BvbnNlIgBiBnBy",
-            "b3RvMw=="));
+            "YW1lcmFfdGFyZ2V0QhAKDl9hdmF0YXJfdGFyZ2V0QgsKCV9kdXJhdGlvbiKF",
+            "AQoRVGVsZXBvcnRUb1JlcXVlc3QSPAoRd29ybGRfY29vcmRpbmF0ZXMYASAB",
+            "KAsyHC5kZWNlbnRyYWxhbmQuY29tbW9uLlZlY3RvcjJIAIgBARISCgVyZWFs",
+            "bRgCIAEoCUgBiAEBQhQKEl93b3JsZF9jb29yZGluYXRlc0IICgZfcmVhbG0i",
+            "ewoTVHJpZ2dlckVtb3RlUmVxdWVzdBIYChBwcmVkZWZpbmVkX2Vtb3RlGAEg",
+            "ASgJEkEKBG1hc2sYAiABKA4yLi5kZWNlbnRyYWxhbmQuc2RrLmNvbXBvbmVu",
+            "dHMuY29tbW9uLkF2YXRhck1hc2tIAIgBAUIHCgVfbWFzayJFChJDaGFuZ2VS",
+            "ZWFsbVJlcXVlc3QSDQoFcmVhbG0YASABKAkSFAoHbWVzc2FnZRgCIAEoCUgA",
+            "iAEBQgoKCF9tZXNzYWdlIiUKFk9wZW5FeHRlcm5hbFVybFJlcXVlc3QSCwoD",
+            "dXJsGAEgASgJIiMKFE9wZW5OZnREaWFsb2dSZXF1ZXN0EgsKA3VybhgBIAEo",
+            "CSIXChVVbmJsb2NrUG9pbnRlclJlcXVlc3QiMAoTQ29tbXNBZGFwdGVyUmVx",
+            "dWVzdBIZChFjb25uZWN0aW9uX3N0cmluZxgBIAEoCSKPAQoYVHJpZ2dlclNj",
+            "ZW5lRW1vdGVSZXF1ZXN0EgsKA3NyYxgBIAEoCRIRCgRsb29wGAIgASgISACI",
+            "AQESQQoEbWFzaxgDIAEoDjIuLmRlY2VudHJhbGFuZC5zZGsuY29tcG9uZW50",
+            "cy5jb21tb24uQXZhdGFyTWFza0gBiAEBQgcKBV9sb29wQgcKBV9tYXNrIiIK",
+            "D1N1Y2Nlc3NSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIIhYKFFRyaWdnZXJF",
+            "bW90ZVJlc3BvbnNlIicKFE1vdmVQbGF5ZXJUb1Jlc3BvbnNlEg8KB3N1Y2Nl",
+            "c3MYASABKAgiFAoSVGVsZXBvcnRUb1Jlc3BvbnNlIiYKFkNvcHlUb0NsaXBi",
+            "b2FyZFJlcXVlc3QSDAoEdGV4dBgBIAEoCSIPCg1FbXB0eVJlc3BvbnNlIhIK",
+            "EFN0b3BFbW90ZVJlcXVlc3QiUwoVT3BlbkV4cGxvcmVyVWlSZXF1ZXN0EjoK",
+            "AnVpGAEgASgOMi4uZGVjZW50cmFsYW5kLnNkay5jb21wb25lbnRzLmNvbW1v",
+            "bi5FeHBsb3JlclVpIl0KFk9wZW5FeHBsb3JlclVpUmVzcG9uc2USQwoLb3Bl",
+            "bl9yZXN1bHQYASABKA4yLi5kZWNlbnRyYWxhbmQua2VybmVsLmFwaXMuT3Bl",
+            "bkV4cGxvcmVyVWlSZXN1bHQqpgEKFE9wZW5FeHBsb3JlclVpUmVzdWx0Eg8K",
+            "C1VOU1BFQ0lGSUVEEAASCgoGT1BFTkVEEAESFAoQV0FTX0FMUkVBRFlfT1BF",
+            "ThACEh4KGlJFSkVDVEVEX05PVF9DVVJSRU5UX1NDRU5FEAMSHQoZUkVKRUNU",
+            "RURfRkVBVFVSRV9ESVNBQkxFRBAEEhwKGFJFSkVDVEVEX05PX1VTRVJfR0VT",
+            "VFVSRRAFMuwJChhSZXN0cmljdGVkQWN0aW9uc1NlcnZpY2USbwoMTW92ZVBs",
+            "YXllclRvEi0uZGVjZW50cmFsYW5kLmtlcm5lbC5hcGlzLk1vdmVQbGF5ZXJU",
+            "b1JlcXVlc3QaLi5kZWNlbnRyYWxhbmQua2VybmVsLmFwaXMuTW92ZVBsYXll",
+            "clRvUmVzcG9uc2UiABJpCgpUZWxlcG9ydFRvEisuZGVjZW50cmFsYW5kLmtl",
+            "cm5lbC5hcGlzLlRlbGVwb3J0VG9SZXF1ZXN0GiwuZGVjZW50cmFsYW5kLmtl",
+            "cm5lbC5hcGlzLlRlbGVwb3J0VG9SZXNwb25zZSIAEm8KDFRyaWdnZXJFbW90",
+            "ZRItLmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5UcmlnZ2VyRW1vdGVSZXF1",
+            "ZXN0Gi4uZGVjZW50cmFsYW5kLmtlcm5lbC5hcGlzLlRyaWdnZXJFbW90ZVJl",
+            "c3BvbnNlIgASaAoLQ2hhbmdlUmVhbG0SLC5kZWNlbnRyYWxhbmQua2VybmVs",
+            "LmFwaXMuQ2hhbmdlUmVhbG1SZXF1ZXN0GikuZGVjZW50cmFsYW5kLmtlcm5l",
+            "bC5hcGlzLlN1Y2Nlc3NSZXNwb25zZSIAEnAKD09wZW5FeHRlcm5hbFVybBIw",
+            "LmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5PcGVuRXh0ZXJuYWxVcmxSZXF1",
+            "ZXN0GikuZGVjZW50cmFsYW5kLmtlcm5lbC5hcGlzLlN1Y2Nlc3NSZXNwb25z",
+            "ZSIAEmwKDU9wZW5OZnREaWFsb2cSLi5kZWNlbnRyYWxhbmQua2VybmVsLmFw",
+            "aXMuT3Blbk5mdERpYWxvZ1JlcXVlc3QaKS5kZWNlbnRyYWxhbmQua2VybmVs",
+            "LmFwaXMuU3VjY2Vzc1Jlc3BvbnNlIgASdgoYU2V0Q29tbXVuaWNhdGlvbnNB",
+            "ZGFwdGVyEi0uZGVjZW50cmFsYW5kLmtlcm5lbC5hcGlzLkNvbW1zQWRhcHRl",
+            "clJlcXVlc3QaKS5kZWNlbnRyYWxhbmQua2VybmVsLmFwaXMuU3VjY2Vzc1Jl",
+            "c3BvbnNlIgASdAoRVHJpZ2dlclNjZW5lRW1vdGUSMi5kZWNlbnRyYWxhbmQu",
+            "a2VybmVsLmFwaXMuVHJpZ2dlclNjZW5lRW1vdGVSZXF1ZXN0GikuZGVjZW50",
+            "cmFsYW5kLmtlcm5lbC5hcGlzLlN1Y2Nlc3NSZXNwb25zZSIAEm4KD0NvcHlU",
+            "b0NsaXBib2FyZBIwLmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5Db3B5VG9D",
+            "bGlwYm9hcmRSZXF1ZXN0GicuZGVjZW50cmFsYW5kLmtlcm5lbC5hcGlzLkVt",
+            "cHR5UmVzcG9uc2UiABJkCglTdG9wRW1vdGUSKi5kZWNlbnRyYWxhbmQua2Vy",
+            "bmVsLmFwaXMuU3RvcEVtb3RlUmVxdWVzdBopLmRlY2VudHJhbGFuZC5rZXJu",
+            "ZWwuYXBpcy5TdWNjZXNzUmVzcG9uc2UiABJ1Cg5PcGVuRXhwbG9yZXJVaRIv",
+            "LmRlY2VudHJhbGFuZC5rZXJuZWwuYXBpcy5PcGVuRXhwbG9yZXJVaVJlcXVl",
+            "c3QaMC5kZWNlbnRyYWxhbmQua2VybmVsLmFwaXMuT3BlbkV4cGxvcmVyVWlS",
+            "ZXNwb25zZSIAYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Decentraland.Common.VectorsReflection.Descriptor, global::DCL.ECSComponents.AvatarMaskReflection.Descriptor, global::DCL.ECSComponents.ExplorerUiReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Decentraland.Kernel.Apis.OpenExplorerUiResult), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Kernel.Apis.MovePlayerToRequest), global::Decentraland.Kernel.Apis.MovePlayerToRequest.Parser, new[]{ "NewRelativePosition", "CameraTarget", "AvatarTarget", "Duration" }, new[]{ "CameraTarget", "AvatarTarget", "Duration" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Kernel.Apis.TeleportToRequest), global::Decentraland.Kernel.Apis.TeleportToRequest.Parser, new[]{ "WorldCoordinates" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Kernel.Apis.TeleportToRequest), global::Decentraland.Kernel.Apis.TeleportToRequest.Parser, new[]{ "WorldCoordinates", "Realm" }, new[]{ "WorldCoordinates", "Realm" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Kernel.Apis.TriggerEmoteRequest), global::Decentraland.Kernel.Apis.TriggerEmoteRequest.Parser, new[]{ "PredefinedEmote", "Mask" }, new[]{ "Mask" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Kernel.Apis.ChangeRealmRequest), global::Decentraland.Kernel.Apis.ChangeRealmRequest.Parser, new[]{ "Realm", "Message" }, new[]{ "Message" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Decentraland.Kernel.Apis.OpenExternalUrlRequest), global::Decentraland.Kernel.Apis.OpenExternalUrlRequest.Parser, new[]{ "Url" }, null, null, null, null),
@@ -535,6 +536,7 @@ namespace Decentraland.Kernel.Apis {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public TeleportToRequest(TeleportToRequest other) : this() {
       worldCoordinates_ = other.worldCoordinates_ != null ? other.worldCoordinates_.Clone() : null;
+      realm_ = other.realm_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -547,6 +549,9 @@ namespace Decentraland.Kernel.Apis {
     /// <summary>Field number for the "world_coordinates" field.</summary>
     public const int WorldCoordinatesFieldNumber = 1;
     private global::Decentraland.Common.Vector2 worldCoordinates_;
+    /// <summary>
+    /// The parcel to land on. Omitted: the realm's default spawn (only meaningful with `realm`).
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public global::Decentraland.Common.Vector2 WorldCoordinates {
@@ -554,6 +559,37 @@ namespace Decentraland.Kernel.Apis {
       set {
         worldCoordinates_ = value;
       }
+    }
+
+    /// <summary>Field number for the "realm" field.</summary>
+    public const int RealmFieldNumber = 2;
+    private readonly static string RealmDefaultValue = "";
+
+    private string realm_;
+    /// <summary>
+    /// The realm the parcel belongs to: a world name (`foo.dcl.eth`) or a realm url. When set, the
+    /// client changes realm (a full reconnect, even to the realm the player is in) and lands on the
+    /// parcel there. Omitted: the parcel is in the player's current realm.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Realm {
+      get { return realm_ ?? RealmDefaultValue; }
+      set {
+        realm_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+    /// <summary>Gets whether the "realm" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasRealm {
+      get { return realm_ != null; }
+    }
+    /// <summary>Clears the value of the "realm" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearRealm() {
+      realm_ = null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -572,6 +608,7 @@ namespace Decentraland.Kernel.Apis {
         return true;
       }
       if (!object.Equals(WorldCoordinates, other.WorldCoordinates)) return false;
+      if (Realm != other.Realm) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -580,6 +617,7 @@ namespace Decentraland.Kernel.Apis {
     public override int GetHashCode() {
       int hash = 1;
       if (worldCoordinates_ != null) hash ^= WorldCoordinates.GetHashCode();
+      if (HasRealm) hash ^= Realm.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -602,6 +640,10 @@ namespace Decentraland.Kernel.Apis {
         output.WriteRawTag(10);
         output.WriteMessage(WorldCoordinates);
       }
+      if (HasRealm) {
+        output.WriteRawTag(18);
+        output.WriteString(Realm);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -616,6 +658,10 @@ namespace Decentraland.Kernel.Apis {
         output.WriteRawTag(10);
         output.WriteMessage(WorldCoordinates);
       }
+      if (HasRealm) {
+        output.WriteRawTag(18);
+        output.WriteString(Realm);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -628,6 +674,9 @@ namespace Decentraland.Kernel.Apis {
       int size = 0;
       if (worldCoordinates_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(WorldCoordinates);
+      }
+      if (HasRealm) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Realm);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -646,6 +695,9 @@ namespace Decentraland.Kernel.Apis {
           WorldCoordinates = new global::Decentraland.Common.Vector2();
         }
         WorldCoordinates.MergeFrom(other.WorldCoordinates);
+      }
+      if (other.HasRealm) {
+        Realm = other.Realm;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -673,6 +725,10 @@ namespace Decentraland.Kernel.Apis {
             input.ReadMessage(WorldCoordinates);
             break;
           }
+          case 18: {
+            Realm = input.ReadString();
+            break;
+          }
         }
       }
     #endif
@@ -697,6 +753,10 @@ namespace Decentraland.Kernel.Apis {
               WorldCoordinates = new global::Decentraland.Common.Vector2();
             }
             input.ReadMessage(WorldCoordinates);
+            break;
+          }
+          case 18: {
+            Realm = input.ReadString();
             break;
           }
         }

--- a/Explorer/Assets/StreamingAssets/Js/Modules/RestrictedActions.js
+++ b/Explorer/Assets/StreamingAssets/Js/Modules/RestrictedActions.js
@@ -53,8 +53,7 @@ module.exports.movePlayerTo = async function(message) {
 }
 
 module.exports.teleportTo = async function(message) {
-    // Both fields are optional: worldCoordinates alone teleports within the current realm, realm alone
-    // targets that realm's default spawn, and together they land on the parcel in that realm.
+    // Unpack optional fields and forward to the C# bridge; both are nullable.
     const coords = message.worldCoordinates
     UnityRestrictedActionsApi.TeleportTo(
         coords != undefined ? Number(coords.x) : null,

--- a/Explorer/Assets/StreamingAssets/Js/Modules/RestrictedActions.js
+++ b/Explorer/Assets/StreamingAssets/Js/Modules/RestrictedActions.js
@@ -53,9 +53,13 @@ module.exports.movePlayerTo = async function(message) {
 }
 
 module.exports.teleportTo = async function(message) {
-    const x = Number(message.worldCoordinates.x);
-    const y = Number(message.worldCoordinates.y);
-    UnityRestrictedActionsApi.TeleportTo(x, y);
+    // Both fields are optional: worldCoordinates alone teleports within the current realm, realm alone
+    // targets that realm's default spawn, and together they land on the parcel in that realm.
+    const coords = message.worldCoordinates
+    UnityRestrictedActionsApi.TeleportTo(
+        coords != undefined ? Number(coords.x) : null,
+        coords != undefined ? Number(coords.y) : null,
+        message.realm != undefined ? message.realm : null);
     return {};
 }
 

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/protocol": "^1.0.0-33874985952.commit-4f4e0ab",
+        "@dcl/protocol": "^1.0.0-34381335718.commit-3c838bb",
         "@protobuf-ts/protoc": "^2.11.0",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.0.1",
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33874985952.commit-4f4e0ab",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33874985952.commit-4f4e0ab.tgz",
-      "integrity": "sha512-VsADthpZ2gFK7IjoK1KahUBedAJnL/BV60QpvGNJU8mmN7D2uBXGZQP8Kincbt2F8VLYUUEQ7zYfrvIc2lu2YA==",
+      "version": "1.0.0-34381335718.commit-3c838bb",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-34381335718.commit-3c838bb.tgz",
+      "integrity": "sha512-0QUcs/F1K60GmB9QncKrsIvUvNjozFw1DcuOQgp0a23s2TC10KwY1aSaOjw0wKgC1aPxyJckXYNixtwu2XYpKg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@dcl/protocol": "^1.0.0-33874985952.commit-4f4e0ab",
+    "@dcl/protocol": "^1.0.0-34381335718.commit-3c838bb",
     "@protobuf-ts/protoc": "^2.11.0",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.0.1",


### PR DESCRIPTION
* Implemented support for new `optional` use of coordiantes in the `TeleportTo` restricted action.
* Test coverage
* Protocol update

### QA TEST STEPS

Use the build from this PR to enter the ZONE/SEPOLIA world `sdk7testscenes.dcl.eth` at position `1,2` and confirm:
- You see different portals to other scenes in this realm
- If you click and accept the teleport from one of them, you get teleported to the correct scene