### PR TITLE
feat: pass session info to launcher for crash reporting

### DIFF
--- a/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Global/Dynamic/BootstrapContainer.cs
@@ -40,6 +40,7 @@ namespace Global.Dynamic
     public class BootstrapContainer : DCLGlobalContainer<BootstrapSettings>
     {
         private IReportsHandlingSettings reportHandlingSettings = null!;
+        private ExplorerSessionInfoWriter? sessionInfoWriter;
 
         public bool EnableAnalytics => Analytics.Enabled;
         public DiagnosticsContainer DiagnosticsContainer { get; private set; } = null!;
@@ -79,6 +80,12 @@ namespace Global.Dynamic
             base.Dispose();
 
             DiagnosticsContainer.Dispose();
+
+            if (sessionInfoWriter != null)
+            {
+                ExitUtils.UnregisterCleanUpCandidate(ExplorerSessionInfoWriter.CLEANUP_CANDIDATE_NAME);
+                sessionInfoWriter.Dispose();
+            }
 
             // CompositeWeb3Provider disposes both authenticators internally
             // Don't dispose Web3Authenticator/EthereumApi separately as they reference the same composite
@@ -127,6 +134,10 @@ namespace Global.Dynamic
 
             await bootstrapContainer.InitializeContainerAsync<BootstrapContainer, BootstrapSettings>(settingsContainer, ct, async container =>
             {
+                // The launcher passes --session_id; it is absent on editor and manual runs. Resolved up front
+                // so the Sentry scope configurator below can capture it.
+                bool hasSessionId = applicationParametersParser.TryGetValue(AppArgsFlags.Analytics.SESSION_ID, out string? sessionId) && !string.IsNullOrEmpty(sessionId);
+
                 container.reportHandlingSettings = ProvideReportHandlingSettingsAsync(container.settings, applicationParametersParser);
 
                 container.DiagnosticsContainer = DiagnosticsContainer.Create(container.ReportHandlingSettings, realmLaunchSettings.CurrentMode is DCL.Utility.LaunchMode.LocalSceneDevelopment);
@@ -142,6 +153,20 @@ namespace Global.Dynamic
                         if (container.IdentityCache.Identity != null)
                             UnityDiagnosticsCenter.Instance.SetWallet(container.IdentityCache.Identity.Address);
                     };
+
+                    // Hand the logged-in identity to the launcher (for crash-report signed fetch) via a file it
+                    // reads. Deleted on clean shutdown so it only survives a crash. Skipped without a session id.
+                    if (hasSessionId)
+                    {
+                        container.sessionInfoWriter = new ExplorerSessionInfoWriter(
+                            container.IdentityCache,
+                            new PlayerPrefsIdentityProvider.DecentralandIdentityWithNethereumAccountJsonSerializer(web3AccountFactory),
+                            sessionId!,
+                            Application.version,
+                            LauncherPaths.LauncherDirectory);
+
+                        ExitUtils.RegisterCleanUpCandidate(new OnQuittingCleanUpCandidate(ExplorerSessionInfoWriter.CLEANUP_CANDIDATE_NAME, container.sessionInfoWriter.DeleteSessionInfoFile));
+                    }
                 }
 
                 var cdpClient = ChromeDevToolHandler.New(applicationParametersParser.HasFlag(AppArgsFlags.LAUNCH_CDP_MONITOR_ON_START));
@@ -156,6 +181,10 @@ namespace Global.Dynamic
                 {
                     if (container.IdentityCache?.Identity != null)
                         container.DiagnosticsContainer.Sentry!.AddIdentityToScope(scope, container.IdentityCache.Identity.Address);
+
+                    // Lets the launcher's crash report and the Explorer's crash event be joined by session id.
+                    if (hasSessionId)
+                        container.DiagnosticsContainer.Sentry!.AddSessionIdToScope(scope, sessionId!);
                 }
             });
 

