### PR TITLE
fix: enable camera controls and local item-only previews

### DIFF
--- a/avatar-preview-renderer/Assets/Scripts/DragRotator.cs
+++ b/avatar-preview-renderer/Assets/Scripts/DragRotator.cs
@@ -129,6 +129,14 @@ public class DragRotator : MonoBehaviour
         }
     }
 
+    public void StopMotion()
+    {
+        _horizontalVel = 0f;
+        _verticalVel = 0f;
+        _targetRotation = null;
+        EnableAutoRotate = false;
+    }
+
     public void ResetRotation()
     {
         _yaw = 0f;

--- a/avatar-preview-renderer/Assets/Scripts/JSBridge.cs
+++ b/avatar-preview-renderer/Assets/Scripts/JSBridge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using Configurator;
 using JetBrains.Annotations;
@@ -105,6 +106,33 @@ public class JSBridge : MonoBehaviour
         }
         if (payload == null) return;
         previewController.SetSpringBonesParams(payload);
+    }
+
+    [UsedImplicitly]
+    public void SetCameraPosition(string value) => previewController.ChangeCameraPosition(ParseCameraVector(value));
+
+    [UsedImplicitly]
+    public void SetOffset(string value) => previewController.SetCameraTarget(ParseCameraVector(value));
+
+    [UsedImplicitly]
+    public void SetZoom(string value) => previewController.ChangeCameraPosition(new Vector3(0f, 0f, -ParseCameraNumber(value)));
+
+    private static Vector3 ParseCameraVector(string value)
+    {
+        var parts = value.Split(',');
+        if (parts.Length != 3)
+            throw new ArgumentException("Send three comma-separated camera values.", nameof(value));
+
+        return new Vector3(ParseCameraNumber(parts[0]), ParseCameraNumber(parts[1]), ParseCameraNumber(parts[2]));
+    }
+
+    private static float ParseCameraNumber(string value)
+    {
+        if (!float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number)
+            || float.IsNaN(number) || float.IsInfinity(number))
+            throw new ArgumentException("Camera values must be finite numbers using a decimal point.", nameof(value));
+
+        return number;
     }
 
     [UsedImplicitly]

