### PR TITLE
fix: add referrer to places and events share links

### DIFF
--- a/Explorer/Assets/DCL/Events/EventCardActionsController.cs
+++ b/Explorer/Assets/DCL/Events/EventCardActionsController.cs
@@ -63,7 +63,7 @@ namespace DCL.Events
             }
 
             eventData.Attending = !eventData.Attending;
-            eventData.Total_attendees += eventData.Attending ? 1 : -1;
+            eventData.TotalAttendees += eventData.Attending ? 1 : -1;
 
             eventCardView?.UpdateInterestedButtonState(eventData.Attending);
             eventCardView?.UpdateVisuals();
@@ -90,7 +90,6 @@ namespace DCL.Events
                 realmNavigator.TryChangeRealmAsync(
                     URLDomain.FromString(new ENS(eventData.Server).ConvertEnsToWorldUrl(decentralandUrlsSource.Url(DecentralandUrl.WorldServer))),
                     ct,
-                    default,
                     isWorld: true,
                     allowsSpawnPointerOverride: true).Forget();
             else

--- a/Explorer/Assets/DCL/Events/EventDetailPanelView.cs
+++ b/Explorer/Assets/DCL/Events/EventDetailPanelView.cs
@@ -109,7 +109,7 @@ namespace DCL.Communities.EventInfo
             thumbnailLoader.LoadCommunityThumbnailFromUrlAsync(eventData.Image, eventImage, null, cancellationToken, true).Forget();
             eventDate.text = EventUtilities.GetEventTimeText(eventData);
             eventName.text = eventData.Name;
-            hostName.text = string.Format(HOST_FORMAT, eventData.User_name);
+            hostName.text = string.Format(HOST_FORMAT, eventData.UserName);
             UpdateInterestedButtonState(eventData.Attending);
             eventDescription.text = eventData.Description;
             jumpInButton.gameObject.SetActive(eventData.Live);
@@ -119,7 +119,7 @@ namespace DCL.Communities.EventInfo
             if (placeData != null)
                 placeNameText.text = eventData.World ? $"{placeData.title} ({placeData.world_name})" : $"{placeData.title} ({eventData.X},{eventData.Y})";
             else
-                placeNameText.text = $"{eventData.Scene_name} ({eventData.X},{eventData.Y})";
+                placeNameText.text = $"{eventData.SceneName} ({eventData.X},{eventData.Y})";
 
             GenerateRecurrentSchedules(eventData);
         }

--- a/Explorer/Assets/DCL/Events/EventUtilities.cs
+++ b/Explorer/Assets/DCL/Events/EventUtilities.cs
@@ -1,5 +1,6 @@
 using DCL.EventsApi;
 using DCL.Multiplayer.Connections.DecentralandUrls;
+using DCL.UI;
 using System;
 using System.Globalization;
 using System.Text;
@@ -99,25 +100,25 @@ namespace DCL.Communities.EventInfo
 
         private static string GetPlaceJumpInLink(IEventDTO eventData, IDecentralandUrlsSource urls) =>
             eventData.World
-                ? string.Format(urls.Url(DecentralandUrl.JumpInWorldLink), eventData.Server)
-                : string.Format(urls.Url(DecentralandUrl.JumpInGenesisCityLink), eventData.X, eventData.Y);
+                ? ShareLinkUtilities.WithReferrer(string.Format(urls.Url(DecentralandUrl.JumpInWorldLink), eventData.Server))
+                : ShareLinkUtilities.WithReferrer(string.Format(urls.Url(DecentralandUrl.JumpInGenesisCityLink), eventData.X, eventData.Y));
 
         private static string GetEventWebsiteLink(IEventDTO eventData, IDecentralandUrlsSource urls) =>
             string.Format(urls.Url(DecentralandUrl.WhatsOnEventLink), eventData.Id);
 
         public static string GetEventShareLink(IEventDTO eventData, IDecentralandUrlsSource urls) =>
