### PR TITLE
fix: prevent community announcement widget to react to unintended paste command

### DIFF
--- a/Explorer/Assets/DCL/Clipboard/ClipboardManager.cs
+++ b/Explorer/Assets/DCL/Clipboard/ClipboardManager.cs
@@ -1,5 +1,4 @@
 using System.Text.RegularExpressions;
-using UnityEngine;
 
 namespace DCL.Clipboard
 {
@@ -26,6 +25,12 @@ namespace DCL.Clipboard
 
         public bool HasValue() =>
             systemClipboard.HasValue();
+
+        /// <summary>
+        ///     Reads the clipboard text without notifying <see cref="OnPaste" /> subscribers.
+        /// </summary>
+        public string GetText() =>
+            systemClipboard.Get();
 
         /// <summary>
         /// Sets the text on the clipboard and then calls an OnCopy event.

--- a/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementCreationCardView.cs
+++ b/Explorer/Assets/DCL/Communities/CommunitiesCard/Announcements/AnnouncementCreationCardView.cs
@@ -50,7 +50,6 @@ namespace DCL.Communities.CommunitiesCard.Announcements
             announcementInput.onValueChanged.AddListener(OnAnnouncementInputValueChanged);
             announcementInput.PasteShortcutPerformed += OnAnnouncementInputPasteShortcut;
             createAnnouncementButton.onClick.AddListener(OnCreateAnnouncementButton);
-            ViewDependencies.ClipboardManager.OnPaste += OnPasteClipboardText;
         }
 
         private void OnDestroy()
@@ -60,7 +59,6 @@ namespace DCL.Communities.CommunitiesCard.Announcements
             announcementInput.onValueChanged.RemoveListener(OnAnnouncementInputValueChanged);
             announcementInput.PasteShortcutPerformed -= OnAnnouncementInputPasteShortcut;
             createAnnouncementButton.onClick.RemoveListener(OnCreateAnnouncementButton);
-            ViewDependencies.ClipboardManager.OnPaste -= OnPasteClipboardText;
 
             announcementEmojiController?.Dispose();
         }
@@ -124,7 +122,7 @@ namespace DCL.Communities.CommunitiesCard.Announcements
         }
 
         private void OnAnnouncementInputPasteShortcut() =>
-            ViewDependencies.ClipboardManager.Paste(this);
+            announcementInput.InsertTextAtCaretPosition(ViewDependencies.ClipboardManager.GetText());
 
         private void OnCreateAnnouncementButton() =>
             CreateAnnouncementButtonClicked?.Invoke(announcementInput.text);
@@ -138,8 +136,5 @@ namespace DCL.Communities.CommunitiesCard.Announcements
 
         private void UpdateCreateButtonState() =>
             createAnnouncementButton.interactable = !string.IsNullOrEmpty(announcementInput.text);
-
-        private void OnPasteClipboardText(object sender, string pastedText) =>
-            announcementInput.InsertTextAtCaretPosition(pastedText);
     }
 }


### PR DESCRIPTION
# Pull Request Description

Fixes #9828

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

This PR breaks the unintended reaction from the `AnnouncementCreationCardView` on a clipboard paste when the community chat gets opened and some text is pasted there.
Since that view is pooled and the subscription was registered at awake and removed on destroy, by using this flow (community card -> chat -> paste) a new inputlock was being applied, preventing the user to move even if they weren't in the community card.


### Test Steps
1. Open a community card
2. Open its chat using the dedicated button
3. Paste some text in the community chat
4. Loose chat focus
5. Verify your avatar is able to move and you are able to move the camera normally


## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