--- a/Explorer/Assets/DCL/Infrastructure/Utility/LauncherPaths.cs
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/LauncherPaths.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace DCL.Utility
+{
+    /// <summary>
+    ///     The Decentraland launcher's per-user application directory. The client exchanges file-based
+    ///     bridges with the launcher inside it (deep-link, auth-token, crash-report session info), so the
+    ///     location is defined once here instead of being copied into every consumer.
+    /// </summary>
+    public static class LauncherPaths
+    {
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || PLATFORM_STANDALONE_WIN
+        // C:\Users\<user>\AppData\Local\DecentralandLauncherLight\
+        public static readonly string LauncherDirectory =
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "DecentralandLauncherLight"
+            );
+#else
+        // ~/Library/Application Support/DecentralandLauncherLight/
+        public static readonly string LauncherDirectory =
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                "Library", "Application Support", "DecentralandLauncherLight"
+            );
+#endif
+
+        public static string InLauncherDirectory(string fileName) =>
+            Path.Combine(LauncherDirectory, fileName);
+    }
+}

--- a/Explorer/Assets/DCL/Infrastructure/Utility/LauncherPaths.cs.meta
+++ b/Explorer/Assets/DCL/Infrastructure/Utility/LauncherPaths.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f9c1a7b52e64d0a9c2e8b4f61d70a12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
+++ b/Explorer/Assets/DCL/PerformanceAndDiagnostics/Diagnostics/ReportsHandling/Sentry/SentryReportHandler.cs
@@ -103,6 +103,11 @@ namespace DCL.Diagnostics.Sentry
             scope.SetTag("wallet", wallet);
         }
 
+        public void AddSessionIdToScope(Scope scope, string sessionId)
+        {
+            scope.SetTag("session_id", sessionId);
+        }
+
         public void AddCurrentSceneToScope(Scope scope, SceneShortInfo sceneInfo)
         {
             scope.SetTag("current_scene.base_parcel", sceneInfo.BaseParcel.ToString());

--- a/Explorer/Assets/DCL/RuntimeDeepLink/DeepLinkSentinel.cs
+++ b/Explorer/Assets/DCL/RuntimeDeepLink/DeepLinkSentinel.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Utilities.Extensions;
+using DCL.Utility;
 using DCL.Utility.Types;
 using System;
 using System.Diagnostics;
@@ -16,23 +17,7 @@ namespace DCL.RuntimeDeepLink
         // Maximum time a deferred signin bridge file is retained on disk; without this cap it would be re-read on every check-in forever.
         private static readonly TimeSpan DEFERRED_SIGNIN_LIFETIME = TimeSpan.FromSeconds(300);
 
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || PLATFORM_STANDALONE_WIN
-        // path for: C:\Users\<YourUsername>\AppData\Local\DecentralandLauncherLight\
-        private static readonly string DEEP_LINK_BRIDGE_PATH =
-            Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "DecentralandLauncherLight", "deeplink-bridge.json"
-            );
-#else
-
-        // path for: ~/Library/Application Support/DecentralandLauncherLight/
-        private static readonly string DEEP_LINK_BRIDGE_PATH =
-            Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.Personal),
-                "Library", "Application Support", "DecentralandLauncherLight", "deeplink-bridge.json"
-            );
-#endif
-
+        private static readonly string DEEP_LINK_BRIDGE_PATH = LauncherPaths.InLauncherDirectory("deeplink-bridge.json");
 
         /// <summary>
         /// Runs for the lifetime of the app.