-            string.Format(TWITTER_NEW_POST_LINK, eventData.Name, TWITTER_HASHTAG, GetEventCopyLink(eventData, urls));
+            string.Format(TWITTER_NEW_POST_LINK, eventData.Name, TWITTER_HASHTAG, ShareLinkUtilities.AsQueryParameterValue(GetEventCopyLink(eventData, urls)));
 
         public static string GetEventAddToCalendarLink(IEventDTO eventData, IDecentralandUrlsSource urls)
         {
             DateTime nextStartAtDate = DateTime.Parse(
-                eventData.Next_start_at,
+                eventData.NextStartAt,
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal
             );
 
             DateTime nextFinishAtDate = DateTime.Parse(
-                eventData.Next_finish_at,
+                eventData.NexFinishAt,
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal
             );
@@ -125,7 +126,7 @@ namespace DCL.Communities.EventInfo
             return string.Format(ADD_TO_CALENDAR_LINK,
                 eventData.Name,
                 eventData.Description,
-                $"jump in: {GetPlaceJumpInLink(eventData, urls)}",
+                $"jump in: {ShareLinkUtilities.AsQueryParameterValue(GetPlaceJumpInLink(eventData, urls))}",
                 nextStartAtDate.ToString("yyyyMMdd'T'HHmmss'Z'"),
                 nextFinishAtDate.ToString("yyyyMMdd'T'HHmmss'Z'"));
         }
@@ -135,14 +136,10 @@ namespace DCL.Communities.EventInfo
             TimeSpan duration = TimeSpan.FromMilliseconds(eventData.Duration);
             DateTime utcEnd = utcStart.Add(duration);
 
-            TimeZoneInfo localZone = TimeZoneInfo.Local;
-            DateTime localStart = TimeZoneInfo.ConvertTimeFromUtc(utcStart, localZone);
-            DateTime localEnd = TimeZoneInfo.ConvertTimeFromUtc(utcEnd, localZone);
-
             return string.Format(ADD_TO_CALENDAR_LINK,
                 eventData.Name,
                 eventData.Description,
-                $"jump in: {GetPlaceJumpInLink(eventData, urls)}",
+                $"jump in: {ShareLinkUtilities.AsQueryParameterValue(GetPlaceJumpInLink(eventData, urls))}",
                 utcStart.ToString("yyyyMMdd'T'HHmmss'Z'"),
                 utcEnd.ToString("yyyyMMdd'T'HHmmss'Z'"));
         }

--- a/Explorer/Assets/DCL/EventsApi/EventDTO.cs
+++ b/Explorer/Assets/DCL/EventsApi/EventDTO.cs
@@ -9,25 +9,25 @@ namespace DCL.EventsApi
         string Name {get; set; }
         string Image {get; set; }
         string Description {get; set; }
-        string Next_start_at {get; set; }
+        string NextStartAt {get; set; }
         DateTime NextStartAtProcessed {get; set; }
-        string Next_finish_at {get; set; }
-        string Finish_at {get; set; }
-        string Scene_name {get; set; }
+        string NexFinishAt {get; set; }
+        string FinishAt {get; set; }
+        string SceneName {get; set; }
         int[] Coordinates {get; set; }
         string Server {get; set; }
-        int Total_attendees {get; set; }
+        int TotalAttendees {get; set; }
         bool Live {get; set; }
-        string User_name {get; set; }
+        string UserName {get; set; }
         bool Highlighted {get; set; }
         bool Trending {get; set; }
         bool Attending {get; set; }
         string[] Categories {get; set; }
         bool Recurrent {get; set; }
         double Duration {get; set; }
-        string Start_at {get; set; }
+        string StartAt {get; set; }
         DateTime StartAtProcessed {get; set; }
-        string[] Recurrent_dates {get; set; }
+        string[] RecurrentDates {get; set; }
         DateTime[] RecurrentDatesProcessed {get; set; }
         bool World {get; set; }
         int X {get; set; }
