### PR TITLE
fix: guard for failed promises in map-pin texture

### DIFF
--- a/Explorer/Assets/DCL/MapPins/Systems/MapPinLoaderSystem.cs
+++ b/Explorer/Assets/DCL/MapPins/Systems/MapPinLoaderSystem.cs
@@ -95,7 +95,9 @@ namespace DCL.SDKComponents.MapPins.Systems
             if (mapPinComponent.TexturePromise.Value.TryConsume(World, out StreamableLoadingResult<TextureData> texture))
             {
                 mapPinComponent.TexturePromise = null;
-                mapPinsEventBus.UpdateMapPinThumbnail(entity, texture.Asset!.EnsureTexture2D());
+
+                if (texture.Succeeded)
+                    mapPinsEventBus.UpdateMapPinThumbnail(entity, texture.Asset!.EnsureTexture2D());
             }
         }
 


### PR DESCRIPTION
# Pull Request Description

Fixes #9927

## What does this PR change?
<!--
Please provide a clear and detailed description of your changes. Include:
- What you're changing and why (describe the problem you're solving)
- Which issue this addresses (if applicable), using #123 format
- For optimizations: Include performance comparisons (before vs. after)
- For SDK features: Include or link to a test scene
- Links to relevant documentation:
  - Design docs
  - Architecture diagrams
  - Figma designs
  - Screenshots
  - Other relevant context
-->

Failed promises were used as successful ones (`!` operator) leading to the exception.
This PR makes sure to use only successful ones

### Test Steps
1. Visit the parcels around `59,60`
2. Verify no `NullReferenceException` tied to `MapPinLoaderSystem` is present in the logs

## Quality Checklist
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if required)
- [ ] Performance impact has been considered
- [ ] For SDK features: Test scene is included

## Code Review Reference
Please review our [Branch & PR Standards](../docs/branch-and-pr-standards.md) before submitting. It explains the automated review flow, QA/DEV approval requirements, and what each label does — especially useful for first-time contributors.