--- a/avatar-preview-renderer/Assets/Scripts/Preview/PreviewCameraController.cs
+++ b/avatar-preview-renderer/Assets/Scripts/Preview/PreviewCameraController.cs
@@ -9,6 +9,7 @@ namespace Preview
     {
         // Floor for the fit's view-axis depth, so a subject sitting on the lens cannot divide by zero.
         private const float MIN_FRUSTUM_DEPTH = 0.01f;
+        private const float POLE_EPSILON = 0.001f;
 
         [SerializeField] private float minFOV = 10f;
         [SerializeField] private float maxFOV = 30f;
@@ -164,6 +165,8 @@ namespace Preview
         private void ResetFraming(CameraFraming framing)
         {
             framing.HasSubject = false;
+            framing.Orbiting = false;
+            framing.Camera.transform.localRotation = framing.InitialLocalRotation;
             framing.TargetFOV = _initialFOV;
             framing.Camera.Lens.FieldOfView = _initialFOV;
             framing.PanOffset = Vector2.zero;
@@ -224,14 +227,56 @@ namespace Preview
                                          new Vector3(framing.PanOffset.x, framing.PanOffset.y, 0f);
         }
 
-        public void ShowMarketplaceWearable(bool showWearable)
+        public void ShowWearable(bool showWearable, PreviewMode mode)
         {
-            _active = showWearable ? _wearableFraming : _avatarFraming;
+            _active = showWearable ? _wearableFraming : mode == PreviewMode.Builder ? _builderFraming : _avatarFraming;
 
             // A different subject starts from the fit's framing, not last time's zoom and pan.
             Refit(_active);
 
             _active.Camera.Prioritize();
+        }
+
+        public void ChangeCameraPosition(Vector3 delta)
+        {
+            BeginOrbit();
+            _active.Alpha += delta.x;
+            _active.Beta = Mathf.Clamp(_active.Beta + delta.y, POLE_EPSILON, Mathf.PI - POLE_EPSILON);
+            _active.Radius = Mathf.Max(MIN_FRUSTUM_DEPTH, _active.Radius + delta.z);
+            ApplyOrbit();
+        }
+
+        public void SetCameraTarget(Vector3 target)
+        {
+            BeginOrbit();
+            _active.OrbitTarget = target;
+            ApplyOrbit();
+        }
+
+        private void BeginOrbit()
+        {
+            if (_active.Orbiting) return;
+
+            var cameraTransform = _active.Camera.transform;
+            _active.OrbitTarget = cameraTransform.position + cameraTransform.forward * panSubjectDistance;
+            var offset = cameraTransform.position - _active.OrbitTarget;
+            _active.Radius = offset.magnitude;
+            _active.Alpha = Mathf.Atan2(offset.z, offset.x);
+            _active.Beta = Mathf.Acos(Mathf.Clamp(offset.y / _active.Radius, -1f, 1f));
+            _active.TargetFOV = _active.Camera.Lens.FieldOfView;
+            _active.HasSubject = false;
+            _active.Orbiting = true;
+        }
+
+        private void ApplyOrbit()
+        {
+            var horizontalRadius = _active.Radius * Mathf.Sin(_active.Beta);
+            var offset = new Vector3(
+                horizontalRadius * Mathf.Cos(_active.Alpha),
+                _active.Radius * Mathf.Cos(_active.Beta),
+                horizontalRadius * Mathf.Sin(_active.Alpha));
+            _active.Camera.transform.SetPositionAndRotation(_active.OrbitTarget + offset,
+                Quaternion.LookRotation(-offset, Vector3.up));
         }
 
         public void ZoomByWheelDelta(float delta)
@@ -253,6 +298,14 @@ namespace Preview
             var fov = _active.Camera.Lens.FieldOfView;
             var worldHeightAtSubject = 2f * panSubjectDistance * Mathf.Tan(fov * 0.5f * Mathf.Deg2Rad);
 
+            if (_active.Orbiting)
+            {
+                _active.OrbitTarget += _active.Camera.transform.rotation *
+                                       new Vector3(-normalizedDelta.x, normalizedDelta.y, 0f) * worldHeightAtSubject;
+                ApplyOrbit();
+                return;
+            }
+
             _active.PanOffset += new Vector2(-normalizedDelta.x, normalizedDelta.y) * worldHeightAtSubject;
             _active.PanOffset = Vector2.ClampMagnitude(_active.PanOffset, maxPanOffset);
 
@@ -265,6 +318,13 @@ namespace Preview
         {
             public readonly CinemachineCamera Camera;
             public readonly Vector3 InitialLocalPosition;
+            public readonly Quaternion InitialLocalRotation;
+
+            public bool Orbiting;
+            public Vector3 OrbitTarget;
+            public float Alpha;
+            public float Beta;
+            public float Radius;
 
             public float TargetFOV;
             public Vector2 PanOffset;
@@ -278,6 +338,7 @@ namespace Preview
             {
                 Camera = camera;
                 InitialLocalPosition = camera.transform.localPosition;
+                InitialLocalRotation = camera.transform.localRotation;
                 TargetFOV = initialFOV;
             }
         }

--- a/avatar-preview-renderer/Assets/Scripts/Preview/PreviewController.cs
+++ b/avatar-preview-renderer/Assets/Scripts/Preview/PreviewController.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -86,7 +88,11 @@ namespace Preview
         // than the one under the avatar's feet.
         private void ShowWearableView(bool showWearable)
         {
-            previewCameraController.ShowMarketplaceWearable(showWearable);
+            previewCameraController.ShowWearable(showWearable, PreviewConfiguration.Instance.Mode);
+
+            avatarLoader.gameObject.SetActive(!showWearable);
+            wearableLoader.gameObject.SetActive(showWearable);
+            glowCatcher.SetActive(!showWearable && PreviewConfiguration.Instance.Glow);
 
             // One 20-unit plane spans both subjects, which sit 5 apart, so the avatar's shadow drifts
             // into the item view once zoomed out. Nothing there casts, so the plane goes with the view.
@@ -108,6 +114,27 @@ namespace Preview
 
             ShowWearableView(false);
             avatarRotator.ResetRotation();
+        }
+
+        public void ChangeCameraPosition(Vector3 delta)
+        {
+            StopAutomaticRotation();
+            previewCameraController.ChangeCameraPosition(delta);
+        }
+
+        public void SetCameraTarget(Vector3 target)
+        {
+            StopAutomaticRotation();
+            previewCameraController.SetCameraTarget(target);
+        }
+
+        private void StopAutomaticRotation()
+        {
+            if (PreviewConfiguration.Instance.Mode is not (PreviewMode.Builder or PreviewMode.Marketplace))
+                throw new InvalidOperationException("Camera controls require builder or marketplace mode.");
+
+            avatarRotator.StopMotion();
+            wearableRotator.StopMotion();
         }
 
         public void SetSpringBonesParams(SpringBones.SpringBonesParamsPayload payload) =>
@@ -165,6 +192,8 @@ namespace Preview
                 // We store the instance in case it gets recreated by a call to PreviewConfiguration.RecreateFrom
                 var config = PreviewConfiguration.Instance;
 
+                avatarLoader.gameObject.SetActive(true);
+                wearableLoader.gameObject.SetActive(config.Mode is PreviewMode.Builder or PreviewMode.Marketplace);
                 avatarRotator.enabled = false;
                 wearableRotator.enabled = false;
                 avatarRotator.ResetRotation();
@@ -226,13 +255,14 @@ namespace Preview
                             await LoadForProfile(config.Profile, config.Emote);
                             break;
                         case PreviewMode.Builder:
-                            await LoadForBuilder(config.BodyShape,
+                            hasWearableOverride = await LoadForBuilder(config.BodyShape,
                                 config.EyeColor,
                                 config.HairColor,
                                 config.SkinColor,
                                 config.Urns.ToArray(),
                                 config.Emote,
-                                config.Base64);
+                                config.Base64,
+                                config.Type == PreviewViewType.Wearable);
                             break;
                         case PreviewMode.Jesus:
                             showingAvatar = true;
@@ -246,7 +276,11 @@ namespace Preview
                 catch (Exception e)
                 {
                     JSBridge.NativeCalls.OnError(e.Message);
-                    throw;
+                    if (_shouldReload) continue;
+
+                    _loading = false;
+                    previewUIPresenter.ShowLoader(false);
+                    return;
                 }
 
                 // Wait for 1 frame for animation to kick in before re-centering the object on screen
@@ -276,16 +310,26 @@ namespace Preview
                 else if (config.Mode is PreviewMode.Builder)
                 {
                     avatarRotator.DragSpeed = 2f;
+                    if (hasWearableOverride)
+                    {
+                        previewCameraController.FitWearableView(wearableLoader.transform);
+                        ShowWearableView(true);
+                    }
+                    else
+                    {
+                        wearableLoader.gameObject.SetActive(false);
+                    }
                 }
 
                 avatarRotator.enabled = true;
                 wearableRotator.enabled = true;
                 avatarRotator.EnableAutoRotate = config.Mode is PreviewMode.Marketplace && !hasEmoteOverride;
+                wearableRotator.EnableAutoRotate = config.Mode is PreviewMode.Marketplace;
 
                 previewUIPresenter.EnableEmoteControls(hasEmoteOverride);
                 previewUIPresenter.EnableZoom(config.Mode is PreviewMode.Marketplace or PreviewMode.Builder);
                 previewUIPresenter.EnablePan(config.Mode is PreviewMode.Marketplace or PreviewMode.Builder);
-                previewUIPresenter.EnableSwitcher(hasWearableOverride && !config.DisableSwitcher);
+                previewUIPresenter.EnableSwitcher(config.Mode == PreviewMode.Marketplace && hasWearableOverride && !config.DisableSwitcher);
                 previewUIPresenter.EnableAudioControls(hasEmoteAudio);
             } while (_shouldReload);
 
