### PR TITLE
fix: hidden body shadows and floating emotes in the preview renderer

### DIFF
--- a/avatar-preview-renderer/Assets/Scenes/Main.unity
+++ b/avatar-preview-renderer/Assets/Scenes/Main.unity
@@ -253,6 +253,7 @@ MonoBehaviour:
   mainCamera: {fileID: 7250373747808368237}
   dragSpeed: 0.5
   inertiaDamp: 0.25
+  maxPitch: 30
   autoRotateSpeed: 10
   autoRotateDelay: 1
   returnSpeed: 2
@@ -314,6 +315,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -3910990755373119420, guid: 5b63cb074d2b1474882caf59b30c3739, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -440673046031751957, guid: 5b63cb074d2b1474882caf59b30c3739, type: 3}
+      propertyPath: m_CastShadows
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8771091787928289351, guid: 5b63cb074d2b1474882caf59b30c3739, type: 3}
@@ -1292,6 +1297,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -440673046031751957, guid: 5b63cb074d2b1474882caf59b30c3739, type: 3}
+      propertyPath: m_CastShadows
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8771091787928289351, guid: 5b63cb074d2b1474882caf59b30c3739, type: 3}
       propertyPath: m_Name
       value: Avatar_Model_Idle
@@ -1652,7 +1661,7 @@ MonoBehaviour:
   facialFeaturesMat: {fileID: 2100000, guid: 640484c930a9c425791b434dd2094bff, type: 2}
   configuratorController: {fileID: 3845507387249961957}
   previewController: {fileID: 1667190199235124708}
-  debugUrl: ?mode=marketplace&profile=0x3f574d05ec670fe2c92305480b175654ca512005&urn=urn:decentraland:matic:collections-v2:0xa826e7769bf0c712bff7b1b9e9031bfc36ed7758:0&type=wearable&background=039dfc
+  debugUrl: ?mode=marketplace&profile=default1&urn=urn:decentraland:matic:collections-v2:0x38a4ace8b52b60d09ae4015068624e69e87988e2:2
 --- !u!4 &983774208
 Transform:
   m_ObjectHideFlags: 0
@@ -1762,6 +1771,7 @@ VisualEffect:
   m_StartSeed: 0
   m_ResetSeedOnPlay: 1
   m_AllowInstancing: 1
+  m_ReleaseInstanceOnDisable: 0
   m_ResourceVersion: 1
   m_PropertySheet:
     m_Float:
@@ -2747,6 +2757,8 @@ MonoBehaviour:
   panSubjectDistance: 7
   maxPanOffset: 2
   lerpSpeed: 10
+  avatarFitMargin: 1.05
+  wearableFitMargin: 1.05
   authProfileCamera: {fileID: 2096491904}
   marketplaceWearableCamera: {fileID: 1248428041}
   marketplaceAvatarCamera: {fileID: 543892823}
@@ -3960,6 +3972,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   facialFeatureRotation: {x: -0.1305262, y: 0, z: 0, w: 0.9914449}
+  upperBodyIdleBlend: 0.8
 --- !u!114 &5537778323977382524
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3975,6 +3988,7 @@ MonoBehaviour:
   mainCamera: {fileID: 7250373747808368237}
   dragSpeed: 0.5
   inertiaDamp: 0.25
+  maxPitch: 30
   autoRotateSpeed: 10
   autoRotateDelay: 1
   returnSpeed: 2
@@ -4395,6 +4409,7 @@ VisualEffect:
   m_StartSeed: 0
   m_ResetSeedOnPlay: 1
   m_AllowInstancing: 1
+  m_ReleaseInstanceOnDisable: 0
   m_ResourceVersion: 1
   m_PropertySheet:
     m_Float:
@@ -4666,6 +4681,7 @@ MonoBehaviour:
   mainCamera: {fileID: 5610390852201726291}
   dragSpeed: 0.5
   inertiaDamp: 0.25
+  maxPitch: 30
   autoRotateSpeed: 10
   autoRotateDelay: 1
   returnSpeed: 5

--- a/avatar-preview-renderer/Assets/Scripts/Preview/PreviewController.cs
+++ b/avatar-preview-renderer/Assets/Scripts/Preview/PreviewController.cs
@@ -249,17 +249,16 @@ namespace Preview
                     throw;
                 }
 
-                // Wait for 1 frame for animation to kick in before re-centering the object on screen
+                // Wait for 1 frame for animation to kick in before measuring bounds for the framing below
                 await Awaitable.NextFrameAsync();
 
+                // The item view only: the avatar is never moved or scaled. Its feet have to stay on the
+                // shadow and glow catchers, which sit at a fixed floor height, so an emote is framed by
+                // the camera fit below instead.
                 if (hasWearableOverride)
                 {
                     GameObjectUtils.CenterAndFit(wearableLoader.transform, mainCamera, wearablePadding);
                     wearableLoader.transform.position += wearableOffset;
-                }
-                else if (hasEmoteOverride)
-                {
-                    GameObjectUtils.CenterAndFit(avatarLoader.transform, mainCamera, wearablePadding);
                 }
 
                 if (config.Mode is PreviewMode.Marketplace)


### PR DESCRIPTION
-The animation rig GLB carries a hidden body mesh the confirmation VFX samples from. Its layer is skipped by the color pass but not by shadow casting, so every avatar cast a full humanoid shadow. It only showed once a wearable hid body parts (skins, full-body items) or an emote moved the visible avatar off it. Cast Shadows is now Off on both rig instances, so only visible geometry shadows the floor.

-Emote where floaring, now overrides no longer run `CenterAndFit` on the avatar root. That scaled the avatar and lifted its bounds center onto the origin, floating it above the fixed-height shadow and glow catchers. The camera fit frames emotes instead.

Test URLs:

- Whale skin (should show only the whale and its splashes on the floor): `?mode=marketplace&profile=default1&urn=urn:decentraland:matic:collections-v2:0x38a4ace8b52b60d09ae4015068624e69e87988e2:2`

- Emote (avatar stays inside the glow, shadow attached to the feet): `?mode=marketplace&profile=default1&urn=urn:decentraland:matic:collections-v2:0x8646cda041ddd91f7efbb73c9ba63d937ad4dfea:0`