@@ -37,6 +37,7 @@ namespace DCL.EventsApi
     [Serializable]
     public struct EventDTO : IEventDTO
     {
+        // ReSharper disable InconsistentNaming
         public string id;
         public string name;
         public string image;
@@ -65,6 +66,7 @@ namespace DCL.EventsApi
         public string[] connected_addresses;
         public string community_id;
         public string image_vertical;
+        // ReSharper restore InconsistentNaming
 
         public string Id
         {
@@ -90,7 +92,7 @@ namespace DCL.EventsApi
             set => description = value;
         }
 
-        public string Next_start_at
+        public string NextStartAt
         {
             get => next_start_at;
             set => next_start_at = value;
@@ -103,19 +105,19 @@ namespace DCL.EventsApi
             set => nextStartAtProcessed = value;
         }
 
-        public string Next_finish_at
+        public string NexFinishAt
         {
             get => next_finish_at;
             set => next_finish_at = value;
         }
 
-        public string Finish_at
+        public string FinishAt
         {
             get => finish_at;
             set => finish_at = value;
         }
 
-        public string Scene_name
+        public string SceneName
         {
             get => scene_name;
             set => scene_name = value;
@@ -133,7 +135,7 @@ namespace DCL.EventsApi
             set => server = value;
         }
 
-        public int Total_attendees
+        public int TotalAttendees
         {
             get => total_attendees;
             set => total_attendees = value;
@@ -145,7 +147,7 @@ namespace DCL.EventsApi
             set => live = value;
         }
 
-        public string User_name
+        public string UserName
         {
             get => user_name;
             set => user_name = value;
@@ -187,7 +189,7 @@ namespace DCL.EventsApi
             set => duration = value;
         }
 
-        public string Start_at
+        public string StartAt
         {
             get => start_at;
             set => start_at = value;
@@ -200,7 +202,7 @@ namespace DCL.EventsApi
             set => startAtProcessed = value;
         }
 
-        public string[] Recurrent_dates
+        public string[] RecurrentDates
         {
             get => recurrent_dates;
             set => recurrent_dates = value;

--- a/Explorer/Assets/DCL/EventsApi/EventDataParser.cs
+++ b/Explorer/Assets/DCL/EventsApi/EventDataParser.cs
@@ -7,41 +7,41 @@ namespace DCL.EventsApi
     {
         internal static void ParseDeserializedDates(ref EventDTO eventDTO)
         {
-            if (DateTime.TryParse(eventDTO.Next_start_at, null, DateTimeStyles.RoundtripKind, out DateTime nextStartAt))
+            if (DateTime.TryParse(eventDTO.NextStartAt, null, DateTimeStyles.RoundtripKind, out DateTime nextStartAt))
                 eventDTO.NextStartAtProcessed = nextStartAt;
-            if (DateTime.TryParse(eventDTO.Start_at, null, DateTimeStyles.RoundtripKind, out DateTime startAt))
+            if (DateTime.TryParse(eventDTO.StartAt, null, DateTimeStyles.RoundtripKind, out DateTime startAt))
                 eventDTO.StartAtProcessed = startAt;
 
-            if (eventDTO.Recurrent_dates == null || eventDTO.Recurrent_dates.Length == 0)
+            if (eventDTO.RecurrentDates == null || eventDTO.RecurrentDates.Length == 0)
             {
                 eventDTO.RecurrentDatesProcessed = Array.Empty<DateTime>();
                 return;
             }
 
-            eventDTO.RecurrentDatesProcessed = new DateTime[eventDTO.Recurrent_dates.Length];
+            eventDTO.RecurrentDatesProcessed = new DateTime[eventDTO.RecurrentDates.Length];
 
-            for (var i = 0; i < eventDTO.Recurrent_dates.Length; i++)
-                if (DateTime.TryParse(eventDTO.Recurrent_dates[i], null, DateTimeStyles.RoundtripKind, out DateTime date))
+            for (var i = 0; i < eventDTO.RecurrentDates.Length; i++)
+                if (DateTime.TryParse(eventDTO.RecurrentDates[i], null, DateTimeStyles.RoundtripKind, out DateTime date))
                     eventDTO.RecurrentDatesProcessed[i] = date;
         }
 
         internal static void ParseDeserializedDates(EventWithPlaceIdDTO eventDTO)
         {
-            if (DateTime.TryParse(eventDTO.Next_start_at, null, DateTimeStyles.RoundtripKind, out DateTime nextStartAt))
+            if (DateTime.TryParse(eventDTO.NextStartAt, null, DateTimeStyles.RoundtripKind, out DateTime nextStartAt))
                 eventDTO.NextStartAtProcessed = nextStartAt;
-            if (DateTime.TryParse(eventDTO.Start_at, null, DateTimeStyles.RoundtripKind, out DateTime startAt))
+            if (DateTime.TryParse(eventDTO.StartAt, null, DateTimeStyles.RoundtripKind, out DateTime startAt))
                 eventDTO.StartAtProcessed = startAt;
 
-            if (eventDTO.Recurrent_dates == null || eventDTO.Recurrent_dates.Length == 0)
+            if (eventDTO.RecurrentDates == null || eventDTO.RecurrentDates.Length == 0)
             {
                 eventDTO.RecurrentDatesProcessed = Array.Empty<DateTime>();
                 return;
             }
 
-            eventDTO.RecurrentDatesProcessed = new DateTime[eventDTO.Recurrent_dates.Length];
+            eventDTO.RecurrentDatesProcessed = new DateTime[eventDTO.RecurrentDates.Length];
 
-            for (var i = 0; i < eventDTO.Recurrent_dates.Length; i++)
-                if (DateTime.TryParse(eventDTO.Recurrent_dates[i], null, DateTimeStyles.RoundtripKind, out DateTime date))
+            for (var i = 0; i < eventDTO.RecurrentDates.Length; i++)
+                if (DateTime.TryParse(eventDTO.RecurrentDates[i], null, DateTimeStyles.RoundtripKind, out DateTime date))
                     eventDTO.RecurrentDatesProcessed[i] = date;
         }
     }

--- a/Explorer/Assets/DCL/EventsApi/EventWithPlaceIdDTO.cs
+++ b/Explorer/Assets/DCL/EventsApi/EventWithPlaceIdDTO.cs
@@ -5,6 +5,7 @@ namespace DCL.EventsApi
     [Serializable]
     public class EventWithPlaceIdDTO : IEventDTO
     {
+        // ReSharper disable InconsistentNaming
         public string place_id;
         public string id;
         public string name;
@@ -30,6 +31,7 @@ namespace DCL.EventsApi
         public bool world;
         public int x;
         public int y;
+        // ReSharper restore InconsistentNaming
 
         public string Id
         {
@@ -55,7 +57,7 @@ namespace DCL.EventsApi
             set => description = value;
         }
 
-        public string Next_start_at
+        public string NextStartAt
         {
             get => next_start_at;
             set => next_start_at = value;
@@ -68,19 +70,19 @@ namespace DCL.EventsApi
             set => nextStartAtProcessed = value;
         }
 
-        public string Next_finish_at
+        public string NexFinishAt
         {
             get => next_finish_at;
             set => next_finish_at = value;
         }
 
-        public string Finish_at
+        public string FinishAt
         {
             get => finish_at;
             set => finish_at = value;
         }
 
-        public string Scene_name
+        public string SceneName
         {
             get => scene_name;
             set => scene_name = value;
@@ -98,7 +100,7 @@ namespace DCL.EventsApi
             set => server = value;
         }
 
-        public int Total_attendees
+        public int TotalAttendees
         {
             get => total_attendees;
             set => total_attendees = value;
@@ -110,7 +112,7 @@ namespace DCL.EventsApi
             set => live = value;
         }
 
-        public string User_name
+        public string UserName
         {
             get => user_name;
             set => user_name = value;
@@ -152,7 +154,7 @@ namespace DCL.EventsApi
             set => duration = value;
         }
 
-        public string Start_at
+        public string StartAt
         {
             get => start_at;
             set => start_at = value;
@@ -165,7 +167,7 @@ namespace DCL.EventsApi
             set => startAtProcessed = value;
         }
 
-        public string[] Recurrent_dates
+        public string[] RecurrentDates
         {
             get => recurrent_dates;
             set => recurrent_dates = value;

--- a/Explorer/Assets/DCL/Minimap/MinimapController.cs
+++ b/Explorer/Assets/DCL/Minimap/MinimapController.cs
@@ -20,7 +20,6 @@ using DCL.Multiplayer.Connections.DecentralandUrls;
 using DCL.PlacesAPIService;
 using DCL.SceneRestrictionBusController.SceneRestrictionBus;
 using DCL.UI;
-using DCL.Web3;
 using DCL.Chat.Commands;
 using DCL.Chat.History;
 using DCL.Chat.MessageBus;
@@ -350,15 +349,7 @@ namespace DCL.Minimap
                 ? $"{decentralandUrls.Url(DecentralandUrl.Host)}/jump?realm={realmData.RealmName}&position={previousParcelPosition.x},{previousParcelPosition.y}"
                 : $"{decentralandUrls.Url(DecentralandUrl.Host)}/jump?position={previousParcelPosition.x},{previousParcelPosition.y}";
 
-            systemClipboard.Set(link + ReferrerQuery());
-        }
-
-        private static string ReferrerQuery()
-        {
-            if (ViewDependencies.CurrentIdentity is not { } identity)
-                return string.Empty;
-
-            return $"&referrer={identity.Address.ToString()}";
+            systemClipboard.Set(ShareLinkUtilities.WithReferrer(link));
         }
 
         private void ExpandMinimap()
@@ -555,7 +546,7 @@ namespace DCL.Minimap
             {
                 return await placesAPIService.GetWorldAsync(parcelPosition, worldName, ct);
             }
-            catch (OperationCanceledException _) { }
+            catch (OperationCanceledException) { }
             catch (NotAPlaceException notAPlaceException)
             {
                 ReportHub.LogWarning(ReportCategory.UNSPECIFIED, $"Not a world requested: {notAPlaceException.Message}");

--- a/Explorer/Assets/DCL/Navmap/EventInfoPanelController.cs
+++ b/Explorer/Assets/DCL/Navmap/EventInfoPanelController.cs
@@ -74,22 +74,22 @@ namespace DCL.Navmap
             view.gameObject.SetActive(false);
         }
 
-        public void Set(EventDTO @event, PlacesData.PlaceInfo place)
+        public void Set(EventDTO newEvent, PlacesData.PlaceInfo newPlace)
         {
-            this.place = place;
-            this.@event = @event;
-            view.EventNameLabel.text = @event.name;
-            view.LiveContainer.SetActive(@event.live);
-            view.InterestedButton.gameObject.SetActive(!@event.live);
-            view.JumpInButton.gameObject.SetActive(@event.live);
-            view.ScheduleLabel.gameObject.SetActive(!@event.live);
-            view.AttendeeContainer.SetActive(!@event.live);
+            this.place = newPlace;
+            this.@event = newEvent;
+            view.EventNameLabel.text = newEvent.name;
+            view.LiveContainer.SetActive(newEvent.live);
+            view.InterestedButton.gameObject.SetActive(!newEvent.live);
+            view.JumpInButton.gameObject.SetActive(newEvent.live);
+            view.ScheduleLabel.gameObject.SetActive(!newEvent.live);
+            view.AttendeeContainer.SetActive(!newEvent.live);
 
             var schedule = "";
 
-            if (DateTime.TryParse(@event.start_at, null, DateTimeStyles.RoundtripKind, out DateTime startAt))
+            if (DateTime.TryParse(newEvent.start_at, null, DateTimeStyles.RoundtripKind, out DateTime startAt))
             {
-                if (@event.live)
+                if (newEvent.live)
                 {
                     TimeSpan elapsed = DateTime.UtcNow - startAt;
 
@@ -105,36 +105,36 @@ namespace DCL.Navmap
                     schedule = startAt.ToString("R");
             }
 
-            if (@event.live)
+            if (newEvent.live)
             {
                 view.LiveScheduleLabel.text = schedule;
-                view.LiveUserCountLabel.text = place.user_count.ToString();
+                view.LiveUserCountLabel.text = newPlace.user_count.ToString();
             }
             else
                 view.ScheduleLabel.text = schedule;
 
-            view.AttendingUserCountLabel.text = @event.total_attendees.ToString();
-            interestedButtonController.SetButtonState(@event.attending);
-            view.HostAndPlaceLabel.text = $"hosted by <b>{@event.user_name}</b> - at <b>{place.title} ({@event.x}, {@event.y})</b>";
-            view.DescriptionLabel.text = @event.description;
+            view.AttendingUserCountLabel.text = newEvent.total_attendees.ToString();
+            interestedButtonController.SetButtonState(newEvent.attending);
+            view.HostAndPlaceLabel.text = $"hosted by <b>{newEvent.user_name}</b> - at <b>{newPlace.title} ({newEvent.x}, {newEvent.y})</b>";
+            view.DescriptionLabel.text = newEvent.description;
             view.DescriptionLabel.ConvertUrlsToClickeableLinks(OpenUrl);
-            thumbnailController.RequestImage(@event.image);
+            thumbnailController.RequestImage(newEvent.image);
 
             updateLayoutCancellationToken = updateLayoutCancellationToken.SafeRestart();
             view.LayoutRoot.ForceUpdateLayoutAsync(updateLayoutCancellationToken.Token).Forget();
 
             ClearScheduleElements();
-            AddRecurrentEvents(@event);
+            AddRecurrentEvents(newEvent);
         }
 
         private void OpenUrl(string url) =>
             webBrowser.OpenUrlMainThreadOnly(url);
 
-        private void AddRecurrentEvents(EventDTO @event)
+        private void AddRecurrentEvents(EventDTO recurrentEvent)
         {
-            DateTime.TryParse(@event.next_start_at, null, DateTimeStyles.RoundtripKind, out DateTime nextStartAt);
+            DateTime.TryParse(recurrentEvent.next_start_at, null, DateTimeStyles.RoundtripKind, out DateTime nextStartAt);
 
-            foreach (string dateStr in @event.recurrent_dates)
+            foreach (string dateStr in recurrentEvent.recurrent_dates)
             {
                 if (!DateTime.TryParse(dateStr, null, DateTimeStyles.RoundtripKind, out DateTime date)) continue;
                 if (date < nextStartAt) continue;
@@ -151,14 +151,14 @@ namespace DCL.Navmap
 
         private void AddRecurrentEventToCalendar(DateTime startAt)
         {
-            string jumpInLink = string.Format(decentralandUrlsSource.Url(DecentralandUrl.JumpInGenesisCityLink), @event?.x, @event?.y);
-            var description = $"jump in: {jumpInLink}";
+            string jumpInLink = ShareLinkUtilities.WithReferrer(string.Format(decentralandUrlsSource.Url(DecentralandUrl.JumpInGenesisCityLink), @event?.x, @event?.y));
+            var description = $"jump in: {ShareLinkUtilities.AsQueryParameterValue(jumpInLink)}";
 
             DateTime nextStartAt = DateTime.Parse(@event?.next_start_at, null, DateTimeStyles.RoundtripKind);
             DateTime nextFinishAt = DateTime.Parse(@event?.next_finish_at, null, DateTimeStyles.RoundtripKind);
             TimeSpan duration = nextFinishAt - nextStartAt;
 
-            userCalendar.Add(@event?.name, description, startAt, startAt + duration);
+            userCalendar.Add(@event?.name ?? string.Empty, description, startAt, startAt + duration);
         }
 
         private void ClearScheduleElements()
@@ -180,10 +180,12 @@ namespace DCL.Navmap
 
             async UniTaskVoid SetInterestedAsync(CancellationToken ct)
             {
+                if (!@event.HasValue) return;
+
                 if (interested)
-                    await eventsApiService.MarkAsInterestedAsync(@event?.id, ct);
+                    await eventsApiService.MarkAsInterestedAsync(@event.Value.id, ct);
                 else
-                    await eventsApiService.MarkAsNotInterestedAsync(@event?.id, ct);
+                    await eventsApiService.MarkAsNotInterestedAsync(@event.Value.id, ct);
 
                 interestedButtonController.SetButtonState(interested);
             }

--- a/Explorer/Assets/DCL/Navmap/SharePlacesAndEventsContextMenuController.cs
+++ b/Explorer/Assets/DCL/Navmap/SharePlacesAndEventsContextMenuController.cs
@@ -55,9 +55,9 @@ namespace DCL.Navmap
         public void Set(PlacesData.PlaceInfo place)
         {
             VectorUtilities.TryParseVector2Int(place.base_position, out var coordinates);
-            copyLink = string.Format(decentralandUrlsSource.Url(DecentralandUrl.JumpInGenesisCityLink), coordinates.x, coordinates.y);
+            copyLink = ShareLinkUtilities.WithReferrer(string.Format(decentralandUrlsSource.Url(DecentralandUrl.JumpInGenesisCityLink), coordinates.x, coordinates.y));
             var description = string.Format(TWITTER_PLACE_DESCRIPTION, place.title);
-            twitterLink = string.Format(TWITTER_NEW_POST_LINK, description, "DCLPlace", copyLink);
+            twitterLink = string.Format(TWITTER_NEW_POST_LINK, description, "DCLPlace", ShareLinkUtilities.AsQueryParameterValue(copyLink));
         }
 
         public void Set(EventDTO @event)
@@ -65,10 +65,10 @@ namespace DCL.Navmap
             string description = @event.name;
 
             copyLink = @event.live
-                ? string.Format(decentralandUrlsSource.Url(DecentralandUrl.JumpInGenesisCityLink), @event.x, @event.y)
+                ? ShareLinkUtilities.WithReferrer(string.Format(decentralandUrlsSource.Url(DecentralandUrl.JumpInGenesisCityLink), @event.x, @event.y))
                 : string.Format(decentralandUrlsSource.Url(DecentralandUrl.WhatsOnEventLink), @event.id);
 
-            twitterLink = string.Format(TWITTER_NEW_POST_LINK, description, "DCLPlace", copyLink);
+            twitterLink = string.Format(TWITTER_NEW_POST_LINK, description, "DCLPlace", ShareLinkUtilities.AsQueryParameterValue(copyLink));
         }
 
         private void CopyLink()

--- a/Explorer/Assets/DCL/Places/PlacesCardSocialActionsController.cs
+++ b/Explorer/Assets/DCL/Places/PlacesCardSocialActionsController.cs
@@ -11,11 +11,11 @@ using DCL.Navmap;
 using DCL.NotificationsBus;
 using DCL.NotificationsBus.NotificationTypes;
 using DCL.PlacesAPIService;
+using DCL.UI;
 using DCL.Utilities.Extensions;
 using ECS.SceneLifeCycle.Realm;
 using System;
 using System.Threading;
-using UnityEngine;
 using Utility;
 
 namespace DCL.Places
@@ -180,7 +180,6 @@ namespace DCL.Places
             if (!string.IsNullOrWhiteSpace(placeInfo.world_name))
                 realmNavigator.TryChangeRealmAsync(URLDomain.FromString(new ENS(placeInfo.world_name).ConvertEnsToWorldUrl(dclUrlSource.Url(DecentralandUrl.WorldServer))),
                     ct,
-                    default,
                     isWorld: true,
                     allowsSpawnPointerOverride: true).Forget();
             else
@@ -192,7 +191,7 @@ namespace DCL.Places
         public void SharePlace(PlacesData.PlaceInfo placeInfo)
         {
             var description = string.Format(TWITTER_PLACE_DESCRIPTION, placeInfo.title);
-            var twitterLink = string.Format(dclUrlSource.Url(DecentralandUrl.TwitterNewPostLink), description, "DCLPlace", GetPlaceCopyLink(placeInfo));
+            var twitterLink = string.Format(dclUrlSource.Url(DecentralandUrl.TwitterNewPostLink), description, "DCLPlace", ShareLinkUtilities.AsQueryParameterValue(GetPlaceCopyLink(placeInfo)));
 
             webBrowser.OpenUrlMainThreadOnly(twitterLink);
 
@@ -211,11 +210,11 @@ namespace DCL.Places
         private string GetPlaceCopyLink(PlacesData.PlaceInfo place)
         {
             if (!string.IsNullOrEmpty(place.world_name))
-                return string.Format(dclUrlSource.Url(DecentralandUrl.JumpInWorldLink), place.world_name);
+                return ShareLinkUtilities.WithReferrer(string.Format(dclUrlSource.Url(DecentralandUrl.JumpInWorldLink), place.world_name));
 
             VectorUtilities.TryParseVector2Int(place.base_position, out var coordinates);
 
-            return string.Format(dclUrlSource.Url(DecentralandUrl.JumpInGenesisCityLink), coordinates.x, coordinates.y);
+            return ShareLinkUtilities.WithReferrer(string.Format(dclUrlSource.Url(DecentralandUrl.JumpInGenesisCityLink), coordinates.x, coordinates.y));
         }
 
         public void StartNavigationToPlace(PlacesData.PlaceInfo placeInfo)

--- a/Explorer/Assets/DCL/UI/ShareLinkUtilities.cs
+++ b/Explorer/Assets/DCL/UI/ShareLinkUtilities.cs
@@ -1,0 +1,19 @@
+using MVC;
+using System;
+
+namespace DCL.UI
+{
+    public static class ShareLinkUtilities
+    {
+        public static string WithReferrer(string jumpInLink)
+        {
+            if (ViewDependencies.CurrentIdentity is not { } identity)
+                return jumpInLink;
+
+            return $"{jumpInLink}&referrer={identity.Address.ToString()}";
+        }
+
+        public static string AsQueryParameterValue(string link) =>
+            Uri.EscapeDataString(link);
+    }
+}

--- a/Explorer/Assets/DCL/UI/ShareLinkUtilities.cs.meta
+++ b/Explorer/Assets/DCL/UI/ShareLinkUtilities.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2422775a8f9e343e6954c96d3760bbbd


### PR DESCRIPTION
## What

Closes #10062

Every share link generated inside the client carries the sharer's wallet, so referrals are
credited no matter which panel the link came from:

- **Places** — copy link and share, for both Genesis City places and Worlds.
- **Events** — copy link, share, and the "add to calendar" entry.
- **Map** — unchanged, still works as before.

### QA

1. Log in with a wallet.
2. Places panel → open any place → **Copy link**. Paste it: the link should end with
   `&referrer=<your wallet address>`. Repeat with a World place.
3. Events panel → open a live event → **Copy link**. Same expectation.
4. Map → **Copy link**. Should still work exactly as before.
5. Open one of the shared links in a browser — it should land on the same place/event as before.