@@ -304,15 +348,16 @@ namespace Preview
             JSBridge.NativeCalls.OnLoadComplete();
         }
 
-        private async Awaitable LoadForBuilder(string bodyShapeName,
+        private async Awaitable<bool> LoadForBuilder(string? bodyShapeName,
             Color? eyeColor,
             Color? hairColor,
             Color? skinColor,
             string[] urns,
             string emoteName,
-            List<byte[]> base64)
+            List<byte[]> base64,
+            bool showItemAlone)
         {
-            var bodyShape = bodyShapeName.Equals(WearablesConstants.BODY_SHAPE_FEMALE, StringComparison.OrdinalIgnoreCase)
+            var bodyShape = string.Equals(bodyShapeName, WearablesConstants.BODY_SHAPE_FEMALE, StringComparison.OrdinalIgnoreCase)
                 ? BodyShape.Female
                 : BodyShape.Male;
 
@@ -341,6 +386,17 @@ namespace Preview
             // plays it with nothing to download. NOTE LoadForProfile does not short-circuit.
             var emoteEntity = base64Emote ?? (emoteName == "idle" ? null : EntityDefinition.FromEmbeddedEmote(emoteName, true));
 
+            EntityDefinition? itemAlone = null;
+            if (showItemAlone)
+            {
+                if (base64Entities.Length != 1 || base64Emote != null)
+                    throw new InvalidOperationException("Builder item-only view requires exactly one local wearable definition.");
+
+                itemAlone = base64Entities[0];
+                if (!itemAlone.HasRepresentation(bodyShape))
+                    throw new InvalidOperationException($"The local wearable has no {bodyShape} representation.");
+            }
+
             await avatarLoader.LoadAvatar(bodyShape,
                 wearableEntities,
                 emoteEntity,
@@ -351,6 +407,13 @@ namespace Preview
             {
                 avatarLoader.HideFacialFeatures();
             }
+
+            if (itemAlone != null)
+                await wearableLoader.LoadWearable(itemAlone, bodyShape, colors, avatarLoader.GetIdlePose());
+            else
+                wearableLoader.Cleanup();
+
+            return itemAlone != null;
         }
 
         private async Awaitable<(bool emoteOverride, bool emoteOverrideAudio, bool validRepresentation,

--- a/avatar-preview-renderer/Assets/Scripts/PreviewConfiguration.cs
+++ b/avatar-preview-renderer/Assets/Scripts/PreviewConfiguration.cs
@@ -37,9 +37,8 @@ public class PreviewConfiguration
     }
 
     /// <summary>
-    /// Which view the preview opens in, for the modes that offer more than one (currently only
-    /// Marketplace). Null means the caller expressed no preference, in which case the view the user
-    /// last picked is used instead.
+    /// Opening view for Marketplace and Builder. Null uses the last selected view in Marketplace
+    /// and the avatar in Builder.
     /// </summary>
     public PreviewViewType? Type { get; private set; }
 

--- a/avatar-preview-renderer/Assets/Tests.meta
+++ b/avatar-preview-renderer/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 963199037a94d494aaec5e1d97746ddd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/avatar-preview-renderer/Assets/Tests/Editor.meta
+++ b/avatar-preview-renderer/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f8236617763ec4c65b97ffe5a571544d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/avatar-preview-renderer/Assets/Tests/Editor/AvatarPreview.Editor.Tests.asmdef
+++ b/avatar-preview-renderer/Assets/Tests/Editor/AvatarPreview.Editor.Tests.asmdef
@@ -1,0 +1,5 @@
+{
+    "name": "AvatarPreview.Editor.Tests",
+    "includePlatforms": ["Editor"],
+    "optionalUnityReferences": ["TestAssemblies"]
+}

--- a/avatar-preview-renderer/Assets/Tests/Editor/AvatarPreview.Editor.Tests.asmdef.meta
+++ b/avatar-preview-renderer/Assets/Tests/Editor/AvatarPreview.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7e731ef71ac7648d2a35a9f72cd69449
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/avatar-preview-renderer/Assets/Tests/Editor/CameraControlsTests.cs
+++ b/avatar-preview-renderer/Assets/Tests/Editor/CameraControlsTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Preview.Tests
+{
+    public class CameraControlsTests
+    {
+        private Scene testScene;
+        private Component bridge;
+        private Transform cameraTransform;
+
+        [SetUp]
+        public void SetUp()
+        {
+            testScene = EditorSceneManager.OpenScene("Assets/Scenes/Main.unity", OpenSceneMode.Additive);
+            bridge = FindBridge();
+            var controller = SerializedReference(bridge, "previewController");
+            var cameraController = SerializedReference(controller, "previewCameraController");
+            cameraTransform = SerializedReference(cameraController, "marketplaceAvatarCamera").transform;
+            Call(cameraController, "Awake");
+            Call(bridge, "SetMode", "marketplace");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (testScene.IsValid()) EditorSceneManager.CloseScene(testScene, true);
+        }
+
+        [Test]
+        public void ShouldMoveAndRepeatCameraAnglesThroughTheWebBridge()
+        {
+            var initialPosition = cameraTransform.position;
+            Call(bridge, "SetCameraPosition", "1.5707963,-0.5235988,0");
+            var requestedPosition = cameraTransform.position;
+            var requestedRotation = cameraTransform.rotation;
+            Assert.That(Vector3.Distance(initialPosition, requestedPosition), Is.GreaterThan(1f));
+
+            Call(bridge, "SetCameraPosition", "-1.5707963,0.5235988,0");
+            Call(bridge, "SetCameraPosition", "1.5707963,-0.5235988,0");
+            Assert.That(Vector3.Distance(requestedPosition, cameraTransform.position), Is.LessThan(0.00001f));
+            Assert.That(Quaternion.Angle(requestedRotation, cameraTransform.rotation), Is.LessThan(0.01f));
+        }
+
+        [Test]
+        public void ShouldSetAnAbsoluteTargetAndReverseZoomInAnyLocale()
+        {
+            var previousCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+                Call(bridge, "SetOffset", "0,0,0");
+                var initialPosition = cameraTransform.position;
+                Call(bridge, "SetOffset", "0.25,0,0");
+                var pannedPosition = cameraTransform.position;
+                Assert.That(Vector3.Distance(initialPosition, pannedPosition), Is.EqualTo(0.25f).Within(0.00001f));
+
+                Call(bridge, "SetOffset", "0.25,0,0");
+                Assert.That(cameraTransform.position, Is.EqualTo(pannedPosition));
+                var target = new Vector3(0.25f, 0f, 0f);
+                var initialDistance = Vector3.Distance(pannedPosition, target);
+                Call(bridge, "SetZoom", "0.5");
+                Assert.That(Vector3.Distance(cameraTransform.position, target), Is.EqualTo(initialDistance - 0.5f).Within(0.00001f));
+                Call(bridge, "SetZoom", "-0.5");
+                Assert.That(Vector3.Distance(pannedPosition, cameraTransform.position), Is.LessThan(0.00001f));
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = previousCulture;
+            }
+        }
+
+        private static void Call(Component target, string method, params object[] arguments)
+        {
+            var entry = target.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                        ?? throw new InvalidOperationException($"Missing web bridge method: {method}");
+            entry.Invoke(target, arguments);
+        }
+
+        private Component FindBridge()
+        {
+            foreach (var root in testScene.GetRootGameObjects())
+            foreach (var component in root.GetComponentsInChildren<MonoBehaviour>(true))
+                if (component != null && component.GetType().Name == "JSBridge") return component;
+
+            throw new InvalidOperationException("The preview scene must contain JSBridge.");
+        }
+
+        // Resolve scene references without depending on the predefined Assembly-CSharp.
+        private static Component SerializedReference(Component owner, string property)
+        {
+            using var serialized = new SerializedObject(owner);
+            if (serialized.FindProperty(property).objectReferenceValue is not Component component)
+                throw new InvalidOperationException($"Missing scene reference: {property}");
+            return component;
+        }
+    }
+}