--- a/Explorer/Assets/DCL/Tests/Editor/ExplorerSessionInfoWriterShould.cs
+++ b/Explorer/Assets/DCL/Tests/Editor/ExplorerSessionInfoWriterShould.cs
@@ -1,0 +1,104 @@
+using DCL.Web3.Accounts.Factory;
+using DCL.Web3.Identities;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.IO;
+
+namespace DCL.EditModeTests
+{
+    [TestFixture]
+    public class ExplorerSessionInfoWriterShould
+    {
+        private const string SESSION_ID = "session-abc-123";
+        private const string EXPLORER_VERSION = "1.2.3";
+
+        private string tempDir = null!;
+        private Web3AccountFactory accountFactory = null!;
+        private PlayerPrefsIdentityProvider.DecentralandIdentityWithNethereumAccountJsonSerializer serializer = null!;
+        private MemoryWeb3IdentityCache identityCache = null!;
+        private ExplorerSessionInfoWriter? writer;
+
+        private string ExpectedPath => Path.Combine(tempDir, $"session-info-{SESSION_ID}.json");
+
+        [SetUp]
+        public void SetUp()
+        {
+            tempDir = Path.Combine(Path.GetTempPath(), $"dcl-session-info-{Path.GetRandomFileName()}");
+            Directory.CreateDirectory(tempDir);
+
+            accountFactory = new Web3AccountFactory();
+            serializer = new PlayerPrefsIdentityProvider.DecentralandIdentityWithNethereumAccountJsonSerializer(accountFactory);
+            identityCache = new MemoryWeb3IdentityCache();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            writer?.Dispose();
+            writer = null;
+            identityCache.Dispose();
+
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        [Test]
+        public void WriteFileWithExpectedNameAndShapeWhenIdentityChanges()
+        {
+            writer = new ExplorerSessionInfoWriter(identityCache, serializer, SESSION_ID, EXPLORER_VERSION, tempDir);
+
+            var identity = new IWeb3Identity.Random(accountFactory);
+            identityCache.Identity = identity;
+
+            Assert.IsTrue(File.Exists(ExpectedPath), "session-info file was not written under the expected name");
+
+            JObject root = JObject.Parse(File.ReadAllText(ExpectedPath));
+
+            Assert.AreEqual(1, (int)root["version"]!);
+            Assert.AreEqual(SESSION_ID, (string)root["session_id"]!);
+            Assert.AreEqual((string)identity.Address, (string)root["wallet"]!);
+            Assert.AreEqual(EXPLORER_VERSION, (string)root["explorer_version"]!);
+
+            // The nested identity object matches the serializer the client persists identity with.
+            JObject expectedIdentity = JObject.Parse(serializer.Serialize(identity));
+            Assert.IsTrue(JToken.DeepEquals(expectedIdentity, root["identity"]), "identity object shape does not match the identity serializer output");
+            Assert.IsNotNull(root["identity"]!["key"], "nested identity must carry the ephemeral key the launcher signs with");
+            Assert.AreEqual(JTokenType.Array, root["identity"]!["ephemeralAuthChain"]!.Type);
+        }
+
+        [Test]
+        public void NotWriteFileWhenSessionIdIsMissing()
+        {
+            writer = new ExplorerSessionInfoWriter(identityCache, serializer, string.Empty, EXPLORER_VERSION, tempDir);
+
+            identityCache.Identity = new IWeb3Identity.Random(accountFactory);
+
+            Assert.IsEmpty(Directory.GetFiles(tempDir), "no file should be written when --session_id is absent");
+        }
+
+        [Test]
+        public void DeleteFileOnShutdown()
+        {
+            writer = new ExplorerSessionInfoWriter(identityCache, serializer, SESSION_ID, EXPLORER_VERSION, tempDir);
+            identityCache.Identity = new IWeb3Identity.Random(accountFactory);
+            Assert.IsTrue(File.Exists(ExpectedPath), "precondition: file must exist before shutdown");
+
+            // The clean-shutdown cleanup candidate registered via ExitUtils invokes exactly this.
+            writer.DeleteSessionInfoFile();
+
+            Assert.IsFalse(File.Exists(ExpectedPath), "session-info file must be removed on clean shutdown");
+        }
+
+        [Test]
+        public void DeleteFileOnLogout()
+        {
+            writer = new ExplorerSessionInfoWriter(identityCache, serializer, SESSION_ID, EXPLORER_VERSION, tempDir);
+            identityCache.Identity = new IWeb3Identity.Random(accountFactory);
+            Assert.IsTrue(File.Exists(ExpectedPath));
+
+            identityCache.Clear();
+
+            Assert.IsFalse(File.Exists(ExpectedPath), "session-info file must be removed on logout");
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Tests/Editor/ExplorerSessionInfoWriterShould.cs.meta
+++ b/Explorer/Assets/DCL/Tests/Editor/ExplorerSessionInfoWriterShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8d3f6019a2c4e7182f5c0a94e6b17d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Explorer/Assets/DCL/Web3/Authenticators/Implementations/TokenFileAuthenticator.cs
+++ b/Explorer/Assets/DCL/Web3/Authenticators/Implementations/TokenFileAuthenticator.cs
@@ -2,6 +2,7 @@ using CommunicationData.URLHelpers;
 using Cysharp.Threading.Tasks;
 using DCL.Diagnostics;
 using DCL.Utilities.Extensions;
+using DCL.Utility;
 using DCL.Utility.Types;
 using DCL.Web3.Abstract;
 using DCL.Web3.Chains;
@@ -17,21 +18,7 @@ namespace DCL.Web3.Authenticators
 {
     public partial class TokenFileAuthenticator : IWeb3Authenticator
     {
-#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || PLATFORM_STANDALONE_WIN
-        // path for: C:\Users\<YourUsername>\AppData\Local\DecentralandLauncherLight\
-        private static readonly string TOKEN_PATH =
-            Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "DecentralandLauncherLight", "auth-token-bridge.txt"
-            );
-#else
-        // path for: ~/Library/Application Support/DecentralandLauncherLight/
-        private static readonly string TOKEN_PATH =
-            Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.Personal),
-                "Library", "Application Support", "DecentralandLauncherLight", "auth-token-bridge.txt"
-            );
-#endif
+        private static readonly string TOKEN_PATH = LauncherPaths.InLauncherDirectory("auth-token-bridge.txt");
 
         private readonly URLAddress authApiUrl;
         private readonly IWebRequestController webRequestController;

--- a/Explorer/Assets/DCL/Web3/Identities/ExplorerSessionInfoWriter.cs
+++ b/Explorer/Assets/DCL/Web3/Identities/ExplorerSessionInfoWriter.cs
@@ -1,0 +1,144 @@
+using DCL.Diagnostics;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+
+namespace DCL.Web3.Identities
+{
+    /// <summary>
+    ///     Writes the logged-in identity to the launcher's directory as <c>session-info-{session_id}.json</c>
+    ///     so the launcher can submit a crash report on the user's behalf after the client exits unexpectedly.
+    ///     The file is rewritten whenever the identity changes (re-login) and removed on logout; the
+    ///     clean-shutdown path (wired through <c>ExitUtils</c> at the composition root) deletes it via
+    ///     <see cref="DeleteSessionInfoFile" />, so a copy only survives a crash.
+    ///     Nothing here logs the file content or the identity.
+    /// </summary>
+    public sealed class ExplorerSessionInfoWriter : IDisposable
+    {
+        public const string CLEANUP_CANDIDATE_NAME = nameof(ExplorerSessionInfoWriter);
+
+        private const int FILE_VERSION = 1;
+
+        private readonly IWeb3IdentityCache identityCache;
+        private readonly PlayerPrefsIdentityProvider.IWeb3IdentityJsonSerializer identitySerializer;
+        private readonly string sessionId;
+        private readonly string explorerVersion;
+        private readonly bool enabled;
+        private readonly string filePath;
+        private readonly string tempFilePath;
+
+        private bool disposed;
+
+        public ExplorerSessionInfoWriter(
+            IWeb3IdentityCache identityCache,
+            PlayerPrefsIdentityProvider.IWeb3IdentityJsonSerializer identitySerializer,
+            string sessionId,
+            string explorerVersion,
+            string launcherDirectory)
+        {
+            this.identityCache = identityCache;
+            this.identitySerializer = identitySerializer;
+            this.sessionId = sessionId;
+            this.explorerVersion = explorerVersion;
+
+            // Without a session id (editor / manual runs) there is no launcher to hand the file to, so the
+            // writer stays inert: it subscribes to nothing and writes nothing.
+            enabled = !string.IsNullOrEmpty(sessionId);
+
+            filePath = enabled ? Path.Combine(launcherDirectory, $"session-info-{sessionId}.json") : string.Empty;
+            tempFilePath = enabled ? filePath + ".tmp" : string.Empty;
+
+            if (!enabled)
+                return;
+
+            identityCache.OnIdentityChanged += OnIdentityChanged;
+            identityCache.OnIdentityCleared += DeleteSessionInfoFile;
+
+            // Write a copy immediately when a valid identity already exists (e.g. auto-login completed
+            // before this writer was wired), so a crash before the next identity change stays reportable.
+            if (identityCache.Identity != null)
+                Write(identityCache.Identity);
+        }
+
+        public void Dispose()
+        {
+            if (disposed || !enabled) return;
+            disposed = true;
+
+            identityCache.OnIdentityChanged -= OnIdentityChanged;
+            identityCache.OnIdentityCleared -= DeleteSessionInfoFile;
+        }
+
+        private void OnIdentityChanged()
+        {
+            IWeb3Identity? identity = identityCache.Identity;
+
+            if (identity == null)
+                DeleteSessionInfoFile();
+            else
+                Write(identity);
+        }
+
+        private void Write(IWeb3Identity identity)
+        {
+            try
+            {
+                // Reuse the identity serializer the client persists with, so the "identity" object matches
+                // userdata_*.json byte-for-byte (field names, expiration "O" format) and the launcher reads
+                // one shape.
+                var identityJson = JObject.Parse(identitySerializer.Serialize(identity));
+
+                string wallet = identity.Address;
+
+                var root = new JObject
+                {
+                    ["version"] = FILE_VERSION,
+                    ["session_id"] = sessionId,
+                    ["wallet"] = wallet,
+                    ["explorer_version"] = explorerVersion,
+                    ["identity"] = identityJson,
+                };
+
+                Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+
+                // Write the temp file then move it over the target, so a reader never observes a
+                // half-written credential file.
+                File.WriteAllText(tempFilePath, root.ToString(Formatting.None));
+
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+
+                File.Move(tempFilePath, filePath);
+            }
+            catch (Exception e)
+            {
+                // Never include the identity or file content in the log line.
+                ReportHub.LogError(ReportCategory.AUTHENTICATION, $"Could not write launcher session info file: {e.GetType().Name}");
+            }
+        }
+
+        /// <summary>
+        ///     Removes the session-info file (and any stale temp file). Registered as the clean-shutdown
+        ///     cleanup at the composition root, so the file survives only a crash.
+        /// </summary>
+        public void DeleteSessionInfoFile()
+        {
+            if (!enabled)
+                return;
+
+            try
+            {
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+
+                if (File.Exists(tempFilePath))
+                    File.Delete(tempFilePath);
+            }
+            catch (Exception e)
+            {
+                ReportHub.LogError(ReportCategory.AUTHENTICATION, $"Could not delete launcher session info file: {e.GetType().Name}");
+            }
+        }
+    }
+}

--- a/Explorer/Assets/DCL/Web3/Identities/ExplorerSessionInfoWriter.cs.meta
+++ b/Explorer/Assets/DCL/Web3/Identities/ExplorerSessionInfoWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a71e4c9d8b3f42569d0a6e15c7b28f34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## What

After login the Explorer writes the identity to the launcher directory as `session-info-{session_id}.json` so the launcher can submit a crash report (Signed Fetch) on the user's behalf after an unexpected exit. The file carries `version`, `session_id`, `wallet`, `explorer_version`, and `identity` (exactly the client's identity serializer output).

- Written on login, rewritten on re-login, deleted on logout.
- Deleted on clean shutdown via `ExitUtils`, so it only survives a crash.
- Skipped when `--session_id` is absent (editor / manual runs).
- `session_id` also added as a Sentry tag so the launcher's report and the Explorer's crash event join by id.
- Launcher directory extracted into one shared `LauncherPaths` constant (was hardcoded in `DeepLinkSentinel` and `TokenFileAuthenticator`).

## Notes for review

- The file writes the ephemeral private key to a second predictable path that survives a crash. Same credential and same class of exposure as the already-persisted `userdata_*.json`; the launcher/Explorer already exchange auth material at this directory (`TokenFileAuthenticator`).
- No `0600` perms: the Unity runtime lacks `File.SetUnixFileMode`, so the file uses the per-user directory default like the sibling bridge files. Tightening via P/Invoke `chmod` is a possible follow-up.

## Test

Happy path only, no main-feature regression pass:
- Launch via launcher with `--session_id`, log in, confirm `session-info-{session_id}.json` appears in the launcher dir with the expected fields.
- Quit cleanly, confirm the file is removed.
- New EditMode tests `ExplorerSessionInfoWriterShould` cover name/shape, skip-without-session-id, delete-on-shutdown, delete-on-logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)