--- a/avatar-preview-renderer/Assets/Tests/Editor/CameraControlsTests.cs.meta
+++ b/avatar-preview-renderer/Assets/Tests/Editor/CameraControlsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62b4c3a15c66c4f16970568aedbfb8e5

--- a/avatar-preview-renderer/README.md
+++ b/avatar-preview-renderer/README.md
@@ -36,7 +36,7 @@ The renderer can run in five different modes, depending on its usage: Marketplac
   * `fist-pump`
   * `head-explode`
 * `urn`: An URN address of a wearable or emote to load. It will override any existing wearable in the same category already present on the profile that has been loaded. Can be included multiple times in `marketplace` and `builder` mode to load multiple wearables.
-* `type`: Which view to open in. Only used in `marketplace` mode, and only when a single wearable is being previewed (an emote or several urns at once can only be shown on the avatar). If omitted, the view the user last switched to is used. Possible values:
+* `type`: Which view to open in. In `marketplace` mode, applies to a single wearable; if omitted, the last selected view is used. In `builder` mode, defaults to `avatar`; `wearable` requires exactly one local base64 wearable definition with a representation for the requested body shape. Other URNs can supply its worn outfit but are not shown in the isolated view. Emote or multi-definition item-only requests report an error. Possible values:
   * `wearable` - the item on its own
   * `avatar` - the item worn by the avatar
 * `disableSwitcher`: Hides the avatar / item switcher, so the view stays as it was requested. Only used in `marketplace` mode. Default is `false`.
@@ -102,6 +102,7 @@ Depending on the mode, not all parameters are used. These are the valid paramete
   * Multiple urn parameters may be used to load several wearables. The categories of the wearables must be unique (e.g. two urns cannot both be for "upper_body")
 * `emote`
 * `base64`
+* `type` (optional; the Builder item-only view has no switcher)
 
 ### Configurator
 * `username`
@@ -134,7 +135,7 @@ unityInstance.SendMessage('JSBridge', 'SetEmote', 'clap');
 unityInstance.SendMessage('JSBridge', 'SetSkinColor', 'ff0000');
 ```
 
-Every call of this function will trigger a reload of the entire avatar.
+Call `SendMessage('JSBridge', 'Reload')` after changing configuration. Camera and playback commands apply immediately without a reload.
 For a full list of available functions check [JSBridge](Assets/Scripts/JSBridge.cs).
 
 ### Special cases
@@ -142,6 +143,24 @@ For a full list of available functions check [JSBridge](Assets/Scripts/JSBridge.
 * `SetUrns`
   * The input should be either a single URN or a list of urns separated by commas.
   * Example: `unityInstance.SendMessage('JSBridge', 'SetUrns', 'urn:decentraland:off-chain:base-avatars:kilt,urn:decentraland:off-chain:base-avatars:full_beard,urn:decentraland:off-chain:base-avatars:blue_bandana');`
+
+## Camera controls
+
+After loading in `builder` or `marketplace` mode, the existing wearable-preview scene controller methods are supported:
+
+| Scene controller | Unity message | Values |
+| --- | --- | --- |
+| `changeCameraPosition({ alpha, beta, radius })` | `SetCameraPosition` | Comma-separated azimuth delta, inclination delta (radians), distance delta (world units) |
+| `panCamera({ x, y, z })` | `SetOffset` | Comma-separated absolute orbit target in world space; unspecified components are zero |
+| `changeZoom(delta)` | `SetZoom` | Distance delta toward the target; positive zooms in |
+
+Camera changes stop automatic subject rotation and inertia; mouse dragging still works. The first command preserves the current lens and starts an orbit around a point on the current view axis. Subsequent angle/distance commands are relative, matching the wrapper's existing API. Inclination stops short of the poles and distance stays positive. Reload resets the camera and normal rotation behavior. Values use decimal points regardless of the browser locale.
+
+```javascript
+unityInstance.SendMessage('JSBridge', 'SetCameraPosition', '1.5707963,0,0');
+unityInstance.SendMessage('JSBridge', 'SetCameraPosition', '0,-0.5235988,0');
+unityInstance.SendMessage('JSBridge', 'SetZoom', '0.5');
+```
 
 ## Taking screenshots
 
@@ -171,3 +190,16 @@ window.addEventListener('message', (event) => {
   }
 });
 ```
+
+## Camera regression tests
+
+Run the Edit Mode tests with the editor version in `ProjectSettings/ProjectVersion.txt`:
+
+```sh
+"/Applications/Unity/Hub/Editor/6000.5.9f1/Unity.app/Contents/MacOS/Unity" \
+  -batchmode -nographics -projectPath avatar-preview-renderer \
+  -runTests -testPlatform EditMode -testFilter Preview.Tests.CameraControlsTests \
+  -testResults /tmp/preview-camera-tests.xml -logFile /tmp/preview-camera-tests.log
+```
+
+These tests invoke the scene's bridge methods by their web message names and verify camera transforms, without entering Play Mode or downloading an avatar. Camera movement and locale-independent values fail against a build without the handlers. Web captures must also be checked for avatar/item visibility and paused-pose stability.


### PR DESCRIPTION
## Summary

Make the existing camera RPCs move the Unity preview and support `type=wearable` for a single local Builder upload. The isolated view hides the avatar, and an unsupported request releases the loader so another upload can recover.

## What could break

Camera commands stop automatic subject rotation. Check manual dragging and Marketplace avatar/item switching after camera changes.

## How to test

- Run the [camera regression tests](https://github.com/decentraland/unity-explorer/blob/feat/validator-capture-controls/avatar-preview-renderer/README.md#camera-regression-tests): both pass with the patch and fail with the original renderer methods restored.
- Build the renderer for Web. In Builder mode, load one local wearable definition with `type=wearable`, then `type=avatar`: expect an isolated item, then the worn item. An emote requested as item-only must report an error and allow the next valid upload.

Validated a local Unity Web build with the validator's capture probe: repeatable camera views, reversible zoom, absolute pan, isolated wearable, paused emote samples and engine recovery after rejection. The current iframe wrapper retains a stale error overlay after recovery; that wrapper UI is a separate follow-up.
